### PR TITLE
Document recovery outlines for highlighted portfolio projects

### DIFF
--- a/projects/01-sde-devops/PRJ-SDE-002/README.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/README.md
@@ -1,0 +1,27 @@
+# Observability & Backup Reliability Stack
+
+## Objective
+- Rebuild the documentation and automation for the Prometheus, Grafana, Loki, Alertmanager, and Proxmox Backup Server (PBS) deployment supporting the homelab services.
+- Provide clear runbooks and dashboards so on-call responders can detect, triage, and recover from failures quickly.
+
+## Key Artifacts to Produce
+- [ ] **Architecture Diagram** – data flow from exporters/log shippers to Prometheus/Loki, alert routing, and PBS integration ([Coming Soon](./artifacts/observability-architecture.md)). *(Target format: draw.io + PNG export)*
+- [ ] **Dashboard Inventory** – Grafana board list with golden-signal metrics, owners, and alert thresholds ([Coming Soon](./dashboards/dashboard-inventory.md)).
+- [ ] **Alert Catalog** – Alertmanager rules, notification targets, and test procedures ([Coming Soon](./runbooks/alert-catalog.md)).
+- [ ] **Backup Validation Runbook** – PBS job verification, restore drills, and integrity checks ([Coming Soon](./runbooks/backup-validation.md)).
+- [ ] **Infrastructure-as-Code Checklist** – Git repo structure, secrets handling, and CI validation steps ([Coming Soon](./checklists/iac-readiness.md)).
+- [ ] **SLO/Error Budget Policy** – definitions for uptime, restore time, and backup success SLOs ([Coming Soon](./policies/slo-error-budget.md)).
+
+## Current Backfill Status
+- Status: 🟠 **In Progress** – legacy Grafana exports are available but need to be normalized; alert catalog missing.
+- Owner: Sam Jackson
+- Target Backfill Window: 2025-04
+
+## Recovery Dependencies & Blockers
+- [ ] Import legacy Grafana JSON exports from the NAS `backups/grafana/` folder. *(Dependency: decrypt vault archive once key escrow is retrieved.)*
+- [ ] Rebuild Alertmanager webhook integration with Matrix. *(Blocked pending Matrix homeserver credentials from password manager.)*
+- [ ] Validate PBS datastore health after NAS resilver completes. *(Shared blocker with PRJ-HOME-002; track on combined ops board.)*
+
+## Coordination Notes
+- Reuse exporter configurations captured in PRJ-HOME-002 once services are back online to avoid drift.
+- Align SLO definitions with production-style documentation in `docs/PRJ-MASTER-HANDBOOK` when that repo is available.

--- a/projects/01-sde-devops/PRJ-SDE-002/artifacts/observability-architecture.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/artifacts/observability-architecture.md
@@ -1,0 +1,1 @@
+Placeholder for observability and backup architecture diagram with data flow notes.

--- a/projects/01-sde-devops/PRJ-SDE-002/checklists/iac-readiness.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/checklists/iac-readiness.md
@@ -1,0 +1,1 @@
+Checklist placeholder for Infra-as-Code readiness and CI validation.

--- a/projects/01-sde-devops/PRJ-SDE-002/dashboards/dashboard-inventory.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/dashboards/dashboard-inventory.md
@@ -1,0 +1,1 @@
+Placeholder inventory of Grafana dashboards, data sources, and alert coverage.

--- a/projects/01-sde-devops/PRJ-SDE-002/policies/slo-error-budget.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/policies/slo-error-budget.md
@@ -1,0 +1,1 @@
+Placeholder policy defining SLO targets and error budget burn procedures.

--- a/projects/01-sde-devops/PRJ-SDE-002/runbooks/alert-catalog.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/runbooks/alert-catalog.md
@@ -1,0 +1,1 @@
+Runbook placeholder cataloging Alertmanager rules and test cases.

--- a/projects/01-sde-devops/PRJ-SDE-002/runbooks/backup-validation.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/runbooks/backup-validation.md
@@ -1,0 +1,1 @@
+Runbook placeholder for PBS backup validation and restore drills.

