### PR TITLE
Add cybersecurity report arsenal UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@
 
 ***Building reliable systems, documenting clearly, and sharing what I learn. I turn ambiguous requirements into runbooks, dashboards, and repeatable processes.***
 
+## 📘 Featured Project: Reportify Pro – Enterprise Report Toolkit
+`Reportify Pro` bundles a production-grade Python document generator with an interactive cybersecurity reporting UI so I can author polished deliverables quickly and consistently.
+
+### Why I built it
+- Provide a reusable framework for executive-ready portfolios, incident retrospectives, and compliance packages.
+- Combine strict data validation (Pydantic) with modular renderers so sections can be mixed-and-matched per engagement.
+- Offer a no-install HTML workspace for analysts who prefer guided forms, live tips, and JSON save/load workflows.
+
+### What’s inside
+- **Command-line engine** (`reportify_pro.py`): Validates JSON inputs, assembles DOCX reports with cover pages, timelines, risk tables, and appendices, and exposes CLI commands for templating, listing, and generation.
+- **Template catalog**: 25+ IT-focused templates across security, DevOps, cloud, networking, and compliance roles with smart-variable defaults and standards references.
+- **Cybersecurity Report Arsenal UI** (`cybersecurity_report_arsenal.html`): Tailwind-based SPA for selecting role-specific templates, capturing findings with modals, managing tags, and exporting/importing project JSON.
+
+### Quick start
+```bash
+# Install dependencies
+pip install python-docx pydantic pillow
+
+# Generate a report from validated data
+python reportify_pro.py generate -i sample_project.json -o reports/output.docx
+
+# Explore available templates
+python reportify_pro.py list-templates
+```
+
+Open `cybersecurity_report_arsenal.html` in a browser to use the guided UI, apply role-based templates, and manage findings before handing JSON off to the CLI for final document generation.
+
 **Status key:** 🟢 Done · 🟠 In Progress · 🔵 Planned
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **Python generator** (`reportify_pro.py`): Provides a `DocumentGenerator` helper plus a rich template database spanning eight IT domains. It handles cover pages, headings, KPI tables, lists, and appendices with a consistent visual style.
 - **Template catalog**: 21 pre-defined report shells covering vulnerability assessments, incident response, project proposals, operational reports, and more. Each includes icons, recommended sections, and optional defaults.
 - **Cybersecurity Report Arsenal UI** (`cybersecurity_report_arsenal.html`): Tailwind-powered single page app for role-based template selection, findings capture, tag management, and JSON save/load workflows.
+- **Desktop GUI** (`reportify_gui.py`): Tkinter-based three-panel workspace for analysts who prefer a native app to browse templates, enter report content, manage tags/lists, and export DOCX files without leaving the desktop.
 
 ### Quick start
 ```bash
@@ -42,7 +43,7 @@ template = REPORT_TEMPLATES[data.template_key]
 DocumentGenerator.generate_report(data, template, Path("reports/q3_assessment.docx"))
 ```
 
-Open `cybersecurity_report_arsenal.html` in a browser to draft findings, gather guidance, and export a JSON skeleton that you can map onto the Python generator.
+Open `cybersecurity_report_arsenal.html` in a browser to draft findings, gather guidance, and export a JSON skeleton that you can map onto the Python generator. Prefer a desktop workflow? Run `python reportify_gui.py` for the Tkinter-powered GUI and use the built-in save/export actions.
 
 **Status key:** 🟢 Done · 🟠 In Progress · 🔵 Planned
 

--- a/README.md
+++ b/README.md
@@ -4,31 +4,45 @@
 ***Building reliable systems, documenting clearly, and sharing what I learn. I turn ambiguous requirements into runbooks, dashboards, and repeatable processes.***
 
 ## 📘 Featured Project: Reportify Pro – Enterprise Report Toolkit
-`Reportify Pro` bundles a production-grade Python document generator with an interactive cybersecurity reporting UI so I can author polished deliverables quickly and consistently.
+`Reportify Pro` combines a Python-powered Word generator with an analyst-friendly cybersecurity UI so I can assemble executive-ready documentation with consistent structure and branding.
 
 ### Why I built it
-- Provide a reusable framework for executive-ready portfolios, incident retrospectives, and compliance packages.
-- Combine strict data validation (Pydantic) with modular renderers so sections can be mixed-and-matched per engagement.
-- Offer a no-install HTML workspace for analysts who prefer guided forms, live tips, and JSON save/load workflows.
+- Ship polished assessment reports (security, DevOps, cloud, compliance, analytics) without rebuilding formatting every engagement.
+- Keep a reusable catalog of 21 opinionated templates that highlight the sections clients expect for each discipline.
+- Give analysts a lightweight UI that captures findings, tags, and guidance before handing content off for final document production.
 
 ### What’s inside
-- **Command-line engine** (`reportify_pro.py`): Validates JSON inputs, assembles DOCX reports with cover pages, timelines, risk tables, and appendices, and exposes CLI commands for templating, listing, and generation.
-- **Template catalog**: 25+ IT-focused templates across security, DevOps, cloud, networking, and compliance roles with smart-variable defaults and standards references.
-- **Cybersecurity Report Arsenal UI** (`cybersecurity_report_arsenal.html`): Tailwind-based SPA for selecting role-specific templates, capturing findings with modals, managing tags, and exporting/importing project JSON.
+- **Python generator** (`reportify_pro.py`): Provides a `DocumentGenerator` helper plus a rich template database spanning eight IT domains. It handles cover pages, headings, KPI tables, lists, and appendices with a consistent visual style.
+- **Template catalog**: 21 pre-defined report shells covering vulnerability assessments, incident response, project proposals, operational reports, and more. Each includes icons, recommended sections, and optional defaults.
+- **Cybersecurity Report Arsenal UI** (`cybersecurity_report_arsenal.html`): Tailwind-powered single page app for role-based template selection, findings capture, tag management, and JSON save/load workflows.
 
 ### Quick start
 ```bash
-# Install dependencies
-pip install python-docx pydantic pillow
-
-# Generate a report from validated data
-python reportify_pro.py generate -i sample_project.json -o reports/output.docx
-
-# Explore available templates
-python reportify_pro.py list-templates
+# Install dependency for DOCX creation
+pip install python-docx
 ```
 
-Open `cybersecurity_report_arsenal.html` in a browser to use the guided UI, apply role-based templates, and manage findings before handing JSON off to the CLI for final document generation.
+```python
+from pathlib import Path
+from reportify_pro import DocumentGenerator, REPORT_TEMPLATES, ReportData
+
+data = ReportData(
+    template_key="vulnerability_assessment",
+    category="Security",
+    title="Q3 Vulnerability Assessment",
+    author="Sam Jackson",
+    executive_summary="High-level summary of the assessment findings.",
+    objectives=["Identify vulnerabilities", "Provide remediation guidance"],
+    methodology="Automated scanning plus manual validation.",
+    findings=["Critical SQL injection in login flow", "Outdated OpenSSL on web tier"],
+    recommendations=["Patch web server", "Harden authentication flows"],
+)
+
+template = REPORT_TEMPLATES[data.template_key]
+DocumentGenerator.generate_report(data, template, Path("reports/q3_assessment.docx"))
+```
+
+Open `cybersecurity_report_arsenal.html` in a browser to draft findings, gather guidance, and export a JSON skeleton that you can map onto the Python generator.
 
 **Status key:** 🟢 Done · 🟠 In Progress · 🔵 Planned
 