--- a/projects/06-homelab/PRJ-HOME-001/README.md
+++ b/projects/06-homelab/PRJ-HOME-001/README.md
@@ -1,0 +1,27 @@
+# Homelab & Secure Network Build
+
+## Objective
+- Reconstruct the end-to-end documentation for the wired rack, UniFi-controlled Wi-Fi, and segmented VLAN layout that underpins the homelab network.
+- Capture the security, backup, and monitoring practices that keep the environment resilient and reproducible.
+
+## Key Artifacts to Produce
+- [ ] **Network Topology Diagram** – physical + logical view of switches, firewall, APs, and inter-VLAN routes ([Coming Soon](./artifacts/network-topology.md)). *(Target format: draw.io + PNG export)*
+- [ ] **Rack Elevation & Cable Map** – labeled ports, patch-panel mapping, and power layout ([Coming Soon](./artifacts/rack-elevation.md)). *(Target format: PDF + CSV patch schedule)*
+- [ ] **VLAN/IPAM Matrix** – subnet allocations, DHCP scopes, and reserved addresses ([Coming Soon](./artifacts/vlan-ipam.md)). *(Target format: Google Sheet export)*
+- [ ] **Network Hardening Checklist** – MFA, RBAC, firmware patch cadence, and guest/IoT isolation tasks ([Coming Soon](./checklists/network-hardening.md)).
+- [ ] **Operations Runbook** – backup workflow, firmware rollback steps, and change-control template ([Coming Soon](./runbooks/network-operations.md)).
+- [ ] **Monitoring & Alert Notes** – UniFi/Prometheus metrics to capture and alert thresholds ([Coming Soon](./dashboards/network-observability.md)).
+
+## Current Backfill Status
+- Status: 🔵 **Planned** – topology exists but artifacts were never captured in version control.
+- Owner: Sam Jackson
+- Target Backfill Window: 2025-03
+
+## Recovery Dependencies & Blockers
+- [ ] Export latest UniFi Network configuration to extract VLAN names and firewall rules. *(Blocked: controller VM powered down until UPS batteries are replaced.)*
+- [ ] Pull rack photos/labels from NAS archive for accurate cable mapping. *(Dependency: locate external drive with 2024-Q4 photo dump.)*
+- [ ] Re-run nmap/L2 discovery to confirm current device inventory. *(Dependency: schedule maintenance window to avoid disrupting PoE cameras.)*
+
+## Coordination Notes
+- Align artifact formats with the standards set in `docs/PRJ-MASTER-PLAYBOOK` once that repository is restored.
+- Share drafts with the virtualization project (PRJ-HOME-002) so service dependencies stay consistent across runbooks.

--- a/projects/06-homelab/PRJ-HOME-001/artifacts/network-topology.md
+++ b/projects/06-homelab/PRJ-HOME-001/artifacts/network-topology.md
@@ -1,0 +1,1 @@
+Placeholder for network topology diagram. Replace with draw.io export and annotated PNG when ready.

--- a/projects/06-homelab/PRJ-HOME-001/artifacts/rack-elevation.md
+++ b/projects/06-homelab/PRJ-HOME-001/artifacts/rack-elevation.md
@@ -1,0 +1,1 @@
+Placeholder for rack elevation & cable map. Add PDF summary and CSV port map.

--- a/projects/06-homelab/PRJ-HOME-001/artifacts/vlan-ipam.md
+++ b/projects/06-homelab/PRJ-HOME-001/artifacts/vlan-ipam.md
@@ -1,0 +1,1 @@
+Placeholder for VLAN/IPAM matrix. Populate with subnet table and DHCP scope notes.

--- a/projects/06-homelab/PRJ-HOME-001/checklists/network-hardening.md
+++ b/projects/06-homelab/PRJ-HOME-001/checklists/network-hardening.md
@@ -1,0 +1,1 @@
+Checklist placeholder for homelab network hardening tasks. Expand with MFA, RBAC, and firmware cadence items.

--- a/projects/06-homelab/PRJ-HOME-001/dashboards/network-observability.md
+++ b/projects/06-homelab/PRJ-HOME-001/dashboards/network-observability.md
@@ -1,0 +1,1 @@
+Placeholder describing planned UniFi/Prometheus monitoring coverage and alert thresholds.

--- a/projects/06-homelab/PRJ-HOME-001/runbooks/network-operations.md
+++ b/projects/06-homelab/PRJ-HOME-001/runbooks/network-operations.md
@@ -1,0 +1,1 @@
+Runbook placeholder covering backups, firmware rollback, and change control for the homelab network.

--- a/projects/06-homelab/PRJ-HOME-002/README.md
+++ b/projects/06-homelab/PRJ-HOME-002/README.md
@@ -1,0 +1,27 @@
+# Virtualization & Core Services Stack
+
+## Objective
+- Document the Proxmox + TrueNAS environment that hosts core services (Wiki.js, Home Assistant, Immich) behind a reverse proxy with TLS.
+- Capture lifecycle procedures for provisioning, patching, backup/restore, and certificate rotation across the virtualized stack.
+
+## Key Artifacts to Produce
+- [ ] **Service Dependency Diagram** – Proxmox clusters, storage, reverse proxy, and service interconnects ([Coming Soon](./artifacts/service-map.md)). *(Target format: draw.io + SVG export)*
+- [ ] **VM Inventory Sheet** – resource sizing, purpose, and backup retention policy ([Coming Soon](./artifacts/vm-inventory.md)). *(Target format: spreadsheet export)*
+- [ ] **Reverse Proxy & TLS Runbook** – certificate renewal automation, DNS validation, and failover steps ([Coming Soon](./runbooks/reverse-proxy-tls.md)).
+- [ ] **Backup & Restore Guide** – Proxmox Backup Server (PBS) schedules, TrueNAS replication notes, and recovery drills ([Coming Soon](./runbooks/backup-restore.md)).
+- [ ] **Service Health Dashboard Checklist** – Grafana dashboards + alert rules needed for each workload ([Coming Soon](./dashboards/service-health.md)).
+- [ ] **Patch & Change Calendar** – monthly cadence for hypervisor, guest OS, and application updates ([Coming Soon](./calendars/patch-schedule.md)).
+
+## Current Backfill Status
+- Status: 🟠 **In Progress** – PBS job notes exist offline, diagrams missing, runbooks incomplete.
+- Owner: Sam Jackson
+- Target Backfill Window: 2025-04
+
+## Recovery Dependencies & Blockers
+- [ ] Confirm last-known-good PBS snapshots for Wiki.js and Immich. *(Dependency: mount PBS datastore that is currently stored off-site.)*
+- [ ] Retrieve reverse proxy config backup from NAS ZFS snapshots. *(Blocked until NAS resilver completes; ETA 2025-02-15.)*
+- [ ] Export Home Assistant automations for inclusion in service inventory. *(Waiting on Zigbee dongle replacement to bring HA online.)*
+
+## Coordination Notes
+- Align monitoring artifacts with observability project PRJ-SDE-002 to avoid duplicate dashboard definitions.
+- Share inventory sheet with PRJ-HOME-001 to ensure network VLAN assignments match service placement.

--- a/projects/06-homelab/PRJ-HOME-002/artifacts/service-map.md
+++ b/projects/06-homelab/PRJ-HOME-002/artifacts/service-map.md
@@ -1,0 +1,1 @@
+Placeholder for virtualization service dependency diagram. Document Proxmox, TrueNAS, reverse proxy, and services.

--- a/projects/06-homelab/PRJ-HOME-002/artifacts/vm-inventory.md
+++ b/projects/06-homelab/PRJ-HOME-002/artifacts/vm-inventory.md
@@ -1,0 +1,1 @@
+Placeholder for VM inventory sheet. Include CPU/RAM, function, backups, and owners.

--- a/projects/06-homelab/PRJ-HOME-002/calendars/patch-schedule.md
+++ b/projects/06-homelab/PRJ-HOME-002/calendars/patch-schedule.md
@@ -1,0 +1,1 @@
+Placeholder for monthly patch and change schedule across hypervisor and guests.

--- a/projects/06-homelab/PRJ-HOME-002/dashboards/service-health.md
+++ b/projects/06-homelab/PRJ-HOME-002/dashboards/service-health.md
@@ -1,0 +1,1 @@
+Placeholder outlining Grafana dashboards and alert rules for core services.

--- a/projects/06-homelab/PRJ-HOME-002/runbooks/backup-restore.md
+++ b/projects/06-homelab/PRJ-HOME-002/runbooks/backup-restore.md
@@ -1,0 +1,1 @@
+Runbook placeholder for PBS backups and service restore drills.

--- a/projects/06-homelab/PRJ-HOME-002/runbooks/reverse-proxy-tls.md
+++ b/projects/06-homelab/PRJ-HOME-002/runbooks/reverse-proxy-tls.md
@@ -1,0 +1,1 @@
+Runbook placeholder for reverse proxy and TLS renewal workflow.