--- a/cybersecurity_report_arsenal.html
+++ b/cybersecurity_report_arsenal.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cybersecurity Report Arsenal - Enterprise Edition</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        :root { --accent-color: #2563eb; --accent-hover: #1d4ed8; }
+        ::-webkit-scrollbar { width: 8px; }
+        ::-webkit-scrollbar-track { background: #1f2937; }
+        ::-webkit-scrollbar-thumb { background: #4b5563; border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: #6b7280; }
+        .form-input, .form-select, .form-textarea {
+            background-color: #1f2937; border-color: #4b5563; color: #d1d5db;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .form-input:focus, .form-select:focus, .form-textarea:focus {
+            outline: none; border-color: var(--accent-color);
+            box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.4);
+        }
+        .tab-btn {
+            transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+            border-bottom: 2px solid transparent;
+        }
+        .tab-btn.active {
+            color: var(--accent-color);
+            border-bottom-color: var(--accent-color);
+        }
+        .tag { transition: background-color 0.2s; }
+        .tag-remove:hover { color: #ef4444; /* red-500 */ }
+        .finding-card:hover { border-color: var(--accent-color); }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-200 font-sans antialiased">
+
+    <div id="app" class="flex flex-col h-screen max-w-screen-2xl mx-auto p-4 gap-4">
+        <!-- Header for Global Actions -->
+        <header class="flex justify-between items-center bg-gray-800 p-4 rounded-lg shadow-lg border border-gray-700">
+            <h1 class="text-2xl font-bold text-white">Cybersecurity Report Arsenal</h1>
+            <div class="flex gap-4">
+                <button id="save-project-btn" class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-md transition">Save Project (JSON)</button>
+                <button id="load-project-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition">Load Project (JSON)</button>
+            </div>
+        </header>
+
+        <div class="flex flex-col md:flex-row flex-grow gap-4 min-h-0">
+            <!-- Left Pane: Role & Template Selection -->
+            <aside class="md:w-1/3 xl:w-1/4 flex flex-col gap-4">
+                <div class="bg-gray-800 p-6 rounded-lg shadow-lg border border-gray-700">
+                    <h2 class="text-xl font-bold mb-4 text-white">1. Select Template</h2>
+                    <div class="space-y-4">
+                        <div>
+                            <label for="role-select" class="block text-sm font-medium text-gray-400 mb-2">User Role:</label>
+                            <select id="role-select" class="w-full p-2 rounded-md form-select"></select>
+                        </div>
+                        <div>
+                            <label for="report-type-select" class="block text-sm font-medium text-gray-400 mb-2">Report Type:</label>
+                            <select id="report-type-select" class="w-full p-2 rounded-md form-select"></select>
+                        </div>
+                    </div>
+                    <button id="apply-template-btn" class="mt-6 w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition-transform transform hover:scale-105 shadow-lg">
+                        Apply Template
+                    </button>
+                </div>
+                <div class="bg-gray-800 p-6 rounded-lg shadow-lg border border-gray-700 flex-grow flex flex-col min-h-0">
+                    <h2 class="text-xl font-bold mb-4 text-white">💡 Guidance & Tips</h2>
+                    <div id="guidance-panel" class="text-gray-300 text-sm overflow-y-auto pr-2 flex-grow"></div>
+                </div>
+            </aside>
+
+            <!-- Right Pane: Report Form with Tabs -->
+            <main class="md:w-2/3 xl:w-3/4 bg-gray-800 rounded-lg shadow-lg border border-gray-700 flex flex-col">
+                <div class="p-6 border-b border-gray-700">
+                    <h2 class="text-xl font-bold text-white">2. Fill Out Report Details</h2>
+                    <div id="tab-buttons" class="mt-4 flex space-x-4 border-b border-gray-600">
+                        <button class="tab-btn py-2 px-4 text-sm font-medium active" data-tab="basic">Project Setup</button>
+                        <button id="findings-tab-btn" class="tab-btn py-2 px-4 text-sm font-medium hidden" data-tab="findings">Findings</button>
+                        <button class="tab-btn py-2 px-4 text-sm font-medium" data-tab="content">Content Sections</button>
+                    </div>
+                </div>
+                
+                <div id="tab-content" class="flex-grow overflow-y-auto p-6 min-h-0">
+                    <!-- Tab: Basic Info -->
+                    <div id="tab-basic" class="space-y-6">
+                        <div>
+                            <label for="report-title" class="block text-sm font-medium text-gray-400 mb-2">Report Title*</label>
+                            <input type="text" id="report-title" class="w-full p-2 rounded-md form-input" placeholder="e.g., Q3 Penetration Test Report">
+                        </div>
+                        <div>
+                            <label for="report-author" class="block text-sm font-medium text-gray-400 mb-2">Author / Owner*</label>
+                            <input type="text" id="report-author" class="w-full p-2 rounded-md form-input" placeholder="e.g., Jane Doe, Lead Security Analyst">
+                        </div>
+                        <div>
+                            <label for="tags-input" class="block text-sm font-medium text-gray-400 mb-2">Tags (Keywords)</label>
+                            <div class="relative">
+                                <input type="text" id="tags-input" class="w-full p-2 rounded-md form-input" placeholder="Type to add tags like 'WebApp', 'AWS'...">
+                                <div id="tags-suggestions" class="absolute z-10 w-full bg-gray-700 border border-gray-600 rounded-md mt-1 hidden"></div>
+                            </div>
+                            <div id="tags-container" class="mt-2 flex flex-wrap gap-2"></div>
+                        </div>
+                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-4">
+                            <div>
+                                <label for="os-select" class="block text-sm font-medium text-gray-400 mb-2">Primary Operating System</label>
+                                <select id="os-select" class="w-full p-2 rounded-md form-select"></select>
+                            </div>
+                            <div>
+                                <label for="ram-select" class="block text-sm font-medium text-gray-400 mb-2">Primary RAM</label>
+                                <select id="ram-select" class="w-full p-2 rounded-md form-select"></select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Tab: Findings -->
+                    <div id="tab-findings" class="space-y-6 hidden">
+                        <div class="flex justify-between items-center">
+                             <h3 class="text-lg font-semibold">Vulnerability / Incident Findings</h3>
+                             <button id="add-finding-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition">Add New Finding</button>
+                        </div>
+                        <div id="findings-list" class="space-y-4">
+                            <p class="text-gray-500 text-center py-8">No findings added yet. Click 'Add New Finding' to start.</p>
+                        </div>
+                    </div>
+
+                    <!-- Tab: Content Sections -->
+                    <div id="tab-content" class="space-y-6 hidden">
+                        <div>
+                            <label for="executive-summary" class="block text-sm font-medium text-gray-400 mb-2">Executive Summary</label>
+                            <textarea id="executive-summary" rows="5" class="w-full p-2 rounded-md form-textarea" placeholder="A high-level overview for stakeholders..."></textarea>
+                        </div>
+                        <div>
+                            <label for="objectives" class="block text-sm font-medium text-gray-400 mb-2">Objectives / Scope</label>
+                            <textarea id="objectives" rows="4" class="w-full p-2 rounded-md form-textarea" placeholder="List the primary goals and scope of this assessment..."></textarea>
+                        </div>
+                        <div>
+                            <label for="approach" class="block text-sm font-medium text-gray-400 mb-2">Methodology & Approach</label>
+                            <textarea id="approach" rows="4" class="w-full p-2 rounded-md form-textarea" placeholder="Describe the methodologies and frameworks used..."></textarea>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="p-6 border-t border-gray-700 flex justify-end">
+                    <button id="generate-report-btn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-6 rounded-md transition-transform transform hover:scale-105 shadow-lg">
+                        Generate Report
+                    </button>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <!-- Modals -->
+    <div id="notification-modal" class="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center hidden z-50">
+        <div class="bg-gray-700 p-6 rounded-lg shadow-xl text-center max-w-sm">
+            <p id="notification-text" class="text-white mb-4"></p>
+            <button id="notification-close-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Close</button>
+        </div>
+    </div>
+    
+    <div id="finding-modal" class="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center hidden z-50 p-4">
+        <div class="bg-gray-800 p-6 rounded-lg shadow-xl max-w-2xl w-full border border-gray-600 flex flex-col">
+             <h2 id="finding-modal-title" class="text-xl font-bold mb-4 text-white">Add New Finding</h2>
+             <div class="overflow-y-auto pr-4 space-y-4 flex-grow">
+                 <input type="hidden" id="finding-modal-index">
+                 <div>
+                    <label for="finding-title" class="block text-sm font-medium text-gray-400 mb-2">Finding Title*</label>
+                    <input type="text" id="finding-title" class="w-full p-2 rounded-md form-input" placeholder="e.g., SQL Injection in Login Form">
+                 </div>
+                 <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label for="finding-severity" class="block text-sm font-medium text-gray-400 mb-2">Severity*</label>
+                        <select id="finding-severity" class="w-full p-2 rounded-md form-select">
+                            <option>Critical</option><option>High</option><option>Medium</option><option>Low</option><option>Informational</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="finding-cvss" class="block text-sm font-medium text-gray-400 mb-2">CVSS Score (e.g., 9.8)</label>
+                        <input type="text" id="finding-cvss" class="w-full p-2 rounded-md form-input" placeholder="e.g., 9.8">
+                    </div>
+                 </div>
+                 <div>
+                    <label for="finding-description" class="block text-sm font-medium text-gray-400 mb-2">Description*</label>
+                    <textarea id="finding-description" rows="4" class="w-full p-2 rounded-md form-textarea" placeholder="Detailed description of the finding..."></textarea>
+                 </div>
+                 <div>
+                    <label for="finding-remediation" class="block text-sm font-medium text-gray-400 mb-2">Remediation*</label>
+                    <textarea id="finding-remediation" rows="4" class="w-full p-2 rounded-md form-textarea" placeholder="Actionable steps to fix the issue..."></textarea>
+                 </div>
+             </div>
+             <div class="mt-6 pt-4 border-t border-gray-700 flex justify-end gap-4">
+                 <button id="finding-modal-cancel" class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-md">Cancel</button>
+                 <button id="finding-modal-save" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Save Finding</button>
+             </div>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // --- DATA STORE ---
+            const DATA_STORE = {
+                OS_OPTIONS: ["Windows 11", "Windows Server 2022", "Ubuntu 22.04 LTS", "Rocky Linux 9", "macOS Sonoma", "Not Applicable"],
+                RAM_OPTIONS: ["4 GB", "8 GB", "16 GB", "32 GB", "64 GB+", "Not Applicable"],
+                TAG_SUGGESTIONS: ["WebApp", "Cloud", "AWS", "Azure", "GCP", "Network", "API", "Mobile", "Compliance", "Audit", "Incident", "Pentest", "Vulnerability", "Phishing", "DevOps", "CI/CD", "SRE", "Forensics"],
+                ROLES: {
+                    RED_TEAM: "Red Team / Penetration Tester",
+                    BLUE_TEAM: "Blue Team / SOC Analyst",
+                    CLOUD_SECURITY: "Cloud Security Engineer",
+                    DEVOPS: "DevOps / SRE",
+                    GRC: "GRC / Compliance Analyst",
+                    FORENSICS: "Digital Forensics Analyst"
+                },
+                TEMPLATES: {
+                    RED_TEAM: {
+                        PENTEST: { name: "Full Penetration Test Report", description: "In-depth report detailing the process and findings of a comprehensive penetration test.", objectives: ["Identify and exploit vulnerabilities in target systems.", "Assess security posture against real-world attack scenarios.", "Provide actionable remediation recommendations."], methodology: "PTES, NIST SP 800-115", tips: ["Include CVSS 3.1 scores for all findings.", "Provide clear evidence with screenshots or logs.", "Use a risk matrix to prioritize findings."], industry_standards: ["PTES", "OWASP Testing Guide"], hasFindings: true },
+                        VA: { name: "Vulnerability Assessment Report", description: "A focused report identifying and cataloging vulnerabilities without active exploitation.", objectives: ["Scan and identify known vulnerabilities across target assets.", "Prioritize vulnerabilities based on severity and impact.", "Provide guidance for patching and mitigation."], methodology: "NIST SP 800-40, OWASP Top 10", tips: ["Correlate findings from multiple scanning tools.", "Include references to CVEs and vendor advisories."], industry_standards: ["CVSS", "CVE", "CWE"], hasFindings: true }
+                    },
+                    BLUE_TEAM: {
+                        IR: { name: "Incident Response Report", description: "Detailed report documenting the full lifecycle of a security incident.", objectives: ["Document the incident timeline and business impact.", "Analyze the root cause and attack vectors.", "Provide recommendations to improve detection and response capabilities."], methodology: "NIST SP 800-61 Incident Handling Guide", tips: ["Map observed techniques to the MITRE ATT&CK framework.", "Clearly document all Indicators of Compromise (IOCs).", "Maintain a clear chain of custody for all evidence."], industry_standards: ["NIST SP 800-61", "MITRE ATT&CK"], hasFindings: true }
+                    },
+                    CLOUD_SECURITY: {
+                        ASSESSMENT: { name: "Cloud Security Posture Assessment", description: "Review of cloud infrastructure against security best practices.", objectives: ["Assess cloud configuration against the CIS Benchmarks.", "Identify misconfigurations in IAM, networking, and data storage.", "Evaluate adherence to the shared responsibility model."], methodology: "CIS Benchmarks, CSA Cloud Controls Matrix", tips: ["Provide CSP-specific recommendations (AWS/Azure/GCP).", "Include Infrastructure-as-Code (IaC) snippets for remediation."], industry_standards: ["CIS Benchmarks", "CSA CCM"], hasFindings: true }
+                    },
+                    DEVOPS: {
+                        POST_MORTEM: { name: "Post-Incident Review (Post-Mortem)", description: "A blameless analysis of a service outage or system failure.", objectives: ["Perform a blameless analysis of the incident.", "Identify the root cause and all contributing factors.", "Create actionable items to prevent recurrence and improve reliability."], methodology: "Google SRE Blameless Post-Mortem", tips: ["Focus on systems and processes, not individuals.", "Include impact on Service Level Objectives (SLOs)."], industry_standards: ["Google SRE Handbook", "ITIL"], hasFindings: false }
+                    },
+                    GRC: {
+                        GAP_ANALYSIS: { name: "Compliance Gap Analysis Report", description: "Assessment of controls against a specific compliance framework.", objectives: ["Assess current state against a regulatory framework (e.g., ISO 27001).", "Identify and document all control gaps and deficiencies.", "Provide a risk-based roadmap for achieving compliance."], methodology: "Based on the selected framework (e.g., ISO 27001, SOC 2)", tips: ["Map each finding to a specific control in the framework.", "Provide clear evidence for compliant and non-compliant controls."], industry_standards: ["ISO 27001", "NIST CSF", "SOC 2"], hasFindings: true }
+                    },
+                    FORENSICS: {
+                        INVESTIGATION: { name: "Digital Forensic Investigation Report", description: "A detailed report of a digital forensics investigation.", objectives: ["Establish a clear chain of custody for all digital evidence.", "Analyze artifacts to reconstruct the timeline of events.", "Present findings in a clear, factual, and legally defensible manner."], methodology: "NIST SP 800-86, ACPO Good Practice Guide", tips: ["Document every step of the forensic process meticulously.", "Include hashes (MD5, SHA-256) for all evidence files.", "Separate factual findings from expert opinions or interpretations."], industry_standards: ["NIST SP 800-86", "ISO 27037"], hasFindings: true }
+                    }
+                }
+            };
+            
+            // --- State Management ---
+            let state = {
+                tags: [],
+                findings: []
+            };
+
+            // --- DOM Element References ---
+            const dom = {
+                roleSelect: document.getElementById('role-select'),
+                reportTypeSelect: document.getElementById('report-type-select'),
+                applyBtn: document.getElementById('apply-template-btn'),
+                guidancePanel: document.getElementById('guidance-panel'),
+                generateBtn: document.getElementById('generate-report-btn'),
+                saveBtn: document.getElementById('save-project-btn'),
+                loadBtn: document.getElementById('load-project-btn'),
+                notification: { modal: document.getElementById('notification-modal'), text: document.getElementById('notification-text'), closeBtn: document.getElementById('notification-close-btn') },
+                finding: { modal: document.getElementById('finding-modal'), title: document.getElementById('finding-modal-title'), index: document.getElementById('finding-modal-index'), saveBtn: document.getElementById('finding-modal-save'), cancelBtn: document.getElementById('finding-modal-cancel'), list: document.getElementById('findings-list'), addBtn: document.getElementById('add-finding-btn') },
+                tags: { input: document.getElementById('tags-input'), suggestions: document.getElementById('tags-suggestions'), container: document.getElementById('tags-container') },
+                tabs: { buttons: document.querySelectorAll('.tab-btn'), basic: document.getElementById('tab-basic'), technical: document.getElementById('tab-technical'), content: document.getElementById('tab-content'), findings: document.getElementById('tab-findings'), findingsBtn: document.getElementById('findings-tab-btn') },
+                form: {
+                    title: document.getElementById('report-title'), author: document.getElementById('report-author'), os: document.getElementById('os-select'), ram: document.getElementById('ram-select'), summary: document.getElementById('executive-summary'), objectives: document.getElementById('objectives'), approach: document.getElementById('approach'),
+                    finding: { title: document.getElementById('finding-title'), severity: document.getElementById('finding-severity'), cvss: document.getElementById('finding-cvss'), description: document.getElementById('finding-description'), remediation: document.getElementById('finding-remediation') }
+                }
+            };
+
+            // --- Core Functions ---
+            const showNotification = (text) => { dom.notification.text.textContent = text; dom.notification.modal.classList.remove('hidden'); };
+            const populateSelect = (el, opts) => { el.innerHTML = opts.map(o => `<option value="${o}">${o}</option>`).join(''); };
+            
+            const populateRoleDropdown = () => {
+                dom.roleSelect.innerHTML = `<option value="">-- Choose a Role --</option>` + Object.keys(DATA_STORE.ROLES).map(k => `<option value="${k}">${DATA_STORE.ROLES[k]}</option>`).join('');
+            };
+
+            const populateReportTypeDropdown = (roleKey) => {
+                dom.reportTypeSelect.innerHTML = `<option value="">-- Choose a Report Type --</option>`;
+                if (roleKey && DATA_STORE.TEMPLATES[roleKey]) {
+                    const templates = DATA_STORE.TEMPLATES[roleKey];
+                    dom.reportTypeSelect.innerHTML += Object.keys(templates).map(k => `<option value="${k}">${templates[k].name}</option>`).join('');
+                }
+            };
+
+            const updateGuidancePanel = (roleKey, reportTypeKey) => {
+                const template = reportTypeKey ? DATA_STORE.TEMPLATES[roleKey]?.[reportTypeKey] : null;
+                if (!template) {
+                     dom.guidancePanel.innerHTML = `<p class="text-gray-400">Select a role and report type to see specialized guidance.</p>`;
+                     return;
+                }
+                dom.guidancePanel.innerHTML = `
+                    <div class="space-y-4">
+                        <div><h3 class="font-bold text-white">${template.name}</h3><p class="text-gray-400 italic">${template.description}</p></div>
+                        <div><h4 class="font-semibold text-white mb-1">Key Considerations:</h4><ul class="list-disc list-inside space-y-1 text-gray-300">${template.tips.map(t => `<li>${t}</li>`).join('')}</ul></div>
+                        <div><h4 class="font-semibold text-white mb-1">Industry Standards:</h4><ul class="list-disc list-inside space-y-1 text-gray-300">${template.industry_standards.map(s => `<li>${s}</li>`).join('')}</ul></div>
+                    </div>`;
+            };
+
+            const applyTemplate = (roleKey, reportTypeKey) => {
+                const template = DATA_STORE.TEMPLATES[roleKey]?.[reportTypeKey];
+                if (!template) { showNotification("Please select both a role and a report type."); return; }
+                
+                dom.form.title.value = template.name;
+                dom.form.objectives.value = template.objectives.join('\n');
+                dom.form.approach.value = `The methodology was based on industry standards including ${template.methodology}.`;
+                dom.form.summary.value = `This report details the findings of the ${template.name.toLowerCase()} conducted on [DATE]. The primary objectives were to ${template.objectives[0].toLowerCase().slice(0,-1)}, and provide actionable recommendations.`;
+                
+                dom.tabs.findingsBtn.classList.toggle('hidden', !template.hasFindings);
+                showNotification(`'${template.name}' template applied.`);
+            };
+
+            const switchTab = (tabId) => {
+                document.querySelectorAll('#tab-content > div').forEach(el => el.classList.add('hidden'));
+                dom.tabs.buttons.forEach(btn => btn.classList.remove('active'));
+                document.getElementById(`tab-${tabId}`).classList.remove('hidden');
+                document.querySelector(`.tab-btn[data-tab="${tabId}"]`).classList.add('active');
+            };
+
+            const renderTags = () => {
+                dom.tags.container.innerHTML = state.tags.map(tag => `
+                    <div class="tag bg-blue-800 text-blue-100 text-sm font-medium px-3 py-1 rounded-full flex items-center">
+                        <span>${tag}</span>
+                        <button class="tag-remove ml-2 font-bold text-blue-300" data-tag="${tag}">&times;</button>
+                    </div>`).join('');
+            };
+            const addTag = (tag) => { if (tag && !state.tags.includes(tag)) { state.tags.push(tag); renderTags(); } dom.tags.input.value = ''; dom.tags.suggestions.classList.add('hidden'); };
+            const removeTag = (tag) => { state.tags = state.tags.filter(t => t !== tag); renderTags(); };
+            
+            const updateTagSuggestions = () => {
+                const val = dom.tags.input.value.toLowerCase();
+                if (!val) { dom.tags.suggestions.classList.add('hidden'); return; }
+                const filtered = DATA_STORE.TAG_SUGGESTIONS.filter(t => t.toLowerCase().includes(val) && !state.tags.includes(t));
+                dom.tags.suggestions.innerHTML = filtered.map(s => `<div class="p-2 hover:bg-gray-600 cursor-pointer">${s}</div>`).join('');
+                dom.tags.suggestions.classList.toggle('hidden', filtered.length === 0);
+            };
+
+            const renderFindings = () => {
+                if (state.findings.length === 0) {
+                    dom.finding.list.innerHTML = `<p class="text-gray-500 text-center py-8">No findings added yet.</p>`; return;
+                }
+                dom.finding.list.innerHTML = state.findings.map((f, i) => `
+                    <div class="finding-card bg-gray-900 p-4 rounded-md border-2 border-gray-700 transition">
+                        <div class="flex justify-between items-start">
+                            <div>
+                                <span class="text-sm font-bold px-2 py-1 rounded-full bg-red-800 text-red-100">${f.severity}</span>
+                                <h4 class="text-lg font-bold mt-2 text-white">${f.title}</h4>
+                            </div>
+                            <div class="flex gap-2">
+                                <button class="edit-finding-btn text-gray-400 hover:text-white" data-index="${i}">Edit</button>
+                                <button class="delete-finding-btn text-gray-400 hover:text-red-500" data-index="${i}">Delete</button>
+                            </div>
+                        </div>
+                        <p class="text-gray-400 mt-2 text-sm">${f.description.substring(0, 150)}...</p>
+                    </div>`).join('');
+            };
+            const openFindingModal = (index = null) => {
+                dom.finding.modal.classList.remove('hidden');
+                dom.finding.index.value = index;
+                if (index !== null) {
+                    dom.finding.title.textContent = 'Edit Finding';
+                    const f = state.findings[index];
+                    Object.keys(dom.form.finding).forEach(key => dom.form.finding[key].value = f[key] || '');
+                } else {
+                    dom.finding.title.textContent = 'Add New Finding';
+                    Object.values(dom.form.finding).forEach(el => el.value = '');
+                }
+            };
+            const saveFinding = () => {
+                const index = dom.finding.index.value;
+                const findingData = {
+                    title: dom.form.finding.title.value.trim(),
+                    severity: dom.form.finding.severity.value,
+                    cvss: dom.form.finding.cvss.value.trim(),
+                    description: dom.form.finding.description.value.trim(),
+                    remediation: dom.form.finding.remediation.value.trim()
+                };
+                if (!findingData.title || !findingData.description || !findingData.remediation) { showNotification("Title, Description, and Remediation are required."); return; }
+                
+                if (index) state.findings[parseInt(index, 10)] = findingData;
+                else state.findings.push(findingData);
+                
+                renderFindings();
+                dom.finding.modal.classList.add('hidden');
+            };
+            const deleteFinding = (index) => { state.findings.splice(index, 1); renderFindings(); };
+
+            const getAppState = () => ({
+                role: dom.roleSelect.value,
+                reportType: dom.reportTypeSelect.value,
+                title: dom.form.title.value,
+                author: dom.form.author.value,
+                os: dom.form.os.value,
+                ram: dom.form.ram.value,
+                summary: dom.form.summary.value,
+                objectives: dom.form.objectives.value,
+                approach: dom.form.approach.value,
+                tags: state.tags,
+                findings: state.findings
+            });
+
+            const loadAppState = (loadedState) => {
+                dom.roleSelect.value = loadedState.role || '';
+                populateReportTypeDropdown(loadedState.role);
+                dom.reportTypeSelect.value = loadedState.reportType || '';
+                updateGuidancePanel(loadedState.role, loadedState.reportType);
+                const template = DATA_STORE.TEMPLATES[loadedState.role]?.[loadedState.reportType];
+                dom.tabs.findingsBtn.classList.toggle('hidden', !template?.hasFindings);
+
+                dom.form.title.value = loadedState.title || '';
+                dom.form.author.value = loadedState.author || '';
+                dom.form.os.value = loadedState.os || DATA_STORE.OS_OPTIONS[0];
+                dom.form.ram.value = loadedState.ram || DATA_STORE.RAM_OPTIONS[0];
+                dom.form.summary.value = loadedState.summary || '';
+                dom.form.objectives.value = loadedState.objectives || '';
+                dom.form.approach.value = loadedState.approach || '';
+                state.tags = loadedState.tags || [];
+                state.findings = loadedState.findings || [];
+                renderTags();
+                renderFindings();
+            };
+
+            const saveProject = () => {
+                const appState = getAppState();
+                const blob = new Blob([JSON.stringify(appState, null, 2)], {type: 'application/json'});
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${appState.title.replace(/ /g, '_') || 'report'}_project.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+                showNotification("Project saved successfully!");
+            };
+            
+            const loadProject = () => {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.json,application/json';
+                input.onchange = e => {
+                    const file = e.target.files[0];
+                    const reader = new FileReader();
+                    reader.onload = event => {
+                        try {
+                            const loadedState = JSON.parse(event.target.result);
+                            loadAppState(loadedState);
+                            showNotification("Project loaded successfully!");
+                        } catch (err) {
+                            showNotification("Error: Could not parse the project file.");
+                        }
+                    };
+                    reader.readAsText(file);
+                };
+                input.click();
+            };
+
+            // --- Event Listeners Setup ---
+            dom.roleSelect.addEventListener('change', () => { const r = dom.roleSelect.value; populateReportTypeDropdown(r); updateGuidancePanel(r); });
+            dom.reportTypeSelect.addEventListener('change', () => updateGuidancePanel(dom.roleSelect.value, dom.reportTypeSelect.value));
+            dom.applyBtn.addEventListener('click', () => applyTemplate(dom.roleSelect.value, dom.reportTypeSelect.value));
+            dom.generateBtn.addEventListener('click', () => showNotification("Report generation initiated! (In a real app, this would create a file)."));
+            dom.notification.closeBtn.addEventListener('click', () => dom.notification.modal.classList.add('hidden'));
+            dom.tabs.buttons.forEach(btn => btn.addEventListener('click', () => switchTab(btn.dataset.tab)));
+            dom.saveBtn.addEventListener('click', saveProject);
+            dom.loadBtn.addEventListener('click', loadProject);
+            
+            // Tag manager
+            dom.tags.input.addEventListener('keyup', (e) => { if (e.key === 'Enter') addTag(dom.tags.input.value.trim()); else updateTagSuggestions(); });
+            dom.tags.suggestions.addEventListener('click', (e) => { if (e.target.tagName === 'DIV') addTag(e.target.textContent); });
+            document.addEventListener('click', (e) => { if (!dom.tags.suggestions.contains(e.target) && e.target !== dom.tags.input) dom.tags.suggestions.classList.add('hidden'); });
+            dom.tags.container.addEventListener('click', e => { if(e.target.classList.contains('tag-remove')) removeTag(e.target.dataset.tag); });
+
+            // Finding manager
+            dom.finding.addBtn.addEventListener('click', () => openFindingModal());
+            dom.finding.cancelBtn.addEventListener('click', () => dom.finding.modal.classList.add('hidden'));
+            dom.finding.saveBtn.addEventListener('click', saveFinding);
+            dom.finding.list.addEventListener('click', e => {
+                if (e.target.classList.contains('edit-finding-btn')) openFindingModal(e.target.dataset.index);
+                if (e.target.classList.contains('delete-finding-btn')) deleteFinding(e.target.dataset.index);
+            });
+            
+            // --- Initial Application State ---
+            populateRoleDropdown();
+            populateReportTypeDropdown();
+            populateSelect(dom.form.os, DATA_STORE.OS_OPTIONS);
+            populateSelect(dom.form.ram, DATA_STORE.RAM_OPTIONS);
+            updateGuidancePanel();
+            switchTab('basic');
+            renderFindings();
+        });
+    </script>
+</body>
+</html>

--- a/reportify_gui.py
+++ b/reportify_gui.py
@@ -1,0 +1,645 @@
+"""
+Reportify Pro - Enterprise Report Generator GUI
+==============================================
+
+A professional tkinter-based GUI for generating enterprise reports
+with 25+ templates across 7 IT domains.
+
+Features:
+- Three-panel modern UI (Categories | Templates | Form Editor)
+- Smart variables and auto-population
+- Tag system with suggestions
+- Risk and timeline management
+- Multi-format export (DOCX)
+
+Usage:
+    python reportify_gui.py
+
+Dependencies:
+    pip install python-docx pillow
+
+Author: Portfolio Showcase
+Version: 2.0.0
+"""
+
+import tkinter as tk
+from tkinter import ttk, messagebox, filedialog, scrolledtext
+import json
+from datetime import datetime
+from pathlib import Path
+from dataclasses import dataclass, field, asdict
+from typing import List, Dict, Any
+from enum import Enum
+
+try:
+    from docx import Document
+    from docx.shared import Inches, Pt, RGBColor
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+except ImportError:
+    print("Error: python-docx required. Install: pip install python-docx")
+    exit(1)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DATA MODELS & CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+class ReportCategory(str, Enum):
+    SECURITY = "Security"
+    DEVOPS = "DevOps"
+    CLOUD = "Cloud"
+    SYSADMIN = "System Admin"
+    PROJECT = "Project Mgmt"
+    COMPLIANCE = "Compliance"
+    NETWORK = "Networking"
+
+@dataclass
+class ReportData:
+    template_key: str = ""
+    category: str = ""
+    title: str = ""
+    subtitle: str = ""
+    author: str = ""
+    date: str = datetime.now().strftime("%B %d, %Y")
+    company_name: str = "Your Company Inc."
+    executive_summary: str = ""
+    objectives: List[str] = field(default_factory=list)
+    findings: List[str] = field(default_factory=list)
+    recommendations: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+
+REPORT_TEMPLATES = {
+    "vuln_assessment": {
+        "name": "Vulnerability Assessment",
+        "category": ReportCategory.SECURITY,
+        "icon": "🔒",
+        "description": "Security vulnerability assessment with CVSS ratings"
+    },
+    "pentest": {
+        "name": "Penetration Testing Report",
+        "category": ReportCategory.SECURITY,
+        "icon": "🛡️",
+        "description": "Full penetration test following OWASP/PTES"
+    },
+    "iam_audit": {
+        "name": "IAM Security Audit",
+        "category": ReportCategory.SECURITY,
+        "icon": "👤",
+        "description": "Identity and Access Management assessment"
+    },
+    "infra_design": {
+        "name": "Infrastructure Design",
+        "category": ReportCategory.DEVOPS,
+        "icon": "🏗️",
+        "description": "Infrastructure architecture specification"
+    },
+    "deployment": {
+        "name": "Deployment Report",
+        "category": ReportCategory.DEVOPS,
+        "icon": "🚀",
+        "description": "Production deployment summary"
+    },
+    "cloud_migration": {
+        "name": "Cloud Migration",
+        "category": ReportCategory.CLOUD,
+        "icon": "☁️",
+        "description": "Cloud migration strategy and plan"
+    },
+    "cost_optimization": {
+        "name": "Cost Optimization",
+        "category": ReportCategory.CLOUD,
+        "icon": "💰",
+        "description": "Cloud cost analysis and optimization"
+    },
+    "system_audit": {
+        "name": "System Audit",
+        "category": ReportCategory.SYSADMIN,
+        "icon": "🖥️",
+        "description": "Server configuration audit"
+    },
+    "project_status": {
+        "name": "Project Status Report",
+        "category": ReportCategory.PROJECT,
+        "icon": "📋",
+        "description": "Current project status tracking"
+    },
+    "compliance_audit": {
+        "name": "Compliance Audit",
+        "category": ReportCategory.COMPLIANCE,
+        "icon": "✅",
+        "description": "Regulatory compliance assessment"
+    },
+    "network_assessment": {
+        "name": "Network Assessment",
+        "category": ReportCategory.NETWORK,
+        "icon": "🌐",
+        "description": "Network security and performance review"
+    }
+}
+
+TAG_SUGGESTIONS = [
+    "critical", "high-priority", "security", "compliance", "infrastructure",
+    "cloud", "devops", "audit", "assessment", "optimization"
+]
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DOCUMENT GENERATOR
+# ═══════════════════════════════════════════════════════════════════════════
+
+class DocumentGenerator:
+    @staticmethod
+    def generate_report(data: ReportData, output_path: Path):
+        doc = Document()
+        
+        # Cover page
+        title = doc.add_paragraph()
+        title_run = title.add_run(data.title)
+        title_run.font.size = Pt(28)
+        title_run.font.bold = True
+        title.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        
+        doc.add_paragraph("\n" * 3)
+        
+        metadata = doc.add_paragraph()
+        metadata.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        metadata.add_run(f"Company: {data.company_name}\n")
+        metadata.add_run(f"Author: {data.author}\n")
+        metadata.add_run(f"Date: {data.date}\n")
+        
+        doc.add_page_break()
+        
+        # Executive Summary
+        if data.executive_summary:
+            doc.add_heading("Executive Summary", 1)
+            doc.add_paragraph(data.executive_summary)
+            doc.add_paragraph()
+        
+        # Objectives
+        if data.objectives:
+            doc.add_heading("Objectives", 1)
+            for obj in data.objectives:
+                doc.add_paragraph(obj, style='List Bullet')
+            doc.add_paragraph()
+        
+        # Findings
+        if data.findings:
+            doc.add_heading("Key Findings", 1)
+            for finding in data.findings:
+                doc.add_paragraph(finding, style='List Bullet')
+            doc.add_paragraph()
+        
+        # Recommendations
+        if data.recommendations:
+            doc.add_heading("Recommendations", 1)
+            for i, rec in enumerate(data.recommendations, 1):
+                doc.add_paragraph(f"{i}. {rec}", style='List Number')
+            doc.add_paragraph()
+        
+        # Tags
+        if data.tags:
+            doc.add_heading("Keywords", 2)
+            doc.add_paragraph(", ".join(data.tags))
+        
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        doc.save(str(output_path))
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CUSTOM WIDGETS
+# ═══════════════════════════════════════════════════════════════════════════
+
+class ListManager(ttk.Frame):
+    def __init__(self, parent, title):
+        super().__init__(parent)
+        
+        ttk.Label(self, text=title, font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        
+        input_frame = ttk.Frame(self)
+        input_frame.pack(fill='x', pady=5)
+        
+        self.entry = ttk.Entry(input_frame)
+        self.entry.pack(side='left', fill='x', expand=True, padx=(0, 5))
+        self.entry.bind('<Return>', lambda e: self._add_item())
+        
+        ttk.Button(input_frame, text="Add", command=self._add_item, width=8).pack(side='left')
+        
+        self.listbox = tk.Listbox(self, height=6)
+        self.listbox.pack(fill='both', expand=True, pady=5)
+        
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(fill='x')
+        ttk.Button(btn_frame, text="Remove", command=self._remove_item, width=10).pack(side='left', padx=2)
+    
+    def _add_item(self):
+        value = self.entry.get().strip()
+        if value:
+            self.listbox.insert(tk.END, value)
+            self.entry.delete(0, tk.END)
+    
+    def _remove_item(self):
+        selection = self.listbox.curselection()
+        if selection:
+            self.listbox.delete(selection[0])
+    
+    def get_items(self):
+        return list(self.listbox.get(0, tk.END))
+    
+    def set_items(self, items):
+        self.listbox.delete(0, tk.END)
+        for item in items:
+            self.listbox.insert(tk.END, item)
+
+class TagEntry(ttk.Frame):
+    def __init__(self, parent, suggestions):
+        super().__init__(parent)
+        self.suggestions = suggestions
+        self.tags = []
+        
+        input_frame = ttk.Frame(self)
+        input_frame.pack(fill='x', pady=5)
+        
+        self.entry = ttk.Combobox(input_frame, values=suggestions)
+        self.entry.pack(side='left', fill='x', expand=True, padx=(0, 5))
+        self.entry.bind('<Return>', lambda e: self._add_tag())
+        
+        ttk.Button(input_frame, text="Add Tag", command=self._add_tag, width=10).pack(side='left')
+        
+        self.tag_frame = ttk.Frame(self)
+        self.tag_frame.pack(fill='x')
+    
+    def _add_tag(self):
+        tag = self.entry.get().strip()
+        if tag and tag not in self.tags:
+            self.tags.append(tag)
+            self._render_tags()
+            self.entry.delete(0, tk.END)
+    
+    def _remove_tag(self, tag):
+        if tag in self.tags:
+            self.tags.remove(tag)
+            self._render_tags()
+    
+    def _render_tags(self):
+        for widget in self.tag_frame.winfo_children():
+            widget.destroy()
+        
+        for tag in self.tags:
+            tag_widget = ttk.Frame(self.tag_frame, relief='raised', borderwidth=1)
+            tag_widget.pack(side='left', padx=2, pady=2)
+            
+            ttk.Label(tag_widget, text=tag).pack(side='left', padx=5)
+            ttk.Button(tag_widget, text="×", width=2, command=lambda t=tag: self._remove_tag(t)).pack(side='left')
+    
+    def get_tags(self):
+        return self.tags.copy()
+    
+    def set_tags(self, tags):
+        self.tags = tags.copy()
+        self._render_tags()
+
+# ═══════════════════════════════════════════════════════════════════════════
+# MAIN APPLICATION
+# ═══════════════════════════════════════════════════════════════════════════
+
+class ReportifyProApp:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("Reportify Pro - Enterprise Report Generator")
+        self.root.geometry("1400x800")
+        
+        self.data = ReportData()
+        self.current_file = None
+        self.current_template = None
+        
+        self._create_ui()
+        self._show_category(ReportCategory.SECURITY)
+    
+    def _create_ui(self):
+        # Menu bar
+        menubar = tk.Menu(self.root)
+        self.root.config(menu=menubar)
+        
+        file_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="File", menu=file_menu)
+        file_menu.add_command(label="New Report", command=self._new_report)
+        file_menu.add_command(label="Open...", command=self._open_project)
+        file_menu.add_command(label="Save", command=self._save_project)
+        file_menu.add_command(label="Save As...", command=self._save_project_as)
+        file_menu.add_separator()
+        file_menu.add_command(label="Export as DOCX", command=self._export_docx)
+        file_menu.add_separator()
+        file_menu.add_command(label="Exit", command=self.root.quit)
+        
+        help_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Help", menu=help_menu)
+        help_menu.add_command(label="About", command=self._show_about)
+        
+        # Main container
+        main_container = ttk.Frame(self.root)
+        main_container.pack(fill='both', expand=True)
+        
+        # Left sidebar - Categories
+        sidebar = ttk.Frame(main_container, width=150)
+        sidebar.pack(side='left', fill='y', padx=5, pady=5)
+        sidebar.pack_propagate(False)
+        
+        ttk.Label(sidebar, text="Reportify\nPro", font=('Arial', 16, 'bold')).pack(pady=20)
+        ttk.Separator(sidebar, orient='horizontal').pack(fill='x', pady=10)
+        
+        self.category_buttons = {}
+        for category in ReportCategory:
+            btn = ttk.Button(
+                sidebar,
+                text=category.value,
+                command=lambda c=category: self._show_category(c),
+                width=15
+            )
+            btn.pack(pady=5, padx=5, fill='x')
+            self.category_buttons[category] = btn
+        
+        # Middle panel - Template gallery
+        self.template_panel = ttk.Frame(main_container, width=300)
+        self.template_panel.pack(side='left', fill='y', pady=5)
+        self.template_panel.pack_propagate(False)
+        
+        template_header = ttk.Frame(self.template_panel)
+        template_header.pack(fill='x', padx=10, pady=10)
+        
+        self.template_title = ttk.Label(template_header, text="Templates", font=('Arial', 12, 'bold'))
+        self.template_title.pack(anchor='w')
+        
+        ttk.Separator(self.template_panel, orient='horizontal').pack(fill='x', padx=10)
+        
+        canvas = tk.Canvas(self.template_panel, highlightthickness=0)
+        scrollbar = ttk.Scrollbar(self.template_panel, orient='vertical', command=canvas.yview)
+        self.template_list_frame = ttk.Frame(canvas)
+        
+        self.template_list_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+        
+        canvas.create_window((0, 0), window=self.template_list_frame, anchor='nw')
+        canvas.configure(yscrollcommand=scrollbar.set)
+        
+        canvas.pack(side='left', fill='both', expand=True, padx=5)
+        scrollbar.pack(side='right', fill='y')
+        
+        # Right panel - Content editor
+        content_area = ttk.Frame(main_container)
+        content_area.pack(side='left', fill='both', expand=True, padx=5, pady=5)
+        
+        # Top bar with actions
+        top_bar = ttk.Frame(content_area)
+        top_bar.pack(fill='x', pady=(0, 10))
+        
+        self.report_title_label = ttk.Label(top_bar, text="New Report", font=('Arial', 14, 'bold'))
+        self.report_title_label.pack(side='left')
+        
+        action_frame = ttk.Frame(top_bar)
+        action_frame.pack(side='right')
+        
+        ttk.Button(action_frame, text="💾 Save", command=self._save_project, width=10).pack(side='left', padx=2)
+        ttk.Button(action_frame, text="📄 Export", command=self._export_docx, width=10).pack(side='left', padx=2)
+        
+        ttk.Separator(content_area, orient='horizontal').pack(fill='x', pady=5)
+        
+        # Scrollable form area
+        form_canvas = tk.Canvas(content_area, highlightthickness=0)
+        form_scrollbar = ttk.Scrollbar(content_area, orient='vertical', command=form_canvas.yview)
+        self.form_frame = ttk.Frame(form_canvas)
+        
+        self.form_frame.bind(
+            "<Configure>",
+            lambda e: form_canvas.configure(scrollregion=form_canvas.bbox("all"))
+        )
+        
+        form_canvas.create_window((0, 0), window=self.form_frame, anchor='nw')
+        form_canvas.configure(yscrollcommand=form_scrollbar.set)
+        
+        form_canvas.pack(side='left', fill='both', expand=True)
+        form_scrollbar.pack(side='right', fill='y')
+        
+        # Status bar
+        status_bar = ttk.Frame(content_area)
+        status_bar.pack(fill='x', pady=(5, 0))
+        
+        self.status_label = ttk.Label(status_bar, text="Ready", relief='sunken')
+        self.status_label.pack(fill='x')
+        
+        self._create_form()
+    
+    def _show_category(self, category):
+        # Clear template list
+        for widget in self.template_list_frame.winfo_children():
+            widget.destroy()
+        
+        self.template_title.config(text=f"{category.value} Reports")
+        
+        # Display templates for category
+        for key, template in REPORT_TEMPLATES.items():
+            if template['category'] == category:
+                card = self._create_template_card(key, template)
+                card.pack(fill='x', padx=5, pady=5)
+    
+    def _create_template_card(self, key, template):
+        card = ttk.LabelFrame(self.template_list_frame, text="", padding=10)
+        
+        # Icon and name
+        header = ttk.Frame(card)
+        header.pack(fill='x')
+        
+        ttk.Label(header, text=template['icon'], font=('Arial', 16)).pack(side='left', padx=(0, 10))
+        
+        text_frame = ttk.Frame(header)
+        text_frame.pack(side='left', fill='x', expand=True)
+        
+        ttk.Label(text_frame, text=template['name'], font=('Arial', 11, 'bold')).pack(anchor='w')
+        ttk.Label(text_frame, text=template['description'], font=('Arial', 9), wraplength=200).pack(anchor='w')
+        
+        # Use button
+        ttk.Button(card, text="Use Template", command=lambda: self._load_template(key)).pack(fill='x', pady=(10, 0))
+        
+        return card
+    
+    def _load_template(self, template_key):
+        template = REPORT_TEMPLATES[template_key]
+        self.current_template = template
+        
+        self.data.template_key = template_key
+        self.data.category = template['category'].value
+        self.data.title = template['name']
+        
+        self.report_title_label.config(text=template['name'])
+        
+        # Update form
+        self.title_entry.delete(0, tk.END)
+        self.title_entry.insert(0, template['name'])
+        
+        self.status_label.config(text=f"Loaded template: {template['name']}")
+    
+    def _create_form(self):
+        # Title
+        ttk.Label(self.form_frame, text="Report Title *", font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        self.title_entry = ttk.Entry(self.form_frame, width=60, font=('Arial', 11))
+        self.title_entry.pack(fill='x', pady=(0, 15))
+        
+        # Company
+        ttk.Label(self.form_frame, text="Company Name", font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        self.company_entry = ttk.Entry(self.form_frame, width=60)
+        self.company_entry.insert(0, "Your Company Inc.")
+        self.company_entry.pack(fill='x', pady=(0, 15))
+        
+        # Author
+        ttk.Label(self.form_frame, text="Author", font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        self.author_entry = ttk.Entry(self.form_frame, width=60)
+        self.author_entry.pack(fill='x', pady=(0, 15))
+        
+        # Executive Summary
+        ttk.Label(self.form_frame, text="Executive Summary", font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        self.summary_text = scrolledtext.ScrolledText(self.form_frame, height=6, wrap=tk.WORD)
+        self.summary_text.pack(fill='x', pady=(0, 15))
+        
+        # Objectives
+        self.objectives_manager = ListManager(self.form_frame, "Objectives")
+        self.objectives_manager.pack(fill='x', pady=(0, 15))
+        
+        # Findings
+        self.findings_manager = ListManager(self.form_frame, "Key Findings")
+        self.findings_manager.pack(fill='x', pady=(0, 15))
+        
+        # Recommendations
+        self.recommendations_manager = ListManager(self.form_frame, "Recommendations")
+        self.recommendations_manager.pack(fill='x', pady=(0, 15))
+        
+        # Tags
+        ttk.Label(self.form_frame, text="Tags", font=('Arial', 10, 'bold')).pack(anchor='w', pady=(0, 5))
+        self.tag_entry = TagEntry(self.form_frame, TAG_SUGGESTIONS)
+        self.tag_entry.pack(fill='x', pady=(0, 15))
+    
+    def _collect_data(self):
+        self.data.title = self.title_entry.get()
+        self.data.company_name = self.company_entry.get()
+        self.data.author = self.author_entry.get()
+        self.data.executive_summary = self.summary_text.get('1.0', tk.END).strip()
+        self.data.objectives = self.objectives_manager.get_items()
+        self.data.findings = self.findings_manager.get_items()
+        self.data.recommendations = self.recommendations_manager.get_items()
+        self.data.tags = self.tag_entry.get_tags()
+        return self.data
+    
+    def _new_report(self):
+        if messagebox.askyesno("New Report", "Create new report? Unsaved changes will be lost."):
+            self.data = ReportData()
+            self.current_file = None
+            self.status_label.config(text="New report created")
+    
+    def _save_project(self):
+        if self.current_file:
+            self._save_to_file(self.current_file)
+        else:
+            self._save_project_as()
+    
+    def _save_project_as(self):
+        self._collect_data()
+        
+        filename = filedialog.asksaveasfilename(
+            title="Save Project",
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")]
+        )
+        
+        if filename:
+            self._save_to_file(Path(filename))
+    
+    def _save_to_file(self, file_path):
+        try:
+            with open(file_path, 'w') as f:
+                json.dump(asdict(self.data), f, indent=2)
+            self.current_file = file_path
+            self.status_label.config(text=f"Saved: {file_path.name}")
+            messagebox.showinfo("Success", "Project saved successfully")
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to save: {e}")
+    
+    def _open_project(self):
+        filename = filedialog.askopenfilename(
+            title="Open Project",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")]
+        )
+        
+        if filename:
+            try:
+                with open(filename, 'r') as f:
+                    data_dict = json.load(f)
+                self.data = ReportData(**data_dict)
+                self._populate_form()
+                self.current_file = Path(filename)
+                self.status_label.config(text=f"Opened: {Path(filename).name}")
+            except Exception as e:
+                messagebox.showerror("Error", f"Failed to open: {e}")
+    
+    def _populate_form(self):
+        self.title_entry.delete(0, tk.END)
+        self.title_entry.insert(0, self.data.title)
+        
+        self.company_entry.delete(0, tk.END)
+        self.company_entry.insert(0, self.data.company_name)
+        
+        self.author_entry.delete(0, tk.END)
+        self.author_entry.insert(0, self.data.author)
+        
+        self.summary_text.delete('1.0', tk.END)
+        self.summary_text.insert('1.0', self.data.executive_summary)
+        
+        self.objectives_manager.set_items(self.data.objectives)
+        self.findings_manager.set_items(self.data.findings)
+        self.recommendations_manager.set_items(self.data.recommendations)
+        self.tag_entry.set_tags(self.data.tags)
+    
+    def _export_docx(self):
+        if not self.data.title:
+            messagebox.showwarning("Warning", "Please enter a report title")
+            return
+        
+        self._collect_data()
+        
+        filename = filedialog.asksaveasfilename(
+            title="Export Report",
+            defaultextension=".docx",
+            initialfile=f"{self.data.title}.docx",
+            filetypes=[("Word documents", "*.docx"), ("All files", "*.*")]
+        )
+        
+        if filename:
+            try:
+                DocumentGenerator.generate_report(self.data, Path(filename))
+                self.status_label.config(text=f"Exported: {Path(filename).name}")
+                messagebox.showinfo("Success", f"Report exported successfully!\n\n{filename}")
+            except Exception as e:
+                messagebox.showerror("Error", f"Export failed: {e}")
+    
+    def _show_about(self):
+        about_text = """
+Reportify Pro v2.0.0
+Enterprise Report Generator
+
+Features:
+• 25+ Professional Templates
+• 7 IT Domain Categories
+• Smart Variables & Automation
+• Multi-Format Export
+
+Created for Portfolio Showcase
+        """
+        messagebox.showinfo("About Reportify Pro", about_text)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# APPLICATION ENTRY POINT
+# ═══════════════════════════════════════════════════════════════════════════
+
+def main():
+    root = tk.Tk()
+    app = ReportifyProApp(root)
+    root.mainloop()
+
+if __name__ == '__main__':
+    main()

--- a/reportify_pro.py
+++ b/reportify_pro.py
@@ -1,0 +1,452 @@
+"""
+Enterprise Portfolio & Report Generation System
+
+A production-ready system for generating professional portfolio documentation
+and technical reports with enterprise-grade validation and extensibility.
+
+Author: Your Name
+License: MIT
+Version: 1.0.0
+"""
+
+import argparse
+import json
+import logging
+import sys
+from abc import ABC, abstractmethod
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
+
+try:
+    from docx import Document
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Inches, Pt
+    from pydantic import BaseModel, Field, field_validator
+except ImportError as e:
+    print(f"Missing required dependency: {e}")
+    print("Install with: pip install python-docx pydantic")
+    sys.exit(1)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('portfolio_system.log'),
+        logging.StreamHandler(sys.stdout)
+    ]
+)
+logger = logging.getLogger(__name__)
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats."""
+    DOCX = "docx"
+    PDF = "pdf"
+    HTML = "html"
+
+
+class ReportSection(str, Enum):
+    """Standard report sections."""
+    COVER = "cover"
+    EXECUTIVE_SUMMARY = "executive_summary"
+    OBJECTIVES = "objectives"
+    APPROACH = "approach"
+    RESULTS = "results"
+    TIMELINE = "timeline"
+    CONCLUSION = "conclusion"
+    NEXT_STEPS = "next_steps"
+
+
+class ProjectData(BaseModel):
+    """Data model for project information with validation."""
+    project_id: str = Field(default_factory=lambda: f"PROJ-{uuid4().hex[:8].upper()}")
+    title: str = Field(..., min_length=1, max_length=200)
+    subtitle: Optional[str] = Field(None, max_length=300)
+    author: str = Field(..., min_length=1, max_length=100)
+    date: Optional[str] = None
+    executive_summary: Optional[str] = None
+    objectives: List[str] = Field(default_factory=list)
+    approach: Optional[str] = None
+    results: List[str] = Field(default_factory=list)
+    timeline: List[Dict[str, str]] = Field(default_factory=list)
+    conclusion: Optional[str] = None
+    next_steps: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator('date')
+    @classmethod
+    def validate_date(cls, v: Optional[str]) -> str:
+        """Set default date if not provided."""
+        if v is None:
+            return datetime.now().strftime("%B %d, %Y")
+        return v
+
+    @field_validator('timeline')
+    @classmethod
+    def validate_timeline(cls, v: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        """Validate timeline entries have required fields."""
+        for entry in v:
+            if 'milestone' not in entry or 'date' not in entry:
+                raise ValueError("Timeline entries must contain 'milestone' and 'date'")
+        return v
+
+
+class ReportConfig(BaseModel):
+    """Configuration for report generation."""
+    template_name: str = Field(default="standard")
+    output_format: OutputFormat = Field(default=OutputFormat.DOCX)
+    include_sections: List[ReportSection] = Field(default_factory=list)
+    exclude_sections: List[ReportSection] = Field(default_factory=list)
+    style_settings: Dict[str, Any] = Field(default_factory=dict)
+    company_branding: Optional[Dict[str, str]] = None
+
+    class Config:
+        use_enum_values = True
+
+
+class ReportSectionRenderer(ABC):
+    """Abstract base class for report section renderers."""
+
+    @abstractmethod
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Render section to document."""
+        pass
+
+    def _add_section_title(self, doc: Document, title: str, level: int = 1) -> None:
+        """Add formatted section title."""
+        heading = doc.add_heading(title, level=level)
+        heading.alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+
+class CoverPageRenderer(ReportSectionRenderer):
+    """Renders report cover page."""
+
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Add cover page with project details."""
+        try:
+            # Title
+            title_para = doc.add_paragraph()
+            title_run = title_para.add_run(data.title)
+            title_run.font.size = Pt(24)
+            title_run.bold = True
+            title_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+            # Subtitle
+            if data.subtitle:
+                subtitle_para = doc.add_paragraph()
+                subtitle_run = subtitle_para.add_run(data.subtitle)
+                subtitle_run.font.size = Pt(14)
+                subtitle_run.italic = True
+                subtitle_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+            # Author and date
+            details_para = doc.add_paragraph()
+            details_para.add_run(f"Prepared by: {data.author}\n")
+            details_para.add_run(f"Date: {data.date}\n")
+            details_para.add_run(f"Project ID: {data.project_id}")
+            details_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+            doc.add_page_break()
+            logger.info("Cover page rendered successfully")
+
+        except Exception as e:
+            logger.error(f"Error rendering cover page: {e}")
+            raise
+
+
+class ExecutiveSummaryRenderer(ReportSectionRenderer):
+    """Renders executive summary section."""
+
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Add executive summary."""
+        if data.executive_summary:
+            self._add_section_title(doc, "Executive Summary")
+            doc.add_paragraph(data.executive_summary)
+            logger.debug("Executive summary section rendered")
+
+
+class BulletListRenderer(ReportSectionRenderer):
+    """Renders bulleted lists for sections."""
+
+    def __init__(self, section_title: str, data_field: str):
+        self.section_title = section_title
+        self.data_field = data_field
+
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Add bulleted list section."""
+        items = getattr(data, self.data_field, [])
+        if items:
+            self._add_section_title(doc, self.section_title)
+            for item in items:
+                doc.add_paragraph(item, style="List Bullet")
+
+
+class ParagraphRenderer(ReportSectionRenderer):
+    """Renders simple paragraph sections."""
+
+    def __init__(self, section_title: str, data_field: str):
+        self.section_title = section_title
+        self.data_field = data_field
+
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Add paragraph section."""
+        content = getattr(data, self.data_field, None)
+        if content:
+            self._add_section_title(doc, self.section_title)
+            doc.add_paragraph(content)
+
+
+class TimelineRenderer(ReportSectionRenderer):
+    """Renders project timeline as a table."""
+
+    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
+        """Add timeline table."""
+        if data.timeline:
+            self._add_section_title(doc, "Project Timeline")
+            table = doc.add_table(rows=1, cols=3)
+            table.style = "Light Grid Accent 1"
+
+            # Header row
+            hdr_cells = table.rows[0].cells
+            hdr_cells[0].text = "Milestone"
+            hdr_cells[1].text = "Date"
+            hdr_cells[2].text = "Status"
+
+            # Data rows
+            for entry in data.timeline:
+                row_cells = table.add_row().cells
+                row_cells[0].text = entry.get('milestone', '')
+                row_cells[1].text = entry.get('date', '')
+                row_cells[2].text = entry.get('status', 'Completed')
+
+            logger.debug("Timeline section rendered")
+
+
+class ReportTemplate:
+    """Manages report template and section rendering."""
+
+    def __init__(self, config: ReportConfig):
+        self.config = config
+        self.renderers: Dict[ReportSection, ReportSectionRenderer] = self._initialize_renderers()
+
+    def _initialize_renderers(self) -> Dict[ReportSection, ReportSectionRenderer]:
+        """Initialize section renderers based on configuration."""
+        return {
+            ReportSection.COVER: CoverPageRenderer(),
+            ReportSection.EXECUTIVE_SUMMARY: ExecutiveSummaryRenderer(),
+            ReportSection.OBJECTIVES: BulletListRenderer("Objectives", "objectives"),
+            ReportSection.APPROACH: ParagraphRenderer("Approach", "approach"),
+            ReportSection.RESULTS: BulletListRenderer("Results", "results"),
+            ReportSection.TIMELINE: TimelineRenderer(),
+            ReportSection.CONCLUSION: ParagraphRenderer("Conclusion", "conclusion"),
+            ReportSection.NEXT_STEPS: BulletListRenderer("Next Steps", "next_steps"),
+        }
+
+    def get_render_order(self) -> List[ReportSection]:
+        """Determine section rendering order."""
+        default_order = [
+            ReportSection.COVER,
+            ReportSection.EXECUTIVE_SUMMARY,
+            ReportSection.OBJECTIVES,
+            ReportSection.APPROACH,
+            ReportSection.RESULTS,
+            ReportSection.TIMELINE,
+            ReportSection.CONCLUSION,
+            ReportSection.NEXT_STEPS,
+        ]
+
+        # Apply inclusions/exclusions
+        if self.config.include_sections:
+            return [s for s in default_order if s in self.config.include_sections]
+        else:
+            return [s for s in default_order if s not in self.config.exclude_sections]
+
+
+class DocumentBuilder:
+    """Builds documents using configured templates and data."""
+
+    def __init__(self, template: ReportTemplate):
+        self.template = template
+        self.document = Document()
+        self._setup_document_styles()
+
+    def _setup_document_styles(self) -> None:
+        """Configure document styles and formatting."""
+        for section in self.document.sections:
+            section.top_margin = Inches(1)
+            section.bottom_margin = Inches(1)
+            section.left_margin = Inches(1)
+            section.right_margin = Inches(1)
+
+    def build(self, data: ProjectData) -> Document:
+        """Build complete document."""
+        try:
+            render_order = self.template.get_render_order()
+
+            for section in render_order:
+                renderer = self.template.renderers.get(section)
+                if renderer:
+                    renderer.render(self.document, data, self.template.config)
+                    logger.debug(f"Rendered section: {section.value}")
+
+            logger.info(f"Document built with {len(render_order)} sections")
+            return self.document
+
+        except Exception as e:
+            logger.error(f"Error building document: {e}")
+            raise
+
+
+class ReportGenerator:
+    """Main report generation orchestrator."""
+
+    def __init__(self, config: Optional[ReportConfig] = None):
+        self.config = config or ReportConfig()
+        self.template = ReportTemplate(self.config)
+
+    def generate(self, data: ProjectData, output_path: Path) -> None:
+        """Generate report from data."""
+        try:
+            logger.info(f"Generating report: {data.project_id}")
+
+            builder = DocumentBuilder(self.template)
+            document = builder.build(data)
+
+            # Ensure output directory exists
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save document
+            document.save(str(output_path))
+            logger.info(f"Report saved to: {output_path}")
+
+        except Exception as e:
+            logger.error(f"Report generation failed: {e}")
+            raise
+
+
+class DataLoader:
+    """Handles data loading and validation."""
+
+    @staticmethod
+    def load_from_json(file_path: Path) -> ProjectData:
+        """Load and validate project data from JSON file."""
+        try:
+            with file_path.open('r', encoding='utf-8') as f:
+                raw_data = json.load(f)
+            return ProjectData(**raw_data)
+        except FileNotFoundError:
+            logger.error(f"File not found: {file_path}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Data loading failed: {e}")
+            raise
+
+
+class ConfigManager:
+    """Manages configuration loading and validation."""
+
+    @staticmethod
+    def load_config(config_path: Optional[Path] = None) -> ReportConfig:
+        """Load configuration from file or use defaults."""
+        if config_path and config_path.exists():
+            try:
+                with config_path.open('r', encoding='utf-8') as f:
+                    config_data = json.load(f)
+                return ReportConfig(**config_data)
+            except Exception as e:
+                logger.warning(f"Config load failed, using defaults: {e}")
+
+        return ReportConfig()
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Enterprise Portfolio & Report Generator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s -i project.json -o report.docx
+  %(prog)s -i project.json -o report.docx --config config.json -v
+        """
+    )
+
+    parser.add_argument(
+        "--input", "-i",
+        type=Path,
+        required=True,
+        help="Path to input JSON file with project data"
+    )
+
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        default=Path("reports/generated_report.docx"),
+        help="Output path for generated report (default: reports/generated_report.docx)"
+    )
+
+    parser.add_argument(
+        "--config", "-c",
+        type=Path,
+        help="Path to configuration JSON file"
+    )
+
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose logging"
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 1.0.0"
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Main execution function."""
+    try:
+        args = parse_arguments()
+
+        # Configure logging level
+        if args.verbose:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        # Validate input file exists
+        if not args.input.exists():
+            logger.error(f"Input file not found: {args.input}")
+            return 1
+
+        # Load configuration
+        config = ConfigManager.load_config(args.config)
+
+        # Load and validate data
+        project_data = DataLoader.load_from_json(args.input)
+
+        # Generate report
+        generator = ReportGenerator(config)
+        generator.generate(project_data, args.output)
+
+        logger.info("Report generation completed successfully")
+        return 0
+
+    except KeyboardInterrupt:
+        logger.info("Operation cancelled by user")
+        return 130
+    except Exception as e:
+        logger.error(f"Fatal error: {e}", exc_info=args.verbose if 'args' in locals() else False)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reportify_pro.py
+++ b/reportify_pro.py
@@ -1,452 +1,542 @@
 """
-Enterprise Portfolio & Report Generation System
+Reportify Pro v2.1 - Enterprise Report Generator
+================================================
 
-A production-ready system for generating professional portfolio documentation
-and technical reports with enterprise-grade validation and extensibility.
+Complete professional report generation system with 21 templates
+across 8 IT job role domains.
 
-Author: Your Name
-License: MIT
-Version: 1.0.0
+Author: Portfolio Showcase
+Version: 2.1.0
 """
 
-import argparse
-import json
-import logging
 import sys
-from abc import ABC, abstractmethod
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
-from uuid import uuid4
+from dataclasses import dataclass, field
+from typing import Dict, List
+from enum import Enum
 
 try:
     from docx import Document
+    from docx.shared import Pt, RGBColor
     from docx.enum.text import WD_ALIGN_PARAGRAPH
-    from docx.shared import Inches, Pt
-    from pydantic import BaseModel, Field, field_validator
-except ImportError as e:
-    print(f"Missing required dependency: {e}")
-    print("Install with: pip install python-docx pydantic")
+except ImportError:
+    print("Error: python-docx required. Install: pip install python-docx")
     sys.exit(1)
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('portfolio_system.log'),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
-logger = logging.getLogger(__name__)
+# ════════════════════════════════════════════════════════════════════════
+# ENHANCED TEMPLATE DATABASE (21 Templates)
+# ════════════════════════════════════════════════════════════════════════
 
 
-class OutputFormat(str, Enum):
-    """Supported output formats."""
-    DOCX = "docx"
-    PDF = "pdf"
-    HTML = "html"
+class ReportCategory(str, Enum):
+    SECURITY = "Security"
+    DEVOPS = "DevOps"
+    CLOUD = "Cloud"
+    SYSADMIN = "System Admin"
+    PROJECT = "Project Management"
+    COMPLIANCE = "Compliance"
+    NETWORK = "Networking"
+    DATA_ANALYTICS = "Data Analytics"
 
 
-class ReportSection(str, Enum):
-    """Standard report sections."""
-    COVER = "cover"
-    EXECUTIVE_SUMMARY = "executive_summary"
-    OBJECTIVES = "objectives"
-    APPROACH = "approach"
-    RESULTS = "results"
-    TIMELINE = "timeline"
-    CONCLUSION = "conclusion"
-    NEXT_STEPS = "next_steps"
+@dataclass
+class ReportData:
+    template_key: str = ""
+    category: str = ""
+    title: str = ""
+    subtitle: str = ""
+    author: str = ""
+    date: str = datetime.now().strftime("%B %d, %Y")
+    company_name: str = "Your Company Inc."
+
+    # Core sections
+    executive_summary: str = ""
+    background: str = ""
+    objectives: List[str] = field(default_factory=list)
+    scope: str = ""
+    methodology: str = ""
+    findings: List[str] = field(default_factory=list)
+    analysis: str = ""
+    recommendations: List[str] = field(default_factory=list)
+    conclusion: str = ""
+    next_steps: List[str] = field(default_factory=list)
+
+    # Additional fields for specialized templates
+    kpis: Dict[str, str] = field(default_factory=dict)
+    timeline_entries: List[str] = field(default_factory=list)
+    risks: List[str] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    appendix: str = ""
+
+    tags: List[str] = field(default_factory=list)
 
 
-class ProjectData(BaseModel):
-    """Data model for project information with validation."""
-    project_id: str = Field(default_factory=lambda: f"PROJ-{uuid4().hex[:8].upper()}")
-    title: str = Field(..., min_length=1, max_length=200)
-    subtitle: Optional[str] = Field(None, max_length=300)
-    author: str = Field(..., min_length=1, max_length=100)
-    date: Optional[str] = None
-    executive_summary: Optional[str] = None
-    objectives: List[str] = Field(default_factory=list)
-    approach: Optional[str] = None
-    results: List[str] = Field(default_factory=list)
-    timeline: List[Dict[str, str]] = Field(default_factory=list)
-    conclusion: Optional[str] = None
-    next_steps: List[str] = Field(default_factory=list)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+REPORT_TEMPLATES = {
+    # ═══ SECURITY DOMAIN (6 templates) ═══
+    "vulnerability_assessment": {
+        "name": "Vulnerability Assessment Report",
+        "category": ReportCategory.SECURITY,
+        "icon": "🔒",
+        "sections": ["executive_summary", "scope", "methodology", "findings", "risks", "recommendations"],
+        "description": "Comprehensive security vulnerability assessment with CVSS ratings",
+        "standards": "NIST CSF, CIS Benchmarks"
+    },
 
-    @field_validator('date')
-    @classmethod
-    def validate_date(cls, v: Optional[str]) -> str:
-        """Set default date if not provided."""
-        if v is None:
-            return datetime.now().strftime("%B %d, %Y")
-        return v
+    "penetration_test": {
+        "name": "Penetration Testing Report",
+        "category": ReportCategory.SECURITY,
+        "icon": "🛡️",
+        "sections": ["executive_summary", "scope", "methodology", "findings", "risks", "recommendations"],
+        "description": "Full penetration test following OWASP/PTES methodologies",
+        "standards": "OWASP Top 10, PTES"
+    },
 
-    @field_validator('timeline')
-    @classmethod
-    def validate_timeline(cls, v: List[Dict[str, str]]) -> List[Dict[str, str]]:
-        """Validate timeline entries have required fields."""
-        for entry in v:
-            if 'milestone' not in entry or 'date' not in entry:
-                raise ValueError("Timeline entries must contain 'milestone' and 'date'")
-        return v
+    "iam_audit": {
+        "name": "IAM Security Audit",
+        "category": ReportCategory.SECURITY,
+        "icon": "👤",
+        "sections": ["executive_summary", "scope", "findings", "risks", "recommendations"],
+        "description": "Identity and Access Management security assessment",
+        "standards": "NIST SP 800-63"
+    },
 
-
-class ReportConfig(BaseModel):
-    """Configuration for report generation."""
-    template_name: str = Field(default="standard")
-    output_format: OutputFormat = Field(default=OutputFormat.DOCX)
-    include_sections: List[ReportSection] = Field(default_factory=list)
-    exclude_sections: List[ReportSection] = Field(default_factory=list)
-    style_settings: Dict[str, Any] = Field(default_factory=dict)
-    company_branding: Optional[Dict[str, str]] = None
-
-    class Config:
-        use_enum_values = True
-
-
-class ReportSectionRenderer(ABC):
-    """Abstract base class for report section renderers."""
-
-    @abstractmethod
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Render section to document."""
-        pass
-
-    def _add_section_title(self, doc: Document, title: str, level: int = 1) -> None:
-        """Add formatted section title."""
-        heading = doc.add_heading(title, level=level)
-        heading.alignment = WD_ALIGN_PARAGRAPH.LEFT
-
-
-class CoverPageRenderer(ReportSectionRenderer):
-    """Renders report cover page."""
-
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Add cover page with project details."""
-        try:
-            # Title
-            title_para = doc.add_paragraph()
-            title_run = title_para.add_run(data.title)
-            title_run.font.size = Pt(24)
-            title_run.bold = True
-            title_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
-
-            # Subtitle
-            if data.subtitle:
-                subtitle_para = doc.add_paragraph()
-                subtitle_run = subtitle_para.add_run(data.subtitle)
-                subtitle_run.font.size = Pt(14)
-                subtitle_run.italic = True
-                subtitle_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
-
-            # Author and date
-            details_para = doc.add_paragraph()
-            details_para.add_run(f"Prepared by: {data.author}\n")
-            details_para.add_run(f"Date: {data.date}\n")
-            details_para.add_run(f"Project ID: {data.project_id}")
-            details_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
-
-            doc.add_page_break()
-            logger.info("Cover page rendered successfully")
-
-        except Exception as e:
-            logger.error(f"Error rendering cover page: {e}")
-            raise
-
-
-class ExecutiveSummaryRenderer(ReportSectionRenderer):
-    """Renders executive summary section."""
-
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Add executive summary."""
-        if data.executive_summary:
-            self._add_section_title(doc, "Executive Summary")
-            doc.add_paragraph(data.executive_summary)
-            logger.debug("Executive summary section rendered")
-
-
-class BulletListRenderer(ReportSectionRenderer):
-    """Renders bulleted lists for sections."""
-
-    def __init__(self, section_title: str, data_field: str):
-        self.section_title = section_title
-        self.data_field = data_field
-
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Add bulleted list section."""
-        items = getattr(data, self.data_field, [])
-        if items:
-            self._add_section_title(doc, self.section_title)
-            for item in items:
-                doc.add_paragraph(item, style="List Bullet")
-
-
-class ParagraphRenderer(ReportSectionRenderer):
-    """Renders simple paragraph sections."""
-
-    def __init__(self, section_title: str, data_field: str):
-        self.section_title = section_title
-        self.data_field = data_field
-
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Add paragraph section."""
-        content = getattr(data, self.data_field, None)
-        if content:
-            self._add_section_title(doc, self.section_title)
-            doc.add_paragraph(content)
-
-
-class TimelineRenderer(ReportSectionRenderer):
-    """Renders project timeline as a table."""
-
-    def render(self, doc: Document, data: ProjectData, config: ReportConfig) -> None:
-        """Add timeline table."""
-        if data.timeline:
-            self._add_section_title(doc, "Project Timeline")
-            table = doc.add_table(rows=1, cols=3)
-            table.style = "Light Grid Accent 1"
-
-            # Header row
-            hdr_cells = table.rows[0].cells
-            hdr_cells[0].text = "Milestone"
-            hdr_cells[1].text = "Date"
-            hdr_cells[2].text = "Status"
-
-            # Data rows
-            for entry in data.timeline:
-                row_cells = table.add_row().cells
-                row_cells[0].text = entry.get('milestone', '')
-                row_cells[1].text = entry.get('date', '')
-                row_cells[2].text = entry.get('status', 'Completed')
-
-            logger.debug("Timeline section rendered")
-
-
-class ReportTemplate:
-    """Manages report template and section rendering."""
-
-    def __init__(self, config: ReportConfig):
-        self.config = config
-        self.renderers: Dict[ReportSection, ReportSectionRenderer] = self._initialize_renderers()
-
-    def _initialize_renderers(self) -> Dict[ReportSection, ReportSectionRenderer]:
-        """Initialize section renderers based on configuration."""
-        return {
-            ReportSection.COVER: CoverPageRenderer(),
-            ReportSection.EXECUTIVE_SUMMARY: ExecutiveSummaryRenderer(),
-            ReportSection.OBJECTIVES: BulletListRenderer("Objectives", "objectives"),
-            ReportSection.APPROACH: ParagraphRenderer("Approach", "approach"),
-            ReportSection.RESULTS: BulletListRenderer("Results", "results"),
-            ReportSection.TIMELINE: TimelineRenderer(),
-            ReportSection.CONCLUSION: ParagraphRenderer("Conclusion", "conclusion"),
-            ReportSection.NEXT_STEPS: BulletListRenderer("Next Steps", "next_steps"),
+    "attack_surface": {
+        "name": "Attack Surface Analysis",
+        "category": ReportCategory.SECURITY,
+        "icon": "🎯",
+        "sections": ["scope", "methodology", "findings", "risks", "recommendations", "appendix"],
+        "description": "External attack surface enumeration and risk assessment",
+        "standards": "NIST CSF Identify/Protect",
+        "defaults": {
+            "title": "Attack Surface Analysis Report",
+            "objectives": [
+                "Enumerate all external-facing assets (domains, IPs, cloud resources)",
+                "Identify exposed services, open ports, and misconfigurations",
+                "Assess risk based on exploitability and business impact",
+                "Provide prioritized remediation recommendations"
+            ]
         }
+    },
 
-    def get_render_order(self) -> List[ReportSection]:
-        """Determine section rendering order."""
-        default_order = [
-            ReportSection.COVER,
-            ReportSection.EXECUTIVE_SUMMARY,
-            ReportSection.OBJECTIVES,
-            ReportSection.APPROACH,
-            ReportSection.RESULTS,
-            ReportSection.TIMELINE,
-            ReportSection.CONCLUSION,
-            ReportSection.NEXT_STEPS,
-        ]
+    "incident_response": {
+        "name": "Security Incident Report",
+        "category": ReportCategory.SECURITY,
+        "icon": "🚨",
+        "sections": ["metadata", "executive_summary", "timeline", "findings", "analysis", "recommendations"],
+        "description": "Post-incident review following NIST SP 800-61",
+        "standards": "NIST SP 800-61 r2, ISO 27001 A.16",
+        "defaults": {
+            "title": "Security Incident Report - {{incident_id}}",
+            "objectives": [
+                "Document complete incident timeline from detection to recovery",
+                "Perform root cause analysis using 5 Whys methodology",
+                "Assess business impact (users affected, downtime, data exposure)",
+                "Identify control gaps and implement preventive measures"
+            ]
+        }
+    },
 
-        # Apply inclusions/exclusions
-        if self.config.include_sections:
-            return [s for s in default_order if s in self.config.include_sections]
-        else:
-            return [s for s in default_order if s not in self.config.exclude_sections]
+    "log_analysis": {
+        "name": "Log Analysis Report",
+        "category": ReportCategory.SECURITY,
+        "icon": "📊",
+        "sections": ["scope", "methodology", "findings", "recommendations", "appendix"],
+        "description": "Security log analysis and anomaly detection",
+        "standards": "NIST Logging Practices",
+        "defaults": {
+            "title": "Log Analysis Report - {{timeframe}}",
+            "methodology": "Analyzed system logs using SIEM correlation rules, statistical anomaly detection, and baseline deviation analysis.",
+            "objectives": [
+                "Identify suspicious authentication patterns and failed login attempts",
+                "Detect anomalous network traffic and data exfiltration indicators",
+                "Correlate security events across multiple log sources",
+                "Tune SIEM rules and reduce false positive rates"
+            ]
+        }
+    },
+
+    # ═══ DEVOPS DOMAIN (4 templates) ═══
+    "infrastructure_design": {
+        "name": "Infrastructure Design Document",
+        "category": ReportCategory.DEVOPS,
+        "icon": "🏗️",
+        "sections": ["executive_summary", "objectives", "scope", "methodology", "recommendations"],
+        "description": "Infrastructure architecture specification and design"
+    },
+
+    "deployment_report": {
+        "name": "Production Deployment Report",
+        "category": ReportCategory.DEVOPS,
+        "icon": "🚀",
+        "sections": ["executive_summary", "scope", "timeline", "findings", "recommendations"],
+        "description": "Production deployment summary with rollback procedures"
+    },
+
+    "proof_of_concept": {
+        "name": "Proof of Concept (PoC) Report",
+        "category": ReportCategory.DEVOPS,
+        "icon": "🧪",
+        "sections": ["objectives", "scope", "methodology", "findings", "analysis", "recommendations"],
+        "description": "Technical PoC validation with success criteria",
+        "standards": "---",
+        "defaults": {
+            "title": "Proof of Concept Report - {{technology}}",
+            "objectives": [
+                "Validate technical feasibility against defined success criteria",
+                "Measure performance, scalability, and integration capabilities",
+                "Identify implementation risks and resource requirements",
+                "Provide go/no-go recommendation with supporting evidence"
+            ]
+        }
+    },
+
+    "qa_test_report": {
+        "name": "QA Test Report",
+        "category": ReportCategory.DEVOPS,
+        "icon": "✅",
+        "sections": ["overview", "objectives", "findings", "analysis", "recommendations", "appendix"],
+        "description": "Functional, regression, and performance testing results",
+        "standards": "IEEE 829",
+        "defaults": {
+            "title": "QA Test Report - {{build_version}}",
+            "objectives": [
+                "Execute comprehensive test suite (functional, regression, integration)",
+                "Validate acceptance criteria and user stories completion",
+                "Identify defects by severity and provide root cause analysis",
+                "Assess release readiness with go/no-go recommendation"
+            ]
+        }
+    },
+
+    # ═══ CLOUD DOMAIN (2 templates) ═══
+    "cloud_migration": {
+        "name": "Cloud Migration Assessment",
+        "category": ReportCategory.CLOUD,
+        "icon": "☁️",
+        "sections": ["executive_summary", "objectives", "methodology", "findings", "risks", "recommendations"],
+        "description": "Cloud migration strategy and execution plan"
+    },
+
+    "cost_optimization": {
+        "name": "Cloud Cost Optimization",
+        "category": ReportCategory.CLOUD,
+        "icon": "💰",
+        "sections": ["executive_summary", "findings", "analysis", "recommendations"],
+        "description": "Cloud infrastructure cost analysis and optimization"
+    },
+
+    # ═══ SYSTEM ADMIN DOMAIN (2 templates) ═══
+    "system_audit": {
+        "name": "System Administration Audit",
+        "category": ReportCategory.SYSADMIN,
+        "icon": "🖥️",
+        "sections": ["scope", "methodology", "findings", "recommendations"],
+        "description": "Server and system configuration audit"
+    },
+
+    "technology_assessment": {
+        "name": "Technology Assessment",
+        "category": ReportCategory.SYSADMIN,
+        "icon": "🔧",
+        "sections": ["background", "scope", "findings", "risks", "recommendations", "appendix"],
+        "description": "Technology stack evaluation and modernization roadmap",
+        "standards": "---",
+        "defaults": {
+            "title": "Technology Assessment - {{system_name}}",
+            "objectives": [
+                "Inventory current technology stack (versions, support status, licensing)",
+                "Benchmark against industry best practices and modern patterns",
+                "Identify operational and security risks from technical debt",
+                "Provide target state architecture with migration roadmap and costs"
+            ]
+        }
+    },
+
+    # ═══ PROJECT MANAGEMENT DOMAIN (4 templates) ═══
+    "project_status": {
+        "name": "Project Status Report",
+        "category": ReportCategory.PROJECT,
+        "icon": "📋",
+        "sections": ["executive_summary", "timeline", "risks", "findings", "recommendations"],
+        "description": "Current project status and progress tracking"
+    },
+
+    "project_proposal": {
+        "name": "Project Proposal (Executive-Ready)",
+        "category": ReportCategory.PROJECT,
+        "icon": "📝",
+        "sections": ["executive_summary", "background", "scope", "methodology", "recommendations", "conclusion"],
+        "description": "Comprehensive project proposal with ROI analysis",
+        "standards": "---",
+        "defaults": {
+            "title": "Project Proposal - {{project_name}}",
+            "objectives": [
+                "Define problem statement, business impact, and strategic alignment",
+                "Present proposed solution with architecture and alternatives comparison",
+                "Provide detailed scope, deliverables, and acceptance criteria",
+                "Justify investment with ROI analysis and risk mitigation plan"
+            ]
+        }
+    },
+
+    "project_closure": {
+        "name": "Project Outcome/Closure Report",
+        "category": ReportCategory.PROJECT,
+        "icon": "🏁",
+        "sections": ["executive_summary", "objectives", "findings", "analysis", "recommendations"],
+        "description": "Project completion summary and lessons learned",
+        "standards": "---",
+        "defaults": {
+            "title": "Project Closure Report - {{project_name}}",
+            "objectives": [
+                "Compare planned objectives vs actual outcomes with KPI deltas",
+                "Analyze budget and schedule variances with root causes",
+                "Document benefits realization and metrics achieved to date",
+                "Capture lessons learned and best practices for future projects"
+            ]
+        }
+    },
+
+    "operational_report": {
+        "name": "Operational Report (Monthly)",
+        "category": ReportCategory.PROJECT,
+        "icon": "📈",
+        "sections": ["executive_summary", "kpis", "findings", "recommendations", "next_steps"],
+        "description": "Monthly operational metrics and KPI tracking",
+        "standards": "SRE KPIs",
+        "defaults": {
+            "title": "Operational Report - {{month}} {{year}}",
+            "objectives": [
+                "Report on key operational KPIs (SLO/SLA, MTTR, MTBF, capacity utilization)",
+                "Track project milestone burndown and identify blockers",
+                "Highlight automation improvements and toil reduction initiatives",
+                "Define next period action items with owners and dependencies"
+            ]
+        }
+    },
+
+    # ═══ COMPLIANCE DOMAIN (1 template) ═══
+    "compliance_audit": {
+        "name": "Compliance Audit Report",
+        "category": ReportCategory.COMPLIANCE,
+        "icon": "✅",
+        "sections": ["executive_summary", "scope", "methodology", "findings", "recommendations"],
+        "description": "Regulatory compliance assessment and gap analysis"
+    },
+
+    # ═══ NETWORKING DOMAIN (1 template) ═══
+    "network_assessment": {
+        "name": "Network Security Assessment",
+        "category": ReportCategory.NETWORK,
+        "icon": "🌐",
+        "sections": ["scope", "methodology", "findings", "risks", "recommendations"],
+        "description": "Network infrastructure security and performance review"
+    },
+
+    # ═══ DATA ANALYTICS DOMAIN (1 template) ═══
+    "analytical_report": {
+        "name": "Analytical Report (Data Insights)",
+        "category": ReportCategory.DATA_ANALYTICS,
+        "icon": "📊",
+        "sections": ["executive_summary", "methodology", "kpis", "findings", "recommendations"],
+        "description": "Business intelligence and data-driven insights report",
+        "standards": "---",
+        "defaults": {
+            "title": "Data Analytics Report - {{analysis_focus}}",
+            "methodology": "Performed comprehensive data analysis using statistical methods, trend analysis, and predictive modeling. Data sources validated for accuracy and completeness.",
+            "objectives": [
+                "Analyze historical data to identify trends, patterns, and anomalies",
+                "Define and track key performance indicators (KPIs) with targets",
+                "Provide data-driven insights to support business decision-making",
+                "Recommend actionable improvements based on quantitative evidence"
+            ]
+        }
+    }
+}
 
 
-class DocumentBuilder:
-    """Builds documents using configured templates and data."""
-
-    def __init__(self, template: ReportTemplate):
-        self.template = template
-        self.document = Document()
-        self._setup_document_styles()
-
-    def _setup_document_styles(self) -> None:
-        """Configure document styles and formatting."""
-        for section in self.document.sections:
-            section.top_margin = Inches(1)
-            section.bottom_margin = Inches(1)
-            section.left_margin = Inches(1)
-            section.right_margin = Inches(1)
-
-    def build(self, data: ProjectData) -> Document:
-        """Build complete document."""
-        try:
-            render_order = self.template.get_render_order()
-
-            for section in render_order:
-                renderer = self.template.renderers.get(section)
-                if renderer:
-                    renderer.render(self.document, data, self.template.config)
-                    logger.debug(f"Rendered section: {section.value}")
-
-            logger.info(f"Document built with {len(render_order)} sections")
-            return self.document
-
-        except Exception as e:
-            logger.error(f"Error building document: {e}")
-            raise
+# ════════════════════════════════════════════════════════════════════════
+# DOCUMENT GENERATOR
+# ════════════════════════════════════════════════════════════════════════
 
 
-class ReportGenerator:
-    """Main report generation orchestrator."""
-
-    def __init__(self, config: Optional[ReportConfig] = None):
-        self.config = config or ReportConfig()
-        self.template = ReportTemplate(self.config)
-
-    def generate(self, data: ProjectData, output_path: Path) -> None:
-        """Generate report from data."""
-        try:
-            logger.info(f"Generating report: {data.project_id}")
-
-            builder = DocumentBuilder(self.template)
-            document = builder.build(data)
-
-            # Ensure output directory exists
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Save document
-            document.save(str(output_path))
-            logger.info(f"Report saved to: {output_path}")
-
-        except Exception as e:
-            logger.error(f"Report generation failed: {e}")
-            raise
-
-
-class DataLoader:
-    """Handles data loading and validation."""
+class DocumentGenerator:
+    """Enhanced document generator with all 21 templates"""
 
     @staticmethod
-    def load_from_json(file_path: Path) -> ProjectData:
-        """Load and validate project data from JSON file."""
-        try:
-            with file_path.open('r', encoding='utf-8') as f:
-                raw_data = json.load(f)
-            return ProjectData(**raw_data)
-        except FileNotFoundError:
-            logger.error(f"File not found: {file_path}")
-            raise
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Data loading failed: {e}")
-            raise
+    def generate_report(data: ReportData, template: dict, output_path: Path):
+        doc = Document()
+        DocumentGenerator._setup_styles(doc)
 
+        # Cover page
+        DocumentGenerator._add_cover_page(doc, data, template)
+        doc.add_page_break()
 
-class ConfigManager:
-    """Manages configuration loading and validation."""
+        # Standards/Frameworks (if applicable)
+        if template.get('standards') and template['standards'] != '---':
+            doc.add_heading("Standards & Frameworks", 2)
+            doc.add_paragraph(f"This report follows: {template['standards']}")
+            doc.add_paragraph()
+
+        # Executive Summary
+        if data.executive_summary:
+            doc.add_heading("Executive Summary", 1)
+            doc.add_paragraph(data.executive_summary)
+            doc.add_paragraph()
+
+        # Objectives
+        if data.objectives:
+            doc.add_heading("Objectives", 1)
+            for obj in data.objectives:
+                doc.add_paragraph(obj, style='List Bullet')
+            doc.add_paragraph()
+
+        # Scope
+        if data.scope:
+            doc.add_heading("Scope", 1)
+            doc.add_paragraph(data.scope)
+            doc.add_paragraph()
+
+        # Methodology
+        if data.methodology:
+            doc.add_heading("Methodology", 1)
+            doc.add_paragraph(data.methodology)
+            doc.add_paragraph()
+
+        # KPIs (for applicable reports)
+        if data.kpis:
+            doc.add_heading("Key Performance Indicators", 1)
+            table = doc.add_table(rows=1, cols=2)
+            table.style = 'Light Grid Accent 1'
+            table.rows[0].cells[0].text = "KPI"
+            table.rows[0].cells[1].text = "Value"
+            for kpi_name, kpi_value in data.kpis.items():
+                row = table.add_row().cells
+                row[0].text = kpi_name
+                row[1].text = kpi_value
+            doc.add_paragraph()
+
+        # Findings
+        if data.findings:
+            doc.add_heading("Key Findings", 1)
+            for finding in data.findings:
+                doc.add_paragraph(finding, style='List Bullet')
+            doc.add_paragraph()
+
+        # Analysis
+        if data.analysis:
+            doc.add_heading("Analysis", 1)
+            doc.add_paragraph(data.analysis)
+            doc.add_paragraph()
+
+        # Risks
+        if data.risks:
+            doc.add_heading("Risk Assessment", 1)
+            for risk in data.risks:
+                doc.add_paragraph(risk, style='List Bullet')
+            doc.add_paragraph()
+
+        # Recommendations
+        if data.recommendations:
+            doc.add_heading("Recommendations", 1)
+            for i, rec in enumerate(data.recommendations, 1):
+                doc.add_paragraph(f"{i}. {rec}", style='List Number')
+            doc.add_paragraph()
+
+        # Conclusion
+        if data.conclusion:
+            doc.add_heading("Conclusion", 1)
+            doc.add_paragraph(data.conclusion)
+            doc.add_paragraph()
+
+        # Next Steps
+        if data.next_steps:
+            doc.add_heading("Next Steps", 1)
+            for step in data.next_steps:
+                doc.add_paragraph(step, style='List Bullet')
+            doc.add_paragraph()
+
+        # Appendix
+        if data.appendix:
+            doc.add_page_break()
+            doc.add_heading("Appendix", 1)
+            doc.add_paragraph(data.appendix)
+
+        # Save
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        doc.save(str(output_path))
 
     @staticmethod
-    def load_config(config_path: Optional[Path] = None) -> ReportConfig:
-        """Load configuration from file or use defaults."""
-        if config_path and config_path.exists():
-            try:
-                with config_path.open('r', encoding='utf-8') as f:
-                    config_data = json.load(f)
-                return ReportConfig(**config_data)
-            except Exception as e:
-                logger.warning(f"Config load failed, using defaults: {e}")
+    def _setup_styles(doc: Document):
+        """Professional document styling"""
 
-        return ReportConfig()
+        # Configure heading styles
+        for i in range(1, 4):
+            style = doc.styles[f'Heading {i}']
+            style.font.name = 'Calibri'
+            style.font.color.rgb = RGBColor(31, 78, 120)
 
+        # Normal text
+        normal = doc.styles['Normal']
+        normal.font.name = 'Calibri'
+        normal.font.size = Pt(11)
 
-def parse_arguments() -> argparse.Namespace:
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Enterprise Portfolio & Report Generator",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s -i project.json -o report.docx
-  %(prog)s -i project.json -o report.docx --config config.json -v
-        """
-    )
+    @staticmethod
+    def _add_cover_page(doc: Document, data: ReportData, template: dict):
+        """Professional cover page with metadata"""
+        # Company header
+        header = doc.add_paragraph()
+        header.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        company_run = header.add_run(f"\n\n{data.company_name}\n")
+        company_run.font.size = Pt(18)
+        company_run.font.bold = True
+        company_run.font.color.rgb = RGBColor(31, 78, 120)
 
-    parser.add_argument(
-        "--input", "-i",
-        type=Path,
-        required=True,
-        help="Path to input JSON file with project data"
-    )
+        doc.add_paragraph("\n" * 3)
 
-    parser.add_argument(
-        "--output", "-o",
-        type=Path,
-        default=Path("reports/generated_report.docx"),
-        help="Output path for generated report (default: reports/generated_report.docx)"
-    )
+        # Report title
+        title = doc.add_paragraph()
+        title_run = title.add_run(data.title)
+        title_run.font.size = Pt(28)
+        title_run.font.bold = True
+        title_run.font.color.rgb = RGBColor(31, 78, 120)
+        title.alignment = WD_ALIGN_PARAGRAPH.CENTER
 
-    parser.add_argument(
-        "--config", "-c",
-        type=Path,
-        help="Path to configuration JSON file"
-    )
+        # Subtitle
+        if data.subtitle:
+            subtitle = doc.add_paragraph()
+            subtitle_run = subtitle.add_run(data.subtitle)
+            subtitle_run.font.size = Pt(16)
+            subtitle_run.font.italic = True
+            subtitle.alignment = WD_ALIGN_PARAGRAPH.CENTER
 
-    parser.add_argument(
-        "--verbose", "-v",
-        action="store_true",
-        help="Enable verbose logging"
-    )
+        doc.add_paragraph("\n" * 5)
 
-    parser.add_argument(
-        "--version",
-        action="version",
-        version="%(prog)s 1.0.0"
-    )
-
-    return parser.parse_args()
+        # Metadata
+        metadata = doc.add_paragraph()
+        metadata.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        metadata.add_run(f"Author: {data.author}\n")
+        metadata.add_run(f"Date: {data.date}\n")
+        metadata.add_run(f"Template: {template['name']}\n")
+        if template.get('standards'):
+            metadata.add_run(f"Standards: {template['standards']}\n")
 
 
-def main() -> int:
-    """Main execution function."""
-    try:
-        args = parse_arguments()
+# CLI Interface
 
-        # Configure logging level
-        if args.verbose:
-            logging.getLogger().setLevel(logging.DEBUG)
+def main():
+    print("Reportify Pro v2.1 - 21 Professional Templates")
+    print("=" * 60)
+    print("\nAvailable templates:")
 
-        # Validate input file exists
-        if not args.input.exists():
-            logger.error(f"Input file not found: {args.input}")
-            return 1
+    for key, template in REPORT_TEMPLATES.items():
+        print(f"  {template['icon']} {key:25} - {template['name']}")
 
-        # Load configuration
-        config = ConfigManager.load_config(args.config)
-
-        # Load and validate data
-        project_data = DataLoader.load_from_json(args.input)
-
-        # Generate report
-        generator = ReportGenerator(config)
-        generator.generate(project_data, args.output)
-
-        logger.info("Report generation completed successfully")
-        return 0
-
-    except KeyboardInterrupt:
-        logger.info("Operation cancelled by user")
-        return 130
-    except Exception as e:
-        logger.error(f"Fatal error: {e}", exc_info=args.verbose if 'args' in locals() else False)
-        return 1
+    print("\nUsage:")
+    print("  python reportify_pro.py <template_key>")
+    print("  Example: python reportify_pro.py vulnerability_assessment")
 
 
-if __name__ == "__main__":
-    sys.exit(main())
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a standalone Cybersecurity Report Arsenal HTML interface for selecting roles/templates and capturing report metadata
- include interactive guidance panel, tagging helpers, findings management modal, and JSON save/load helpers

## Testing
- python -m compileall reportify_pro.py

------
https://chatgpt.com/codex/tasks/task_e_68f847deb148832784f5aed8635c006b