--- a/projects/08-web-data/PRJ-WEB-001/README.md
+++ b/projects/08-web-data/PRJ-WEB-001/README.md
@@ -1,0 +1,27 @@
+# Commercial E-commerce & Booking Systems Portfolio
+
+## Objective
+- Recreate the evidence pack for the three commercial web projects (resort booking, high-SKU flooring, and tours marketplace) highlighting data workflows, automations, and operational playbooks.
+- Provide contributor guidance for refreshing screenshots, anonymized datasets, and QA/regression artifacts that prove repeatability.
+
+## Key Artifacts to Produce
+- [ ] **Solution Overview Diagram** – front-end, CMS, payment gateways, and integration touchpoints for each client ([Coming Soon](./artifacts/solution-overview.md)). *(Target format: draw.io + PDF summary)*
+- [ ] **Data Flow & ETL Workbook** – catalog update process, pricing imports, and validation queries ([Coming Soon](./workbooks/data-flow.md)). *(Target format: spreadsheet export with SQL snippets)*
+- [ ] **Operational Runbook** – publishing cadence, content review, and incident triage steps ([Coming Soon](./runbooks/operations.md)).
+- [ ] **QA Regression Checklist** – smoke/regression tests for booking flows, search, and pricing ([Coming Soon](./checklists/qa-regression.md)).
+- [ ] **Analytics & KPI Dashboard Outline** – traffic, conversion, and booking metrics with owners ([Coming Soon](./dashboards/kpi-outline.md)).
+- [ ] **Client Evidence Packet Index** – sanitized screenshots, testimonials, and deployment history ([Coming Soon](./evidence/client-packet.md)).
+
+## Current Backfill Status
+- Status: 🔵 **Planned** – prior documentation stored in client-specific Google Drives; nothing migrated to Git yet.
+- Owner: Sam Jackson
+- Target Backfill Window: 2025-05
+
+## Recovery Dependencies & Blockers
+- [ ] Obtain written approval from clients to reuse sanitized assets. *(Dependency: pending outreach emails sent 2025-01-22.)*
+- [ ] Rebuild anonymized datasets from last export. *(Blocked until access to legacy VPS backups is restored; coordinate with hosting provider.)*
+- [ ] Capture updated UI screenshots in staging environments. *(Dependency: rebuild staging containers using IaC from PRJ-SDE-001 once available.)*
+
+## Coordination Notes
+- Align QA checklist format with the standards defined in `projects/04-qa-testing/PRJ-QA-001` to keep testing artifacts consistent.
+- Once data pipeline notebook is ready, cross-link with future automation work in `projects/07-aiml-automation/PRJ-AIML-001` for reuse.

--- a/projects/08-web-data/PRJ-WEB-001/artifacts/solution-overview.md
+++ b/projects/08-web-data/PRJ-WEB-001/artifacts/solution-overview.md
@@ -1,0 +1,1 @@
+Placeholder for client solution overview diagrams highlighting integrations.

--- a/projects/08-web-data/PRJ-WEB-001/checklists/qa-regression.md
+++ b/projects/08-web-data/PRJ-WEB-001/checklists/qa-regression.md
@@ -1,0 +1,1 @@
+Placeholder QA regression checklist for booking and e-commerce flows.

--- a/projects/08-web-data/PRJ-WEB-001/dashboards/kpi-outline.md
+++ b/projects/08-web-data/PRJ-WEB-001/dashboards/kpi-outline.md
@@ -1,0 +1,1 @@
+Placeholder for analytics/KPI dashboard outline with metric owners.

--- a/projects/08-web-data/PRJ-WEB-001/evidence/client-packet.md
+++ b/projects/08-web-data/PRJ-WEB-001/evidence/client-packet.md
@@ -1,0 +1,1 @@
+Placeholder index for sanitized client evidence packets and testimonials.

--- a/projects/08-web-data/PRJ-WEB-001/runbooks/operations.md
+++ b/projects/08-web-data/PRJ-WEB-001/runbooks/operations.md
@@ -1,0 +1,1 @@
+Runbook placeholder covering publishing cadence, review workflows, and incident response.

--- a/projects/08-web-data/PRJ-WEB-001/workbooks/data-flow.md
+++ b/projects/08-web-data/PRJ-WEB-001/workbooks/data-flow.md
@@ -1,0 +1,1 @@
+Placeholder workbook notes for catalog ETL flows, SQL validation, and automation.


### PR DESCRIPTION
## Summary
- add structured objectives, artifact checklists, and blocker notes to the highlighted project READMEs
- create placeholder stubs for each referenced diagram, runbook, checklist, and evidence artifact so contributors have targets to fill in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8fff346d88327a3863149a98b0792