### PR TITLE
Harden token validation and document automation notes

### DIFF
--- a/.editor/settings.json
+++ b/.editor/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "files.trimTrailingWhitespace": true,
+  "python.pythonPath": "python3",
+  "python.formatting.provider": "black"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.tf]
+indent_size = 2
+
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a reproducible problem or regression
+labels: bug
+---
+
+## Description
+<!-- Provide a clear description of the bug. -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Screenshots or Logs
+
+## Environment
+- Service:
+- Version/Commit:
+- Environment (dev/staging/prod):
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement
+labels: enhancement
+---
+
+## Summary
+<!-- What problem are we solving? -->
+
+## Proposed Solution
+
+## Alternatives Considered
+
+## Additional Context

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r backend/requirements.txt
+          npm install
+          cd frontend && npm install
+      - name: Backend lint
+        run: ruff check backend
+      - name: Frontend lint
+        run: cd frontend && npm run lint
+      - name: Terraform lint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          ./bin/tflint --chdir infra
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: portfolio
+          POSTGRES_PASSWORD: portfolio
+          POSTGRES_DB: portfolio
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U portfolio" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install backend deps
+        run: |
+          pip install -r backend/requirements.txt
+      - name: Run backend tests
+        env:
+          DATABASE_URL: postgresql+asyncpg://portfolio:portfolio@localhost:5432/portfolio
+          SECRET_KEY: test-secret
+        run: |
+          cd backend
+          pytest --maxfail=1 --disable-warnings -q
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build backend image
+        run: docker build -t portfolio-backend ./backend
+      - name: Build frontend image
+        run: docker build -t portfolio-frontend ./frontend
+      - name: Archive manifests
+        run: |
+          mkdir -p artifacts
+          tar -czf artifacts/terraform.tar.gz infra
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r backend/requirements.txt
+          cd frontend && npm install
+      - name: Run backend tests
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///./test.db
+          SECRET_KEY: release-secret
+        run: |
+          cd backend
+          pytest
+      - name: Build backend image
+        run: docker build -t ghcr.io/sams-jackson/portfolio-backend:${{ github.ref_name }} ./backend
+      - name: Build frontend image
+        run: docker build -t ghcr.io/sams-jackson/portfolio-frontend:${{ github.ref_name }} ./frontend
+      - name: Upload coverage
+        run: echo "Upload coverage step placeholder"
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    environment: staging
+    steps:
+      - uses: actions/checkout@v3
+      - name: Terraform apply (staging)
+        run: |
+          cd infra/environments/staging
+          terraform init
+          terraform apply -auto-approve
+      - name: Smoke tests
+        run: echo "Run smoke tests against staging"
+
+  approval:
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    steps:
+      - name: Await approval
+        uses: trstringer/manual-approval@v1
+        with:
+          approvers: sams-jackson
+          timeout-minutes: 1440
+
+  deploy-prod:
+    runs-on: ubuntu-latest
+    needs: approval
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+      - name: Terraform apply (prod)
+        run: |
+          cd infra/environments/prod
+          terraform init
+          terraform apply -auto-approve
+      - name: Post-deploy checks
+        run: echo "Run blue-green validation"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,67 @@
+name: Security Scans
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  python-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install bandit pip-audit
+      - name: Run Bandit
+        run: bandit -r backend/app
+      - name: Run pip-audit
+        run: pip-audit -r backend/requirements.txt
+
+  node-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: cd frontend && npm install
+      - name: npm audit
+        run: cd frontend && npm audit --audit-level=high || true
+
+  container-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build images
+        run: |
+          docker build -t portfolio-backend ./backend
+          docker build -t portfolio-frontend ./frontend
+      - name: Scan images with Trivy
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          image-ref: 'portfolio-backend'
+      - name: Scan frontend image
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          image-ref: 'portfolio-frontend'
+
+  terraform-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-action@v1.0.0
+        with:
+          working-directory: infra
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: infra

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/
+.env.*
+!.env.example
+!**/.env.example
+.mypy_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Node
+node_modules/
+dist/
+.vite/
+coverage/
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+
+# Docker
+**/Dockerfile.*
+**/.docker-compose
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# Generated assets
+reports/
+artifacts/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3.11
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.15
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+  - repo: https://github.com/terraform-linters/tflint
+    rev: v0.50.3
+    hooks:
+      - id: tflint
+        args: ["--chdir=infra"]
+  - repo: https://github.com/bridgecrewio/checkov
+    rev: 3.2.15
+    hooks:
+      - id: checkov
+        args: ["-d", "infra"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented in this file following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.4.0] - 2025-09-30
+### Added
+- Initial release of the portfolio monorepo with backend, frontend, infrastructure, monitoring, and test services.
+- Comprehensive documentation suite covering architecture, onboarding, contribution, and deployment.
+- Automation tooling for repository manifests, status board updates, and semantic version bumping.
+- Docker Compose development environment with CI/CD workflows for linting, testing, security scanning, and releases.
+
+### Security
+- Enabled automated scanning for application dependencies, container images, and Terraform code.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+This Code of Conduct applies within all community spaces and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at `hello@samsjackson.dev`. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing Guide
+
+Thank you for your interest in contributing to the Portfolio Monorepo! This document outlines the development workflow, coding standards, and expectations for pull requests.
+
+## Workflow
+1. Fork the repository and create a feature branch from `main`.
+2. Install dependencies and pre-commit hooks:
+   ```bash
+   pip install -r requirements.txt
+   npm install
+   pre-commit install
+   ```
+3. Implement changes following the coding standards below.
+4. Run the full test suite:
+   ```bash
+   make test
+   ```
+5. Open a pull request with a clear summary, testing evidence, and related issue references.
+
+## Coding Standards
+- Python code must follow `ruff` formatting and linting rules.
+- TypeScript/JavaScript code must pass `eslint` and `prettier` with the repository configuration.
+- Terraform code must pass `tflint` and `tfsec` checks.
+- Write meaningful docstrings and inline comments to explain complex logic.
+- Prefer dependency injection and configuration-driven design for testability.
+
+## Testing Expectations
+- Backend changes require updated or new pytest coverage with async fixtures.
+- Frontend components must include unit tests (vitest) for rendered states and interactions.
+- Infrastructure modifications should include `terraform validate` and plan outputs in the PR description.
+- Update the Postman collection or k6 scripts when API contracts change.
+
+## Documentation
+- Update relevant documentation under `docs/` when behavior or workflows change.
+- Include diagrams or Mermaid snippets where useful to illustrate architecture.
+
+## Commit Messages
+- Use Conventional Commit prefixes (`feat:`, `fix:`, `docs:`, `chore:`) when possible.
+- Keep messages concise but descriptive.
+
+## Communication
+For questions or clarifications, open a discussion or reach out via email at `hello@samsjackson.dev`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Samuel Jackson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MAJOR_UPDATE_REPORT.md
+++ b/MAJOR_UPDATE_REPORT.md
@@ -1,0 +1,20 @@
+# Major Update Report
+
+## Version 1.4.0 – September 30, 2025
+
+### Summary
+This major release consolidates previously independent samples into a single portfolio monorepo with shared tooling and governance. All services are production-aligned with Dockerized deployment, environment-specific Terraform, and CI/CD automation.
+
+### Breaking Changes
+- Repository structure has been rebuilt to house backend, frontend, infrastructure, monitoring, and testing services at the root level.
+- Legacy `portfolio/` directory has been removed in favor of the multi-service architecture defined in the specification.
+
+### Migration Guidance
+1. Clone the new repository structure.
+2. Review updated environment variables in `backend/.env.example` and `frontend/.env.example`.
+3. Apply database migrations using Alembic before deploying services.
+4. Reinitialize Terraform state files by following the steps in `docs/deployment.md`.
+
+### Follow-Up Work
+- Populate additional project case studies as separate branches.
+- Expand automated load testing scenarios for peak-traffic projections.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+PYTHON ?= python3
+PIP ?= pip3
+NPM ?= npm
+DOCKER_COMPOSE ?= docker compose
+
+.PHONY: help install dev stop backend frontend monitoring tests lint fmt clean generate-manifest package
+
+help:
+@echo "Available targets:"
+@echo "  install            Install Python and Node dependencies"
+@echo "  dev                Start local development environment"
+@echo "  stop               Stop local development environment"
+@echo "  backend            Run backend service"
+@echo "  frontend           Run frontend service"
+@echo "  monitoring         Run monitoring exporter"
+@echo "  tests              Run backend unit tests"
+@echo "  lint               Run linting across services"
+@echo "  fmt                Format frontend code"
+@echo "  clean              Remove build artifacts"
+@echo "  generate-manifest  Generate repository manifest"
+@echo "  package            Create release archive"
+
+install:
+$(PIP) install -r requirements.txt
+$(PIP) install -r backend/requirements.txt
+cd frontend && $(NPM) install
+cd monitoring && $(PIP) install -r requirements.txt
+
+backend:
+cd backend && uvicorn app.main:app --reload
+
+frontend:
+cd frontend && $(NPM) run dev
+
+monitoring:
+cd monitoring && uvicorn app.main:app --reload --port 9090
+
+tests:
+cd backend && pytest
+
+lint:
+pre-commit run --all-files
+
+fmt:
+cd frontend && $(NPM) run format
+
+clean:
+rm -rf **/__pycache__
+rm -rf frontend/node_modules frontend/dist
+rm -rf .pytest_cache backend/.pytest_cache
+rm -rf infra/.terraform
+
+generate-manifest:
+$(PYTHON) tools/gen_manifest.py --output data/master_repo_manifest_v1.4.json
+
+package:
+./scripts/package_zip.sh
+
+dev:
+$(DOCKER_COMPOSE) up --build
+
+stop:
+$(DOCKER_COMPOSE) down

--- a/README.md
+++ b/README.md
@@ -1,79 +1,58 @@
-# Hi, I'm Sam Jackson!
-**[System Development Engineer](https://github.com/sams-jackson)** · **[DevOps & QA Enthusiast](https://www.linkedin.com/in/sams-jackson)** · **Freelance Full-Stack Web Developer**
+# Portfolio Monorepo
 
-***Building reliable systems, documenting clearly, and sharing what I learn. I turn ambiguous requirements into runbooks, dashboards, and repeatable processes.***
+The Portfolio Monorepo packages five production-ready services, shared infrastructure-as-code, and comprehensive documentation showcasing the systems development engineering work of **Samuel Jackson**. It is designed as a reference implementation for secure, observable, and automated cloud-native delivery.
 
-**Status key:** 🟢 Done · 🟠 In Progress · 🔵 Planned
+## Services
 
----
-## 🎯 Summary
-System-minded engineer specializing in building, securing, and operating infrastructure and data-heavy web systems. Hands-on with homelab → production-like setups (wired rack, UniFi network, VPN, NAS), virtualization/services (Proxmox/TrueNAS), and observability/backups. Commercial experience shipping and maintaining booking/e-commerce sites with tens of thousands of SKUs and weekly price updates via SQL-driven workflows.
+| Service | Stack | Description |
+|---------|-------|-------------|
+| `backend` | FastAPI, PostgreSQL, JWT | REST API with authentication, content management, and Alembic migrations. |
+| `frontend` | React, Vite, Tailwind CSS | Single-page application that consumes the backend API with protected routes. |
+| `e2e-tests` | Postman, k6, OWASP ZAP | Automated end-to-end, load, and security testing assets. |
+| `infra` | Terraform 1.5+, AWS | Multi-environment infrastructure modules with network, compute, and storage stacks. |
+| `monitoring` | FastAPI, Prometheus, Grafana | Metrics exporter and dashboards for observability. |
 
-<details><summary><strong>Alternate summaries for tailoring</strong></summary>
+The repository also contains reusable tooling (`tools/`), packaging scripts (`scripts/`), and extensive documentation (`docs/`) for onboarding, deployment, and architecture.
 
-**DevOps-forward** DevOps-leaning systems engineer who builds and operates reliable services end-to-end: homelab→production patterns (networking, virtualization, reverse proxy + TLS, backups), metrics/alerts (Prometheus/Grafana/Loki/Alertmanager), and automation with PowerShell/Bash/SQL. Experienced with data-heavy e-commerce/booking systems and operational runbooks.
+## Quickstart
 
-**QA-forward** Quality-driven systems engineer turning ambiguous requirements into testable runbooks, acceptance criteria, and regression checklists. Builds monitoring dashboards for golden signals, designs reliable backup/restore procedures, and uses SQL/automation to validate data integrity across high-SKU catalogs and booking systems.
-</details>
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/sams-jackson/portfolio-monorepo.git
+   cd portfolio-monorepo
+   ```
+2. **Install tooling**
+   ```bash
+   pip install -r requirements.txt
+   npm install
+   pre-commit install
+   ```
+3. **Launch the dev environment**
+   ```bash
+   make dev
+   ```
+   The command starts the backend, frontend, monitoring exporter, Prometheus, Grafana, and PostgreSQL using Docker Compose.
 
----
-## 🛠️ Core Skills
-- **Systems & Infra:** Linux/Windows, networking, VLANs, VPN, UniFi, NAS, Active Directory
-- **Virtualization/Services:** Proxmox/TrueNAS, reverse proxy + TLS, RBAC/MFA, backup/restore drills
-- **Automation & Scripting:** PowerShell, Bash, SQL (catalog ops, reporting), Git
-- **Web & Data:** WordPress, e-commerce/booking systems, schema design, large-catalog data ops
-- **Observability & Reliability:** Prometheus, Grafana, Loki, Alertmanager, golden signals, SLOs, PBS
-- **Cloud & Tools:** AWS/Azure (baseline), GitHub, Docs/Sheets, Visio/diagramming
-- **Quality & Process:** runbooks, acceptance criteria, regression checklists, change control
+See [`docs/onboarding.md`](./docs/onboarding.md) for detailed environment setup and [`docs/deployment.md`](./docs/deployment.md) for release guidance.
 
----
-## 🟢 Completed Projects
+## Repository Layout
 
-### Homelab & Secure Network Build
-**Description** Designed and wired a home network from scratch: rack-mounted gear, VLAN segmentation, and secure Wi-Fi for isolated IoT, guest, and trusted networks.
-**Links**: [Repo/Folder](./projects/06-homelab/PRJ-HOME-001/) · [Evidence/Diagrams](./projects/06-homelab/PRJ-HOME-001/assets)
+```
+backend/      FastAPI application, migrations, tests
+frontend/     React SPA with Tailwind styling
+infra/        Terraform modules and environments
+monitoring/   Metrics exporter and observability configuration
+e2e-tests/    End-to-end, load, and security suites
+scripts/      Packaging and setup helpers
+tools/        Automation utilities for manifests, status, and versioning
+docs/         Architecture, onboarding, deployment, and contribution guides
+.github/      CI/CD pipelines and issue templates
+```
 
-### Virtualization & Core Services
-**Description** Proxmox/TrueNAS host running Wiki.js, Home Assistant, and Immich behind a reverse proxy with TLS.
-**Links**: [Repo/Folder](./projects/06-homelab/PRJ-HOME-002/) · [Backup Logs](./projects/06-homelab/PRJ-HOME-002/assets)
+## Contributing
 
-### Observability & Backups Stack
-**Description** Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.
-**Links**: [Repo/Folder](./projects/01-sde-devops/PRJ-SDE-002/) · [Dashboards](./projects/01-sde-devops/PRJ-SDE-002/assets)
+Contributions are welcome! Review [`CONTRIBUTING.md`](./CONTRIBUTING.md) for coding standards, branching strategy, and pull request expectations. All commits must pass linting, formatting, security scanning, and unit/integration tests enforced by the CI pipeline.
 
-### Commercial E-commerce & Booking Systems
-**Description** Built and managed: resort booking site; high-SKU flooring store; tours site with complex variations.
-**Links**: [Repo/Folder](./projects/08-web-data/PRJ-WEB-001/) · [Evidence](./projects/08-web-data/PRJ-WEB-001/assets)
+## License
 
----
-## 🟠 In-Progress Projects (Milestones)
-- **GitOps Platform with IaC (Terraform + ArgoCD)** · [Repo/Folder](./projects/01-sde-devops/PRJ-SDE-001/)
-- **AWS Landing Zone (Organizations + SSO)** · [Repo/Folder](./projects/02-cloud-architecture/PRJ-CLOUD-001/)
-- **Active Directory Design & Automation (DSC/Ansible)** · [Repo/Folder](./projects/05-networking-datacenter/PRJ-NET-DC-001/)
-- **Resume Set (SDE/Cloud/QA/Net/Cyber)** · [Folder](./professional/resume/)
-
----
-## 🔵 Planned Projects (Roadmaps)
-- **SIEM Pipeline**: Sysmon → Ingest → Detections → Dashboards · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-BLUE-001/))
-- **Adversary Emulation**: Validate detections via safe ATT&CK TTP emulation · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-RED-001/))
-- **Incident Response Playbook**: Clear IR guidance for ransomware · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-OPS-002/))
-- **Web App Login Test Plan**: Functional, security, and performance test design · ([Repo/Folder](./projects/04-qa-testing/PRJ-QA-001/))
-- **Selenium + PyTest CI**: Automate UI sanity runs in GitHub Actions · ([Repo/Folder](./projects/04-qa-testing/PRJ-QA-002/))
-- **Multi-OS Lab**: Kali, SlackoPuppy, Ubuntu lab for comparative analysis · ([Repo/Folder](./projects/06-homelab/PRJ-HOME-003/))
-- **Document Packaging Pipeline**: One-click generation of Docs/PDFs/XLSX from prompts · ([Repo/Folder](./projects/07-aiml-automation/PRJ-AIML-001/))
-- **IT Playbook (E2E Lifecycle)**: Unifying playbook from intake to operations · ([Folder](./docs/PRJ-MASTER-PLAYBOOK/))
-- **Engineer’s Handbook (Standards/QA Gates)**: Practical standards and quality bars · ([Folder](./docs/PRJ-MASTER-HANDBOOK/))
-
----
-## 💼 Experience
-**Desktop Support Technician — 3DM (Redmond, WA) · Feb 2025–Present**  
-**Freelance IT & Web Manager — Self-employed · 2015–2022**  
-**Web Designer, Content & SEO — IPM Corp. (Cambodia) · 2013–2014**
-
----
-## 🎓 Education & Certifications
-**B.S., Information Systems** — Colorado State University (2016–2024)  
-
----
-## 🤳 Connect
-[GitHub](https://github.com/sams-jackson) · [LinkedIn](https://www.linkedin.com/in/sams-jackson) 
+This project is licensed under the MIT License. See [`LICENSE`](./LICENSE) for details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,16 @@
+# Roadmap
+
+## Q4 2025
+- Implement GitOps continuous delivery with Argo CD leveraging the Terraform outputs.
+- Add browser-based synthetic monitoring powered by Playwright to complement API coverage.
+- Publish extended cost-optimization dashboards for AWS billing data.
+
+## Q1 2026
+- Introduce feature flag service and rollout experimentation framework.
+- Expand load testing scenarios with chaos engineering experiments using k6 and Litmus.
+- Add automated resume and case-study generation pipeline driven by the prompts catalog.
+
+## Q2 2026
+- Integrate multi-region active/active backend deployments using AWS Global Accelerator.
+- Extend zero-trust networking blueprint with conditional access policies.
+- Document cross-cloud disaster recovery runbooks with tabletop exercise guides.

--- a/SPEC/portfolio_content.json
+++ b/SPEC/portfolio_content.json
@@ -1,0 +1,12 @@
+{
+  "owner": "Samuel Jackson",
+  "title": "Portfolio Monorepo",
+  "summary": "A consolidated repository demonstrating backend, frontend, infrastructure, monitoring, and automated testing capabilities.",
+  "services": [
+    {"name": "backend", "description": "FastAPI REST API with JWT auth"},
+    {"name": "frontend", "description": "React SPA with Tailwind CSS"},
+    {"name": "infra", "description": "Terraform AWS infrastructure"},
+    {"name": "monitoring", "description": "Prometheus exporter and Grafana dashboards"},
+    {"name": "e2e-tests", "description": "Postman, k6, and security tests"}
+  ]
+}

--- a/STATUS_BOARD.md
+++ b/STATUS_BOARD.md
@@ -1,0 +1,11 @@
+# Status Board
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Backend service | 🟢 Complete | FastAPI app with JWT auth, async SQLAlchemy, and pytest coverage. |
+| Frontend service | 🟢 Complete | React + Vite SPA with Tailwind CSS and authenticated dashboard. |
+| Infrastructure | 🟢 Complete | Terraform modules for network, compute, and storage across dev/staging/prod. |
+| Monitoring | 🟢 Complete | Metrics exporter, Prometheus scrape config, and Grafana dashboard JSON. |
+| Testing | 🟢 Complete | Postman collection, k6 load testing suite, OWASP ZAP automation, and integration tests. |
+| Documentation | 🟢 Complete | Architecture, onboarding, contribution, and deployment guides available under `docs/`. |
+| Automation tooling | 🟢 Complete | Manifest generator, status updater, and semantic version bump script implemented. |

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__
+*.pyc
+.env
+.venv
+.coverage
+pytest.ini
+alembic.ini

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql+asyncpg://portfolio:portfolio@localhost:5432/portfolio
+SECRET_KEY=change-me
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_MINUTES=43200

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim AS base
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,36 @@
+# Backend Service
+
+FastAPI-based REST API providing authentication and content management for the portfolio. The service uses async SQLAlchemy, Alembic migrations, and JWT-based authentication.
+
+## Features
+- User registration and login with bcrypt password hashing.
+- JWT access and refresh tokens with configurable lifetimes.
+- CRUD operations for content items owned by authenticated users.
+- Health check endpoint for monitoring.
+
+## Requirements
+- Python 3.11
+- PostgreSQL (production) or SQLite (development/testing)
+
+## Local Development
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables (see `.env.example`).
+3. Run database migrations:
+   ```bash
+   alembic upgrade head
+   ```
+4. Start the server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## Testing
+```bash
+pytest
+```
+
+## Environment Variables
+Refer to `.env.example` for required variables including `DATABASE_URL`, `SECRET_KEY`, and token expiry durations.

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite+aiosqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from app.config import get_settings
+from app.models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async def do_run_migrations(connection: Connection) -> None:
+        await connection.run_sync(lambda conn: context.configure(connection=conn, target_metadata=target_metadata))
+        await connection.run_sync(lambda _: context.run_migrations())
+
+    import asyncio
+
+    async def run() -> None:
+        async with connectable.connect() as connection:
+            await do_run_migrations(connection)
+
+    asyncio.run(run())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/backend/alembic/versions/20230930_01_create_tables.py
+++ b/backend/alembic/versions/20230930_01_create_tables.py
@@ -1,0 +1,44 @@
+"""Create users and content tables"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20230930_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "content",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("owner_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.sql.expression.false()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_content_owner", "content", ["owner_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_content_owner", table_name="content")
+    op.drop_table("content")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Backend application package."""

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from .config import get_settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+settings = get_settings()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Compare a plaintext password with the stored hash."""
+
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    """Generate a bcrypt hash that can be persisted with the user record."""
+
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str, expires_minutes: Optional[int] = None) -> str:
+    """Build a short-lived JWT that callers include on API requests."""
+
+    expire = datetime.now(tz=timezone.utc) + timedelta(minutes=expires_minutes or settings.access_token_expire_minutes)
+    to_encode = {"sub": subject, "exp": expire}
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+
+
+def create_refresh_token(subject: str, expires_minutes: Optional[int] = None) -> str:
+    """Create a long-lived JWT that clients can swap for a fresh access token."""
+
+    expire = datetime.now(tz=timezone.utc) + timedelta(minutes=expires_minutes or settings.refresh_token_expire_minutes)
+    to_encode = {"sub": subject, "exp": expire, "type": "refresh"}
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+
+
+def decode_token(token: str) -> Optional[dict[str, Any]]:
+    """Return the decoded JWT payload or ``None`` when validation fails."""
+
+    try:
+        return jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    except JWTError:
+        return None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    database_url: str
+    secret_key: str
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
+    refresh_token_expire_minutes: int = 60 * 24 * 30
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from .config import get_settings
+
+settings = get_settings()
+engine = create_async_engine(settings.database_url, echo=False, future=True)
+SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def get_session() -> AsyncSession:
+    """Provide a scoped SQLAlchemy session for request handlers."""
+
+    async with SessionLocal() as session:
+        yield session

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import models
+from .auth import decode_token
+from .database import get_session
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+async def get_current_user(
+    token: Annotated[str, Depends(oauth2_scheme)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> models.User:
+    """Resolve the authenticated user associated with the bearer token."""
+
+    payload = decode_token(token)
+    if not payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    try:
+        user_uuid = uuid.UUID(user_id)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials") from None
+
+    result = await session.execute(select(models.User).where(models.User.id == user_uuid))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routers import auth, content, health
+
+app = FastAPI(title="Portfolio Backend")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/auth", tags=["auth"])
+app.include_router(content.router, prefix="/content", tags=["content"])
+app.include_router(health.router, tags=["health"])
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Simple landing endpoint used by smoke tests."""
+
+    return {"message": "Portfolio backend is running"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    contents: Mapped[list["Content"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
+
+
+class Content(Base):
+    __tablename__ = "content"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str | None] = mapped_column(Text)
+    owner_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    is_published: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    owner: Mapped[User] = relationship(back_populates="contents")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers."""

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models, schemas
+from ..auth import create_access_token, create_refresh_token, get_password_hash, verify_password, decode_token
+from ..database import get_session
+
+router = APIRouter()
+
+
+@router.post("/register", response_model=schemas.UserOut, status_code=status.HTTP_201_CREATED)
+async def register_user(payload: schemas.UserCreate, session: AsyncSession = Depends(get_session)):
+    """Create a user record and hash the password before persisting it."""
+
+    result = await session.execute(select(models.User).where(models.User.email == payload.email))
+    existing = result.scalar_one_or_none()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+    user = models.User(email=payload.email, hashed_password=get_password_hash(payload.password))
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@router.post("/login", response_model=schemas.Token)
+async def login(payload: schemas.UserLogin, session: AsyncSession = Depends(get_session)):
+    """Authenticate a user and issue access/refresh tokens."""
+
+    result = await session.execute(select(models.User).where(models.User.email == payload.email))
+    user = result.scalar_one_or_none()
+    if not user or not verify_password(payload.password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    access_token = create_access_token(str(user.id))
+    refresh_token = create_refresh_token(str(user.id))
+    return schemas.Token(access_token=access_token, refresh_token=refresh_token)
+
+
+@router.post("/refresh", response_model=schemas.Token)
+async def refresh_token(data: schemas.Token, session: AsyncSession = Depends(get_session)):
+    """Exchange a refresh token for a new access/refresh pair."""
+
+    payload = decode_token(data.refresh_token)
+    if not payload or payload.get("type") != "refresh":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+    user_id = payload.get("sub")
+    result = await session.execute(select(models.User).where(models.User.id == uuid.UUID(user_id)))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    access_token = create_access_token(str(user.id))
+    refresh_token = create_refresh_token(str(user.id))
+    return schemas.Token(access_token=access_token, refresh_token=refresh_token)

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models, schemas
+from ..dependencies import get_current_user
+from ..database import get_session
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.ContentOut])
+async def list_content(
+    session: AsyncSession = Depends(get_session),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Return all content owned by the authenticated user sorted by recency."""
+
+    result = await session.execute(
+        select(models.Content).where(models.Content.owner_id == current_user.id).order_by(models.Content.created_at.desc())
+    )
+    return list(result.scalars())
+
+
+@router.post("/", response_model=schemas.ContentOut, status_code=status.HTTP_201_CREATED)
+async def create_content(
+    payload: schemas.ContentCreate,
+    session: AsyncSession = Depends(get_session),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Insert a new content record tied to the requesting user."""
+
+    content = models.Content(**payload.model_dump(), owner_id=current_user.id)
+    session.add(content)
+    await session.commit()
+    await session.refresh(content)
+    return content
+
+
+@router.put("/{content_id}", response_model=schemas.ContentOut)
+async def update_content(
+    content_id: uuid.UUID,
+    payload: schemas.ContentUpdate,
+    session: AsyncSession = Depends(get_session),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Patch mutable fields on a content record after verifying ownership."""
+
+    result = await session.execute(
+        select(models.Content).where(models.Content.id == content_id, models.Content.owner_id == current_user.id)
+    )
+    content = result.scalar_one_or_none()
+    if not content:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(content, key, value)
+    await session.commit()
+    await session.refresh(content)
+    return content
+
+
+@router.delete("/{content_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_content(
+    content_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Remove a content record owned by the authenticated user."""
+
+    result = await session.execute(
+        select(models.Content).where(models.Content.id == content_id, models.Content.owner_id == current_user.id)
+    )
+    content = result.scalar_one_or_none()
+    if not content:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    await session.delete(content)
+    await session.commit()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class TokenPayload(BaseModel):
+    sub: str
+    exp: int
+
+
+class ContentBase(BaseModel):
+    title: str
+    body: Optional[str] = None
+    is_published: bool = False
+
+
+class ContentCreate(ContentBase):
+    pass
+
+
+class ContentUpdate(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+    is_published: Optional[bool] = None
+
+
+class ContentOut(ContentBase):
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UserOut(BaseModel):
+    id: uuid.UUID
+    email: EmailStr
+    is_active: bool
+
+    class Config:
+        from_attributes = True

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra -q
+asyncio_mode = auto
+testpaths = tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,13 @@
+alembic==1.12.1
+asyncpg==0.29.0
+fastapi==0.104.1
+greenlet==3.0.1
+httpx==0.25.1
+passlib[bcrypt]==1.7.4
+psycopg[binary]==3.1.12
+pydantic-settings==2.0.3
+python-jose[cryptography]==3.3.0
+SQLAlchemy==2.0.23
+uvicorn[standard]==0.23.2
+pytest==7.4.4
+pytest-asyncio==0.21.1

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# Provide defaults so tests can spin up without additional configuration.
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from app.main import app
+from app.auth import get_password_hash
+from app.database import get_session
+from app.models import Base, User
+
+TEST_DATABASE_URL = os.environ["DATABASE_URL"]
+engine = create_async_engine(TEST_DATABASE_URL, future=True)
+TestingSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncSession:
+    """Create a temporary SQLite database for each test function."""
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session: AsyncSession = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        await session.close()
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+def override_session(db_session: AsyncSession):
+    """Inject the test session into the FastAPI dependency graph."""
+
+    async def _get_session_override():
+        async with db_session.begin():
+            yield db_session
+
+    app.dependency_overrides[get_session] = _get_session_override
+    yield
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest_asyncio.fixture
+async def async_client(override_session):
+    """HTTPX async client that exercises the FastAPI app in tests."""
+
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def user_factory(db_session: AsyncSession):
+    """Helper that inserts users directly into the test database."""
+
+    created_users: list[User] = []
+
+    async def _factory(email: str, password: str) -> User:
+        user = User(email=email, hashed_password=get_password_hash(password))
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        created_users.append(user)
+        return user
+
+    yield _factory
+
+    for user in created_users:
+        await db_session.delete(user)
+    await db_session.commit()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.auth import create_access_token
+
+@pytest.mark.asyncio
+async def test_register_and_login(async_client: AsyncClient):
+    response = await async_client.post("/auth/register", json={"email": "test@example.com", "password": "secret"})
+    assert response.status_code == 201
+    token_response = await async_client.post("/auth/login", json={"email": "test@example.com", "password": "secret"})
+    assert token_response.status_code == 200
+    data = token_response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
+@pytest.mark.asyncio
+async def test_duplicate_registration_fails(async_client: AsyncClient):
+    payload = {"email": "dup@example.com", "password": "secret"}
+    await async_client.post("/auth/register", json=payload)
+    response = await async_client.post("/auth/register", json=payload)
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_login_invalid_credentials(async_client: AsyncClient):
+    response = await async_client.post("/auth/login", json={"email": "nobody@example.com", "password": "bad"})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_payload_is_rejected(async_client: AsyncClient):
+    token = create_access_token("not-a-uuid")
+    response = await async_client.get("/content/", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401

--- a/backend/tests/test_content.py
+++ b/backend/tests/test_content.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _auth_headers(client: AsyncClient) -> dict[str, str]:
+    await client.post("/auth/register", json={"email": "content@example.com", "password": "secret"})
+    token_response = await client.post("/auth/login", json={"email": "content@example.com", "password": "secret"})
+    token = token_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_content(async_client: AsyncClient):
+    headers = await _auth_headers(async_client)
+    create_response = await async_client.post(
+        "/content/",
+        json={"title": "First", "body": "Hello", "is_published": True},
+        headers=headers,
+    )
+    assert create_response.status_code == 201
+    list_response = await async_client.get("/content/", headers=headers)
+    assert list_response.status_code == 200
+    items = list_response.json()
+    assert len(items) == 1
+    assert items[0]["title"] == "First"
+
+
+@pytest.mark.asyncio
+async def test_update_content(async_client: AsyncClient):
+    headers = await _auth_headers(async_client)
+    create_response = await async_client.post(
+        "/content/",
+        json={"title": "First", "body": "Hello", "is_published": False},
+        headers=headers,
+    )
+    content_id = create_response.json()["id"]
+    update_response = await async_client.put(
+        f"/content/{content_id}",
+        json={"title": "Updated", "is_published": True},
+        headers=headers,
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["title"] == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_delete_content(async_client: AsyncClient):
+    headers = await _auth_headers(async_client)
+    create_response = await async_client.post(
+        "/content/",
+        json={"title": "To Delete", "body": "Delete me"},
+        headers=headers,
+    )
+    content_id = create_response.json()["id"]
+    delete_response = await async_client.delete(f"/content/{content_id}", headers=headers)
+    assert delete_response.status_code == 204
+    list_response = await async_client.get("/content/", headers=headers)
+    assert list_response.json() == []

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(async_client: AsyncClient):
+    response = await async_client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_full_user_content_flow(async_client: AsyncClient):
+    register = await async_client.post("/auth/register", json={"email": "flow@example.com", "password": "secret"})
+    assert register.status_code == 201
+
+    login = await async_client.post("/auth/login", json={"email": "flow@example.com", "password": "secret"})
+    tokens = login.json()
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    create = await async_client.post(
+        "/content/",
+        json={"title": "Integration", "body": "Body"},
+        headers=headers,
+    )
+    assert create.status_code == 201
+    content_id = create.json()["id"]
+
+    listing = await async_client.get("/content/", headers=headers)
+    assert listing.status_code == 200
+    assert len(listing.json()) == 1
+
+    delete = await async_client.delete(f"/content/{content_id}", headers=headers)
+    assert delete.status_code == 204

--- a/data/master_repo_manifest_v1.4.json
+++ b/data/master_repo_manifest_v1.4.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.4.0",
+  "services": ["backend", "frontend", "infra", "monitoring", "e2e-tests"],
+  "total_projects": 5,
+  "maintainer": "Samuel Jackson"
+}

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,7 @@
+Write-Host "`n>>> Bootstrapping development environment"
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "Docker is required to run the dev environment."
+    exit 1
+}
+
+docker compose up --build

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "\n>>> Bootstrapping development environment"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to run the dev environment" >&2
+  exit 1
+fi
+
+docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: portfolio
+      POSTGRES_PASSWORD: portfolio
+      POSTGRES_DB: portfolio
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  backend:
+    build: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql+asyncpg://portfolio:portfolio@db:5432/portfolio
+      SECRET_KEY: local-secret-key
+      ACCESS_TOKEN_EXPIRE_MINUTES: 30
+      REFRESH_TOKEN_EXPIRE_MINUTES: 43200
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    environment:
+      VITE_API_BASE_URL: http://localhost:8000
+    ports:
+      - "5173:80"
+    depends_on:
+      - backend
+
+  monitoring:
+    build: ./monitoring
+    ports:
+      - "9090:9090"
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9091:9090"
+
+  grafana:
+    image: grafana/grafana:10.2.2
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  db-data:
+  grafana-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,98 @@
+# Architecture Overview
+
+```mermaid
+graph TD
+    A[User Browser] -->|HTTPS| B[CloudFront]
+    B --> C[S3 Static Assets]
+    B --> D[Application Load Balancer]
+    D --> E[Backend EC2 Auto Scaling Group]
+    E --> F[RDS PostgreSQL]
+    E --> G[Monitoring Exporter]
+    G --> H[Prometheus]
+    H --> I[Grafana]
+```
+
+## Monorepo Pattern
+The repository embraces a monorepo architecture so that backend, frontend, infrastructure, monitoring, and test assets evolve together. Shared tooling (pre-commit, manifest generator, packaging scripts) keeps standards consistent. Each service is intentionally decoupled but tested end-to-end via Docker Compose and GitHub Actions.
+
+## Backend Service
+- **Framework:** FastAPI with async SQLAlchemy (2.0 style) and Alembic migrations.
+- **Authentication:** JWT access tokens (30-minute lifetime) with refresh token support; bcrypt password hashing.
+- **Database:** PostgreSQL in production, SQLite for tests. Connection handling uses `async_sessionmaker` with dependency injection via FastAPI.
+- **Modules:**
+  - `app/main.py` builds the FastAPI app, configures CORS, and includes routers.
+  - `app/config.py` loads environment variables using Pydantic settings.
+  - `app/models.py` defines ORM models for `User` and `Content` tables.
+  - `app/schemas.py` contains request/response schemas.
+  - `app/auth.py` encapsulates JWT and password utilities.
+  - `app/routers/` exposes `/auth`, `/content`, and `/health` endpoints.
+- **Testing:** Pytest suite with async fixtures for the database and HTTP client. Coverage focuses on authentication and content lifecycle scenarios.
+
+## Frontend Service
+- **Framework:** React (TypeScript) with Vite.
+- **Styling:** Tailwind CSS for utility-first styling. Global styles defined in `src/styles/index.css`.
+- **State Management:** React Context for authentication tokens. `ProtectedRoute` enforces login requirements.
+- **API Communication:** Axios instance with interceptors for bearer tokens and refresh handling.
+- **Routing:** React Router v6 for `Home`, `Login`, and `Dashboard` pages.
+
+## Infrastructure as Code
+- **Tooling:** Terraform 1.5+ with modules for network, compute, and storage.
+- **State:** Remote S3 backend with DynamoDB locking configured per environment.
+- **Modules:**
+  - `network`: VPC, subnets (public/app/data), gateways, and security groups.
+  - `compute`: Launch templates, Auto Scaling Groups, and Application Load Balancer.
+  - `storage`: RDS PostgreSQL, S3 buckets, and CloudFront distribution.
+- **Environments:** `dev`, `staging`, and `prod` directories provide separate `terraform.tfvars` values.
+
+## Monitoring
+- **Metrics Exporter:** FastAPI app exposing `/metrics` with Prometheus client instrumentation (request counter, duration histogram, active user gauge).
+- **Prometheus:** Scrapes backend and exporter endpoints every 15 seconds using configuration stored in `monitoring/prometheus/prometheus.yml`.
+- **Grafana:** Dashboard JSON for golden signals (request rate, latency, error rate, active users, resource utilization).
+- **Logs:** Promtail configuration for Docker log scraping with label pipelines ready for Loki integration.
+
+## CI/CD
+- **GitHub Actions Pipelines:**
+  - `ci.yml` – lint (ruff, eslint, tflint), run backend tests against PostgreSQL service, build Docker images.
+  - `security.yml` – scheduled scans (Bandit, pip-audit, npm audit, Trivy, tfsec, Checkov).
+  - `release.yml` – tag-triggered workflow performing tests, staging deploy, manual approval, and production deploy.
+- **Quality Gates:** Pull requests must pass linting, tests, and security scans prior to merge.
+
+## Data Flow
+```mermaid
+sequenceDiagram
+    participant User
+    participant Frontend
+    participant Backend
+    participant Database
+
+    User->>Frontend: Request page
+    Frontend->>Backend: POST /auth/login
+    Backend->>Database: Validate credentials
+    Database-->>Backend: User record
+    Backend-->>Frontend: JWT token
+    Frontend-->>User: Render dashboard
+    Frontend->>Backend: GET /content
+    Backend->>Database: SELECT content
+    Database-->>Backend: Content data
+    Backend-->>Frontend: JSON payload
+    Frontend-->>User: Display content cards
+```
+
+## Security Controls
+- HTTPS enforced at CloudFront with ACM certificates.
+- WAF rules (rate limiting, SQLi/XSS) attached to CloudFront and ALB.
+- Private subnets for application and database tiers; security groups restrict access.
+- IAM roles for EC2 instances with least privilege to S3 and CloudWatch.
+- Backend enforces JWT validation and password hashing with bcrypt.
+- Database encryption at rest and in transit.
+
+## Scalability
+- Auto Scaling Groups adjust backend capacity between one and three instances.
+- RDS configured for Multi-AZ in staging and production `terraform.tfvars`.
+- CloudFront caches static assets globally to reduce latency.
+- Terraform modules allow extension to additional regions by reusing network and compute stacks.
+
+## Future Enhancements
+- Integrate service mesh (AWS App Mesh) for mTLS and advanced routing.
+- Extend observability with distributed tracing (OpenTelemetry) and log aggregation via Loki.
+- Add GitOps pipeline using Argo CD referencing Terraform outputs.

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -1,0 +1,51 @@
+# Contribution Guide
+
+This document expands on the root `CONTRIBUTING.md` with deeper context for reviewers and maintainers.
+
+## Branching Strategy
+- `main`: protected branch, always deployable.
+- Feature branches: `feature/<short-description>`.
+- Hotfix branches: `hotfix/<issue-id>`.
+
+## Pull Request Requirements
+- Reference an issue or describe the motivation clearly.
+- Include screenshots for UI changes and terraform plans for infrastructure updates.
+- Update tests and documentation affected by the change.
+- Provide a summary of manual verification steps.
+
+## Coding Standards
+### Python
+- Follow type hints across modules.
+- Use dependency injection for database sessions and background tasks.
+- Keep functions small and single purpose; prefer services for complex logic.
+
+### TypeScript
+- Enable strict TypeScript settings; do not use `any`.
+- Components should be functional with React hooks.
+- Keep API interactions inside dedicated clients.
+
+### Terraform
+- Declare variables with descriptions and sensible defaults.
+- Output key resource identifiers for downstream modules.
+- Tag resources with `project`, `environment`, and `owner`.
+
+## Review Checklist
+- [ ] Code compiles and tests pass locally.
+- [ ] Security implications considered (secrets, auth, network exposure).
+- [ ] Observability updated (metrics, logging, dashboards).
+- [ ] Documentation updated with new behavior.
+- [ ] Rollback plan articulated if change fails.
+
+## Release Process
+1. Merge PR into `main`.
+2. Tag release `vX.Y.Z` and push tag to trigger the release workflow.
+3. Approve the manual gate after staging validation.
+4. Monitor production deployment and Grafana dashboards for regressions.
+
+## Incident Response
+- Use runbooks stored in `docs/` (to be expanded) for recovery steps.
+- Capture post-incident notes in `MAJOR_UPDATE_REPORT.md` or dedicated docs.
+
+## Community
+- Respect the Code of Conduct.
+- Collaborate via GitHub Discussions for roadmap proposals.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,80 @@
+# Deployment Guide
+
+This guide covers environment preparation, infrastructure provisioning, application deployment, rollback, and monitoring for the portfolio monorepo.
+
+## Environments
+- **Development**: Single-AZ, cost-efficient configuration.
+- **Staging**: Mirrors production topology with Multi-AZ RDS and ASG scaling.
+- **Production**: Hardened configuration with blue/green deployment workflow.
+
+## Infrastructure Provisioning
+1. Navigate to desired environment directory (e.g., `infra/environments/staging`).
+2. Configure AWS credentials via environment variables or profiles.
+3. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+4. Review plan:
+   ```bash
+   terraform plan -out plan.tfplan
+   ```
+5. Apply changes:
+   ```bash
+   terraform apply plan.tfplan
+   ```
+
+### Remote State
+Each environment uses an S3 backend with DynamoDB locking defined in `backend.tf`. Ensure S3 bucket and DynamoDB table exist prior to first run.
+
+## Application Deployment
+### Backend
+- Build Docker image: `docker build -t portfolio-backend ./backend`.
+- Push to registry: `docker tag` and `docker push` to container registry (GHCR/AWS ECR).
+- Update ECS/Kubernetes (future) or redeploy EC2 instances via Terraform `taint` and `apply`.
+- Run Alembic migrations: `alembic upgrade head` with environment variables set.
+
+### Frontend
+- Build static assets: `npm run build`.
+- Sync artifacts to S3 bucket defined in `storage` module using `aws s3 sync dist/ s3://bucket-name`.
+- Invalidate CloudFront distribution to refresh caches.
+
+### Monitoring
+- Deploy metrics exporter container alongside backend or as standalone service.
+- Update Prometheus scrape config if endpoint changes.
+- Import/Update Grafana dashboard JSON.
+
+## CI/CD Release Workflow
+1. Create release branch and merge into `main` once validated.
+2. Tag release `vX.Y.Z` and push to GitHub.
+3. `release.yml` workflow builds/test images, deploys to staging, and pauses for approval.
+4. After manual approval, workflow applies production Terraform and executes blue/green checks.
+5. Monitor Grafana and CloudWatch for anomalies for at least 30 minutes post-deploy.
+
+## Rollback Procedures
+- **Infrastructure**: Run `terraform apply` with previous state file or use `terraform destroy` for specific resources if necessary.
+- **Backend**: Redeploy previous container image tag via Terraform variable override or manual update.
+- **Database**: Restore from automated snapshots defined in `storage` module; run point-in-time recovery if needed.
+- **Frontend**: Re-sync previous build artifacts from artifact storage.
+
+## Disaster Recovery
+- Daily automated snapshots for RDS with 7-day retention.
+- S3 versioning enabled for static asset bucket.
+- Cross-region replication optional for production configuration.
+- Document recovery steps and validate quarterly using tabletop exercises.
+
+## Monitoring and Alerts
+- Prometheus alerts on high error rate (>1%), elevated latency (p95 > 500ms), and low active users.
+- Grafana dashboards provide visibility into request rate, latency, errors, and infrastructure metrics.
+- Future work includes integrating Alertmanager with Slack/PagerDuty.
+
+## Security Considerations
+- Store secrets in AWS SSM Parameter Store or Secrets Manager; never commit `.env` files.
+- Enforce TLS for all external endpoints; rotate certificates regularly.
+- Use AWS IAM roles with least privilege for compute resources.
+- Run scheduled security scans via `security.yml` workflow.
+
+## Post-Deployment Checklist
+- [ ] Terraform state committed and locked released.
+- [ ] Grafana dashboards updated with new metrics.
+- [ ] Status board refreshed using `python tools/update_status.py`.
+- [ ] Changelog entries added and release tagged.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,75 @@
+# Developer Onboarding Guide
+
+Welcome to the Portfolio Monorepo! This guide walks through setting up the development environment, running services, executing tests, and troubleshooting common issues.
+
+## Prerequisites
+- Docker and Docker Compose
+- Python 3.11
+- Node.js 20+
+- Terraform 1.5+
+- AWS CLI (for provisioning environments)
+- Make (optional but recommended)
+
+## Initial Setup
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/sams-jackson/portfolio-monorepo.git
+   cd portfolio-monorepo
+   ```
+2. **Bootstrap tooling**
+   ```bash
+   ./scripts/setup.sh
+   ```
+   The script installs Python/Node dependencies and configures pre-commit hooks.
+
+## Running the Stack Locally
+The fastest way to spin up all services is via Docker Compose:
+```bash
+make dev
+```
+This command builds and starts:
+- PostgreSQL database
+- Backend API on `http://localhost:8000`
+- Frontend SPA served from Nginx on `http://localhost:5173`
+- Monitoring exporter on `http://localhost:9090`
+- Prometheus (`http://localhost:9091`)
+- Grafana (`http://localhost:3000`)
+
+To stop containers, run `make stop`.
+
+## Service Development
+### Backend
+- Activate a virtual environment and install dependencies from `backend/requirements.txt`.
+- Run the app locally with `uvicorn app.main:app --reload`.
+- Execute tests using `pytest`. The configuration automatically provisions a temporary SQLite database.
+
+### Frontend
+- Install dependencies via `npm install` in `frontend/`.
+- Start the dev server with `npm run dev` and open the browser to `http://localhost:5173`.
+- Update environment variables in `.env` or `.env.local` for API URLs.
+
+### Infrastructure
+- Copy `infra/environments/dev/terraform.tfvars` to a workspace-specific file.
+- Run `terraform init` and `terraform plan` to preview changes.
+- Ensure AWS credentials are configured via `aws configure` or environment variables.
+
+### Monitoring
+- Install Python dependencies via `pip install -r monitoring/requirements.txt`.
+- Run exporter locally with `uvicorn app.main:app --port 9090`.
+- Import `monitoring/grafana/dashboards/app-metrics.json` into Grafana to view metrics.
+
+## Testing
+- `make tests` – backend unit/integration suite.
+- `frontend`: run `npm run test` (vitest) for component coverage.
+- `e2e-tests/tests/test_api_flows.py`: run API smoke tests using pytest.
+- `e2e-tests/k6`: execute load scenarios via `k6 run scenarios.js`.
+
+## Troubleshooting
+- **Docker compose fails to start**: ensure ports 5432, 8000, 5173, 9090, 9091, and 3000 are free.
+- **Backend cannot connect to database**: verify environment variable `DATABASE_URL` and confirm PostgreSQL container health.
+- **Frontend displays network errors**: update `VITE_API_BASE_URL` to match backend host and port.
+- **Terraform state lock issues**: release the lock via AWS DynamoDB console or `terraform force-unlock`.
+- **Grafana login**: default credentials `admin/admin`; change password on first login.
+
+## Support
+For assistance, open a GitHub issue or email `hello@samsjackson.dev`. Welcome aboard!

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,30 @@
+# End-to-End Test Suite
+
+This package contains resources for exercising the portfolio application from the outside: API validation, load testing, and security scanning.
+
+## Structure
+- `postman/collection.json` – Postman collection for REST workflows.
+- `k6/` – Load testing scripts with ramping scenarios.
+- `security/zap-scan.py` – Automates OWASP ZAP spider and active scan.
+- `tests/test_api_flows.py` – Pytest suite that orchestrates full API flows.
+
+## Usage
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run pytest flows:
+```bash
+pytest tests/test_api_flows.py
+```
+
+Run load tests:
+```bash
+k6 run k6/scenarios.js
+```
+
+Run security scan:
+```bash
+python security/zap-scan.py --target http://localhost:8000
+```

--- a/e2e-tests/k6/load-test.js
+++ b/e2e-tests/k6/load-test.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 10 },
+    { duration: '3m', target: 50 },
+    { duration: '1m', target: 0 }
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01']
+  }
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+export default function () {
+  const res = http.get(`${BASE_URL}/health`);
+  check(res, {
+    'status is 200': (r) => r.status === 200
+  });
+  sleep(1);
+}

--- a/e2e-tests/k6/scenarios.js
+++ b/e2e-tests/k6/scenarios.js
@@ -1,0 +1,44 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: 'constant-vus',
+      vus: 1,
+      duration: '1m'
+    },
+    load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 10 },
+        { duration: '3m', target: 50 },
+        { duration: '1m', target: 0 }
+      ]
+    },
+    stress: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 50 },
+        { duration: '2m', target: 100 },
+        { duration: '2m', target: 0 }
+      ]
+    }
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01']
+  }
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+export default function () {
+  const res = http.get(`${BASE_URL}/health`);
+  check(res, {
+    'status is 200': (r) => r.status === 200
+  });
+  sleep(1);
+}

--- a/e2e-tests/postman/collection.json
+++ b/e2e-tests/postman/collection.json
@@ -1,0 +1,85 @@
+{
+  "info": {
+    "name": "Portfolio API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Register",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/register",
+          "host": ["{{baseUrl}}"],
+          "path": ["auth", "register"]
+        }
+      }
+    },
+    {
+      "name": "Login",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var data = JSON.parse(responseBody);",
+              "pm.environment.set('accessToken', data.access_token);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": ["{{baseUrl}}"],
+          "path": ["auth", "login"]
+        }
+      }
+    },
+    {
+      "name": "List Content",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{accessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/content/",
+          "host": ["{{baseUrl}}"],
+          "path": ["content", ""]
+        }
+      }
+    }
+  ],
+  "event": [],
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:8000" },
+    { "key": "email", "value": "postman@example.com" },
+    { "key": "password", "value": "secret" }
+  ]
+}

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==7.4.4
+requests==2.31.0
+python-owasp-zap-v2.4==0.0.21

--- a/e2e-tests/security/zap-scan.py
+++ b/e2e-tests/security/zap-scan.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Automate an OWASP ZAP scan against the portfolio backend."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from owasp_zap_v2 import ZAPv2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="Base URL of the target application")
+    parser.add_argument("--apikey", default="", help="Optional ZAP API key")
+    args = parser.parse_args()
+
+    zap = ZAPv2(apikey=args.apikey)
+    print(f"Spidering {args.target}")
+    scan_id = zap.spider.scan(args.target)
+    while int(zap.spider.status(scan_id)) < 100:
+        time.sleep(1)
+    print("Spider completed")
+
+    print("Starting active scan")
+    ascan_id = zap.ascan.scan(args.target)
+    while int(zap.ascan.status(ascan_id)) < 100:
+        time.sleep(5)
+    print("Active scan completed")
+
+    alerts = zap.core.alerts(baseurl=args.target)
+    print(f"Found {len(alerts)} alerts")
+    for alert in alerts:
+        print(f"- {alert['alert']} ({alert['risk']}) -> {alert['url']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-tests/tests/test_api_flows.py
+++ b/e2e-tests/tests/test_api_flows.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+import requests
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")
+
+
+@pytest.mark.integration
+def test_full_flow():
+    register = requests.post(f"{BASE_URL}/auth/register", json={"email": "e2e@example.com", "password": "secret"})
+    assert register.status_code in (201, 400)  # allow reruns
+
+    login = requests.post(f"{BASE_URL}/auth/login", json={"email": "e2e@example.com", "password": "secret"})
+    assert login.status_code == 200
+    tokens = login.json()
+
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    create = requests.post(
+        f"{BASE_URL}/content/",
+        json={"title": "E2E", "body": "created via pytest", "is_published": True},
+        headers=headers,
+    )
+    assert create.status_code == 201
+
+    listing = requests.get(f"{BASE_URL}/content/", headers=headers)
+    assert listing.status_code == 200
+    data = listing.json()
+    assert isinstance(data, list) and len(data) >= 1

--- a/e2e-tests/tests/test_load.sh
+++ b/e2e-tests/tests/test_load.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+k6 run "$(dirname "$0")/../k6/scenarios.js"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# Frontend Service
+
+React + Vite application that consumes the backend API. The app provides authentication, content management, and dashboard views styled with Tailwind CSS.
+
+## Commands
+- `npm install` – Install dependencies.
+- `npm run dev` – Start development server.
+- `npm run build` – Build production bundle.
+- `npm run preview` – Preview production build locally.
+- `npm run lint` – Run ESLint with project configuration.
+
+## Environment Variables
+Copy `.env.example` to `.env` and configure:
+- `VITE_API_BASE_URL` – Base URL for backend API (e.g., `http://localhost:8000`).
+
+## Production Build
+The Dockerfile creates a multi-stage build that outputs static assets served by Nginx.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+  server_name _;
+
+  location / {
+    root /usr/share/nginx/html;
+    try_files $uri /index.html;
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "portfolio-frontend",
+  "version": "1.4.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css}'"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.8",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.54.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.31",
+    "prettier": "^3.1.0",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,32 @@
+import { Route, Routes, Navigate } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import ProtectedRoute from './components/ProtectedRoute';
+
+function App() {
+  // Define the public and authenticated routes rendered inside the shared layout.
+  return (
+    <div className="min-h-screen bg-gray-50 text-secondary">
+      <Navbar />
+      <main className="max-w-5xl mx-auto px-4 py-8">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+// Centralised Axios instance so every request shares base config and interceptors.
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
+});
+
+api.interceptors.request.use((config) => {
+  // Attach the bearer token when the user is authenticated.
+  const token = localStorage.getItem('accessToken');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    // When the API returns 401 we clear local session state so UI can react accordingly.
+    if (error.response?.status === 401) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/frontend/src/components/ContentCard.tsx
+++ b/frontend/src/components/ContentCard.tsx
@@ -1,0 +1,36 @@
+import { Content } from '../pages/Dashboard';
+
+type Props = {
+  content: Content;
+  onEdit?: (content: Content) => void;
+  onDelete?: (content: Content) => void;
+};
+
+function ContentCard({ content, onEdit, onDelete }: Props) {
+  // Provide small management affordances for each portfolio entry.
+  return (
+    <div className="bg-white rounded shadow p-4 space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-primary">{content.title}</h3>
+        <span className="text-xs uppercase tracking-wide text-gray-500">
+          {content.is_published ? 'Published' : 'Draft'}
+        </span>
+      </div>
+      <p className="text-sm text-gray-700">{content.body}</p>
+      <div className="flex space-x-2 text-sm">
+        {onEdit && (
+          <button onClick={() => onEdit(content)} className="text-blue-500">
+            Edit
+          </button>
+        )}
+        {onDelete && (
+          <button onClick={() => onDelete(content)} className="text-red-500">
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ContentCard;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,44 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+function Navbar() {
+  const { isAuthenticated, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    // Clear auth state and return the visitor to the marketing view.
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <header className="bg-white shadow">
+      <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
+        <Link to="/" className="text-xl font-semibold text-primary">
+          Portfolio Dashboard
+        </Link>
+        <nav className="space-x-4">
+          <Link to="/" className="text-sm font-medium hover:text-primary">
+            Home
+          </Link>
+          {isAuthenticated ? (
+            <>
+              <Link to="/dashboard" className="text-sm font-medium hover:text-primary">
+                Dashboard
+              </Link>
+              <button onClick={handleLogout} className="text-sm font-medium text-red-500">
+                Logout
+              </button>
+            </>
+          ) : (
+            <Link to="/login" className="text-sm font-medium text-primary">
+              Login
+            </Link>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+type Props = {
+  children: ReactNode;
+};
+
+function ProtectedRoute({ children }: Props) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    // Persist the original location so we can route back after login.
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+}
+
+export default ProtectedRoute;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import api from '../api/client';
+
+type AuthContextValue = {
+  isAuthenticated: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => !!localStorage.getItem('accessToken'));
+
+  useEffect(() => {
+    // Sync initial state when the provider is mounted in the browser.
+    setIsAuthenticated(!!localStorage.getItem('accessToken'));
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    // Delegate the HTTP request to the shared API client so interceptors stay consistent.
+    const response = await api.post('/auth/login', { email, password });
+    const { access_token, refresh_token } = response.data;
+    localStorage.setItem('accessToken', access_token);
+    localStorage.setItem('refreshToken', refresh_token);
+    setIsAuthenticated(true);
+  };
+
+  const logout = () => {
+    // Removing tokens ensures the ProtectedRoute component blocks subsequent requests.
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    setIsAuthenticated(false);
+  };
+
+  const value: AuthContextValue = { isAuthenticated, login, logout };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AuthProvider } from './context/AuthContext';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,114 @@
+import { FormEvent, useEffect, useState } from 'react';
+import api from '../api/client';
+import ContentCard from '../components/ContentCard';
+
+export type Content = {
+  id: string;
+  title: string;
+  body: string;
+  is_published: boolean;
+};
+
+const defaultFormState = { title: '', body: '', is_published: false };
+
+function Dashboard() {
+  const [items, setItems] = useState<Content[]>([]);
+  const [formState, setFormState] = useState(defaultFormState);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadContent = async () => {
+    // Load data from the API and keep a friendly message handy on failure.
+    try {
+      const response = await api.get<Content[]>('/content/');
+      setItems(response.data);
+    } catch (err) {
+      setError('Failed to load content');
+    }
+  };
+
+  useEffect(() => {
+    loadContent();
+  }, []);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (editingId) {
+        await api.put(`/content/${editingId}`, formState);
+      } else {
+        await api.post('/content/', formState);
+      }
+      setFormState(defaultFormState);
+      setEditingId(null);
+      loadContent();
+    } catch (err) {
+      setError('Unable to save content');
+    }
+  };
+
+  const handleEdit = (content: Content) => {
+    // Switch the form into update mode for the selected record.
+    setEditingId(content.id);
+    setFormState({ title: content.title, body: content.body, is_published: content.is_published });
+  };
+
+  const handleDelete = async (content: Content) => {
+    // Delete the record and refresh so the grid reflects the change.
+    await api.delete(`/content/${content.id}`);
+    loadContent();
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-secondary">Content Dashboard</h2>
+        <p className="text-sm text-gray-600">Manage portfolio case studies and showcase entries.</p>
+      </header>
+      <form onSubmit={handleSubmit} className="bg-white shadow rounded p-4 space-y-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm font-medium text-gray-700">
+            Title
+            <input
+              className="mt-1 w-full border rounded px-3 py-2"
+              value={formState.title}
+              onChange={(event) => setFormState({ ...formState, title: event.target.value })}
+              required
+            />
+          </label>
+          <label className="text-sm font-medium text-gray-700">
+            Published
+            <input
+              type="checkbox"
+              className="ml-2"
+              checked={formState.is_published}
+              onChange={(event) => setFormState({ ...formState, is_published: event.target.checked })}
+            />
+          </label>
+        </div>
+        <label className="text-sm font-medium text-gray-700">
+          Body
+          <textarea
+            className="mt-1 w-full border rounded px-3 py-2"
+            rows={4}
+            value={formState.body}
+            onChange={(event) => setFormState({ ...formState, body: event.target.value })}
+          />
+        </label>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">
+          {editingId ? 'Update content' : 'Create content'}
+        </button>
+      </form>
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.map((item) => (
+          <ContentCard key={item.id} content={item} onEdit={handleEdit} onDelete={handleDelete} />
+        ))}
+        {items.length === 0 && <p className="text-sm text-gray-500">No content yet. Create your first entry above.</p>}
+      </div>
+    </section>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,21 @@
+function Home() {
+  return (
+    <section className="space-y-6">
+      <header className="text-center space-y-2">
+        <h1 className="text-3xl font-bold text-primary">Samuel Jackson - Systems Development Engineer</h1>
+        <p className="text-gray-600">Building secure, scalable systems with visibility baked in.</p>
+      </header>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Spotlight the themes showcased in the dashboard. */}
+        {["Infrastructure automation", "Observability dashboards", "Quality engineering"].map((item) => (
+          <div key={item} className="bg-white shadow rounded p-4">
+            <h2 className="text-lg font-semibold text-secondary">{item}</h2>
+            <p className="text-sm text-gray-600">Detailed guides, code samples, and runbooks showcasing production-ready delivery.</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Home;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,78 @@
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import api from '../api/client';
+import { useAuth } from '../context/AuthContext';
+
+function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await login(email, password);
+      const redirectTo = (location.state as { from?: Location })?.from?.pathname || '/dashboard';
+      navigate(redirectTo);
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  const handleRegister = async () => {
+    // Registration reuses the login helper so the dashboard opens automatically.
+    try {
+      await api.post('/auth/register', { email, password });
+      await login(email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <section className="max-w-md mx-auto bg-white shadow rounded p-6 space-y-4">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-primary">Sign in</h2>
+        <p className="text-sm text-gray-600">Access the portfolio content dashboard.</p>
+      </header>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Email</label>
+          <input
+            type="email"
+            className="mt-1 w-full border rounded px-3 py-2"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Password</label>
+          <input
+            type="password"
+            className="mt-1 w-full border rounded px-3 py-2"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <div className="flex items-center justify-between">
+          <button type="submit" className="bg-primary text-white px-4 py-2 rounded">
+            Login
+          </button>
+          <button type="button" onClick={handleRegister} className="text-sm text-primary">
+            Register instead
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+export default Login;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#3B82F6',
+        secondary: '#1F2937'
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,18 @@
+# Infrastructure-as-Code
+
+Terraform modules and environment configurations for deploying the portfolio stack to AWS.
+
+## Modules
+- `network`: VPC, subnets, gateways, and security groups.
+- `compute`: Launch template, Auto Scaling Group, and Application Load Balancer.
+- `storage`: RDS PostgreSQL, S3 buckets, and CloudFront distribution.
+
+## Usage
+```bash
+cd infra/environments/dev
+terraform init
+terraform plan
+terraform apply
+```
+
+Each environment has its own `terraform.tfvars` and backend configuration. Update variable values to match account-specific requirements.

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/infra/environments/dev/backend.tf
+++ b/infra/environments/dev/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket = "portfolio-dev-terraform"
+    key    = "state/terraform.tfstate"
+    region = "us-east-1"
+    dynamodb_table = "portfolio-dev-locks"
+  }
+}

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,0 +1,14 @@
+module "portfolio" {
+  source = "../../"
+
+  environment     = "dev"
+  region          = "us-east-1"
+  vpc_cidr        = "10.1.0.0/16"
+  public_subnets  = ["10.1.1.0/24", "10.1.2.0/24"]
+  private_subnets = ["10.1.11.0/24", "10.1.12.0/24"]
+  data_subnets    = ["10.1.21.0/24", "10.1.22.0/24"]
+  instance_type   = "t3.small"
+  min_size        = 1
+  max_size        = 2
+  db_password     = "change-me"
+}

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -1,0 +1,9 @@
+environment = "dev"
+region      = "us-east-1"
+public_subnets  = ["10.1.1.0/24", "10.1.2.0/24"]
+private_subnets = ["10.1.11.0/24", "10.1.12.0/24"]
+data_subnets    = ["10.1.21.0/24", "10.1.22.0/24"]
+instance_type   = "t3.small"
+min_size        = 1
+max_size        = 2
+db_password     = "change-me"

--- a/infra/environments/prod/backend.tf
+++ b/infra/environments/prod/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket = "portfolio-prod-terraform"
+    key    = "state/terraform.tfstate"
+    region = "us-east-1"
+    dynamodb_table = "portfolio-prod-locks"
+  }
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,0 +1,15 @@
+module "portfolio" {
+  source = "../../"
+
+  environment     = "prod"
+  region          = "us-east-1"
+  vpc_cidr        = "10.3.0.0/16"
+  public_subnets  = ["10.3.1.0/24", "10.3.2.0/24"]
+  private_subnets = ["10.3.11.0/24", "10.3.12.0/24"]
+  data_subnets    = ["10.3.21.0/24", "10.3.22.0/24"]
+  instance_type   = "t3.medium"
+  min_size        = 2
+  max_size        = 3
+  db_instance_class = "db.t3.medium"
+  db_password     = "change-me"
+}

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -1,0 +1,10 @@
+environment = "prod"
+region      = "us-east-1"
+public_subnets  = ["10.3.1.0/24", "10.3.2.0/24"]
+private_subnets = ["10.3.11.0/24", "10.3.12.0/24"]
+data_subnets    = ["10.3.21.0/24", "10.3.22.0/24"]
+instance_type   = "t3.medium"
+min_size        = 2
+max_size        = 3
+db_instance_class = "db.t3.medium"
+db_password     = "change-me"

--- a/infra/environments/staging/backend.tf
+++ b/infra/environments/staging/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket = "portfolio-staging-terraform"
+    key    = "state/terraform.tfstate"
+    region = "us-east-1"
+    dynamodb_table = "portfolio-staging-locks"
+  }
+}

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -1,0 +1,15 @@
+module "portfolio" {
+  source = "../../"
+
+  environment     = "staging"
+  region          = "us-east-1"
+  vpc_cidr        = "10.2.0.0/16"
+  public_subnets  = ["10.2.1.0/24", "10.2.2.0/24"]
+  private_subnets = ["10.2.11.0/24", "10.2.12.0/24"]
+  data_subnets    = ["10.2.21.0/24", "10.2.22.0/24"]
+  instance_type   = "t3.medium"
+  min_size        = 2
+  max_size        = 3
+  db_instance_class = "db.t3.medium"
+  db_password     = "change-me"
+}

--- a/infra/environments/staging/terraform.tfvars
+++ b/infra/environments/staging/terraform.tfvars
@@ -1,0 +1,10 @@
+environment = "staging"
+region      = "us-east-1"
+public_subnets  = ["10.2.1.0/24", "10.2.2.0/24"]
+private_subnets = ["10.2.11.0/24", "10.2.12.0/24"]
+data_subnets    = ["10.2.21.0/24", "10.2.22.0/24"]
+instance_type   = "t3.medium"
+min_size        = 2
+max_size        = 3
+db_instance_class = "db.t3.medium"
+db_password     = "change-me"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,33 @@
+module "network" {
+  source          = "./modules/network"
+  project         = var.project
+  environment     = var.environment
+  vpc_cidr        = var.vpc_cidr
+  public_subnets  = var.public_subnets
+  private_subnets = var.private_subnets
+  data_subnets    = var.data_subnets
+}
+
+module "compute" {
+  source          = "./modules/compute"
+  project         = var.project
+  environment     = var.environment
+  subnet_ids      = module.network.private_subnet_ids
+  instance_type   = var.instance_type
+  min_size        = var.min_size
+  max_size        = var.max_size
+  vpc_id          = module.network.vpc_id
+  security_group_ids = [module.network.app_security_group_id]
+}
+
+module "storage" {
+  source              = "./modules/storage"
+  project             = var.project
+  environment         = var.environment
+  data_subnet_ids     = module.network.data_subnet_ids
+  db_instance_class   = var.db_instance_class
+  db_name             = var.db_name
+  db_username         = var.db_username
+  db_password         = var.db_password
+  vpc_security_groups = [module.network.db_security_group_id]
+}

--- a/infra/modules/compute/main.tf
+++ b/infra/modules/compute/main.tf
@@ -1,0 +1,92 @@
+resource "aws_launch_template" "backend" {
+  name_prefix   = "${var.project}-${var.environment}-lt"
+  image_id      = data.aws_ami.amazon_linux.id
+  instance_type = var.instance_type
+
+  user_data = base64encode(<<EOT
+#!/bin/bash
+echo "Starting portfolio backend"
+EOT
+  )
+
+  vpc_security_group_ids = var.security_group_ids
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(var.common_tags, {
+      Name = "${var.project}-${var.environment}-backend"
+    })
+  }
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_lb" "app" {
+  name               = "${var.project}-${var.environment}-alb"
+  load_balancer_type = "application"
+  subnets            = var.subnet_ids
+
+  security_groups = var.security_group_ids
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "app" {
+  name     = "${var.project}-${var.environment}-tg"
+  port     = 8000
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    path                = "/health"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_lb_listener" "app" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_autoscaling_group" "backend" {
+  name                = "${var.project}-${var.environment}-asg"
+  min_size            = var.min_size
+  max_size            = var.max_size
+  desired_capacity    = var.min_size
+  health_check_type   = "EC2"
+  vpc_zone_identifier = var.subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.backend.id
+    version = "$Latest"
+  }
+
+  target_group_arns = [aws_lb_target_group.app.arn]
+
+  tag {
+    key                 = "Name"
+    value               = "${var.project}-${var.environment}-backend"
+    propagate_at_launch = true
+  }
+}

--- a/infra/modules/compute/outputs.tf
+++ b/infra/modules/compute/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_dns_name" {
+  value = aws_lb.app.dns_name
+}

--- a/infra/modules/compute/variables.tf
+++ b/infra/modules/compute/variables.tf
@@ -1,0 +1,36 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "min_size" {
+  type = number
+}
+
+variable "max_size" {
+  type = number
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "common_tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,104 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = { for index, cidr in var.public_subnets : index => cidr }
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  map_public_ip_on_launch = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-public-${each.key}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = { for index, cidr in var.private_subnets : index => cidr }
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = each.value
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-private-${each.key}"
+    Tier = "app"
+  })
+}
+
+resource "aws_subnet" "data" {
+  for_each = { for index, cidr in var.data_subnets : index => cidr }
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = each.value
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-data-${each.key}"
+    Tier = "data"
+  })
+}
+
+resource "aws_security_group" "app" {
+  name        = "${var.project}-${var.environment}-app"
+  description = "App security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "Allow HTTP"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-app-sg"
+  })
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.project}-${var.environment}-db"
+  description = "DB security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "Postgres"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-db-sg"
+  })
+}

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,0 +1,23 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "private_subnet_ids" {
+  value = [for subnet in aws_subnet.private : subnet.id]
+}
+
+output "data_subnet_ids" {
+  value = [for subnet in aws_subnet.data : subnet.id]
+}
+
+output "app_security_group_id" {
+  value = aws_security_group.app.id
+}
+
+output "db_security_group_id" {
+  value = aws_security_group.db.id
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,0 +1,28 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "public_subnets" {
+  type = list(string)
+}
+
+variable "private_subnets" {
+  type = list(string)
+}
+
+variable "data_subnets" {
+  type = list(string)
+}
+
+variable "common_tags" {
+  type = map(string)
+  default = {}
+}

--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -1,0 +1,82 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.project}-${var.environment}-db"
+  subnet_ids = var.data_subnet_ids
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-db-subnet"
+  })
+}
+
+resource "aws_db_instance" "this" {
+  identifier              = "${var.project}-${var.environment}-db"
+  engine                  = "postgres"
+  engine_version          = "14"
+  instance_class          = var.db_instance_class
+  allocated_storage       = 20
+  db_name                 = var.db_name
+  username                = var.db_username
+  password                = var.db_password
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = var.vpc_security_groups
+  skip_final_snapshot     = true
+  publicly_accessible     = false
+  deletion_protection     = false
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-db"
+  })
+}
+
+resource "aws_s3_bucket" "static" {
+  bucket = "${var.project}-${var.environment}-static-${random_string.suffix.id}"
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-static"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "static" {
+  bucket = aws_s3_bucket.static.id
+
+  block_public_acls   = false
+  block_public_policy = false
+  ignore_public_acls  = false
+  restrict_public_buckets = false
+}
+
+resource "aws_cloudfront_distribution" "static" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name = aws_s3_bucket.static.bucket_regional_domain_name
+    origin_id   = "s3-static"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-static"
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-cdn"
+  })
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+}

--- a/infra/modules/storage/outputs.tf
+++ b/infra/modules/storage/outputs.tf
@@ -1,0 +1,11 @@
+output "db_endpoint" {
+  value = aws_db_instance.this.address
+}
+
+output "static_bucket" {
+  value = aws_s3_bucket.static.bucket
+}
+
+output "cloudfront_domain" {
+  value = aws_cloudfront_distribution.static.domain_name
+}

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -1,0 +1,37 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "data_subnet_ids" {
+  type = list(string)
+}
+
+variable "db_instance_class" {
+  type = string
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "db_username" {
+  type = string
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "vpc_security_groups" {
+  type = list(string)
+}
+
+variable "common_tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "alb_dns_name" {
+  value = module.compute.alb_dns_name
+}
+
+output "db_endpoint" {
+  value = module.storage.db_endpoint
+}
+
+output "static_bucket" {
+  value = module.storage.static_bucket
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.25"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,9 @@
+environment = "dev"
+region      = "us-east-1"
+public_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnets = ["10.0.11.0/24", "10.0.12.0/24"]
+data_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
+instance_type   = "t3.small"
+min_size        = 1
+max_size        = 3
+db_password     = "change-me"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,79 @@
+variable "region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project tag"
+  type        = string
+  default     = "portfolio"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Public subnet CIDRs"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "Private subnet CIDRs"
+  type        = list(string)
+}
+
+variable "data_subnets" {
+  description = "Data subnet CIDRs"
+  type        = list(string)
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for backend"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "min_size" {
+  description = "Minimum instances in Auto Scaling Group"
+  type        = number
+  default     = 1
+}
+
+variable "max_size" {
+  description = "Maximum instances in Auto Scaling Group"
+  type        = number
+  default     = 3
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "portfolio"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  default     = "portfolio"
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
+  sensitive   = true
+}

--- a/internal/AI_NOTES.md
+++ b/internal/AI_NOTES.md
@@ -1,0 +1,9 @@
+# Internal Automation Notes
+
+The following cues guide tooling that generates or updates project assets. These notes remain private to prevent automated
+systems from leaking into public-facing documentation.
+
+- Follow repository coding standards defined in `CONTRIBUTING.md`.
+- Generate code that is production-focused with tests and documentation.
+- Prefer configuration-driven approaches and environment variables for secrets.
+- Ensure all generated assets are idempotent so scripts can run repeatedly.

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9090"]

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,15 @@
+# Monitoring Service
+
+FastAPI-based Prometheus exporter that surfaces synthetic metrics for the portfolio system. Pair with Prometheus and Grafana for end-to-end observability.
+
+## Commands
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 9090
+```
+
+## Endpoints
+- `GET /metrics` – Prometheus metrics endpoint.
+- `GET /health` – Exporter health probe.
+
+Grafana dashboards are located in `grafana/dashboards/` and Prometheus scrape configuration is under `prometheus/`.

--- a/monitoring/app/__init__.py
+++ b/monitoring/app/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring exporter package."""

--- a/monitoring/app/main.py
+++ b/monitoring/app/main.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime
+
+from fastapi import FastAPI
+from prometheus_client import Counter, Gauge, Histogram, generate_latest
+from starlette.responses import PlainTextResponse
+
+app = FastAPI(title="Portfolio Monitoring Exporter")
+
+# Core Prometheus metrics describing request load, latency, and the synthetic active user count.
+REQUEST_COUNT = Counter("portfolio_requests_total", "Total requests processed", ["endpoint"])
+REQUEST_DURATION = Histogram("portfolio_request_duration_seconds", "Request duration", buckets=(0.1, 0.3, 0.5, 1, 2))
+ACTIVE_USERS = Gauge("portfolio_active_users", "Number of active users")
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    ACTIVE_USERS.set(5)
+
+
+@app.get("/metrics")
+async def metrics() -> PlainTextResponse:
+    REQUEST_COUNT.labels(endpoint="metrics").inc()
+    REQUEST_DURATION.observe(random.uniform(0.05, 0.2))
+    ACTIVE_USERS.set(random.randint(3, 10))
+    return PlainTextResponse(generate_latest().decode("utf-8"), media_type="text/plain; version=0.0.4")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}

--- a/monitoring/grafana/dashboards/app-metrics.json
+++ b/monitoring/grafana/dashboards/app-metrics.json
@@ -1,0 +1,26 @@
+{
+  "title": "Portfolio Application Metrics",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Request Rate",
+      "targets": [
+        {"expr": "rate(portfolio_requests_total[1m])"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Request Duration",
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum(rate(portfolio_request_duration_seconds_bucket[5m])) by (le))"}
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Active Users",
+      "targets": [
+        {"expr": "portfolio_active_users"}
+      ]
+    }
+  ]
+}

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: portfolio-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['backend:8000']
+  - job_name: monitoring-exporter
+    static_configs:
+      - targets: ['monitoring:9090']

--- a/monitoring/promtail/promtail.yml
+++ b/monitoring/promtail/promtail.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: portfolio-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: portfolio
+          __path__: /var/log/portfolio/*.log

--- a/monitoring/requirements.txt
+++ b/monitoring/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.104.1
+prometheus-client==0.17.1
+uvicorn[standard]==0.23.2

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "portfolio-monorepo",
+  "version": "1.4.0",
+  "private": true,
+  "scripts": {
+    "lint": "npm run lint:backend && npm run lint:frontend && npm run lint:infra",
+    "lint:backend": "ruff check backend",
+    "lint:frontend": "cd frontend && npm run lint",
+    "lint:infra": "tflint --chdir infra",
+    "format": "npm run format:frontend",
+    "format:frontend": "cd frontend && npm run format"
+  },
+  "devDependencies": {
+    "eslint": "^8.54.0",
+    "prettier": "^3.1.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/prompts/AI_INSTRUCTIONS.md
+++ b/prompts/AI_INSTRUCTIONS.md
@@ -1,0 +1,12 @@
+# Prompt Harness Overview
+
+The prompts in this directory document the contract between our internal automation and the portfolio repository. Detailed
+automation cues now live in `internal/AI_NOTES.md` so that public artifacts focus on implementation guidance rather than
+machine-oriented directives.
+
+```text
+# Maintainer guidance
+# - Update BUILD_SPEC.json when services or technology stacks change.
+# - Keep AI_NOTES.md in sync with the coding standards referenced by CONTRIBUTING.md.
+# - Treat this directory as the source of truth for automated asset generation.
+```

--- a/prompts/BUILD_SPEC.json
+++ b/prompts/BUILD_SPEC.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.4.0",
+  "services": {
+    "backend": "FastAPI + PostgreSQL",
+    "frontend": "React + Vite",
+    "infra": "Terraform AWS",
+    "monitoring": "FastAPI metrics exporter",
+    "e2e-tests": "Postman and k6"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pre-commit==3.6.0
+pytest==7.4.4
+ruff==0.1.15

--- a/scripts/package_zip.ps1
+++ b/scripts/package_zip.ps1
@@ -1,0 +1,18 @@
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Join-Path $RootDir '..'
+$OutputDir = Join-Path $RootDir 'reports'
+$ArchiveName = "portfolio-monorepo-$(Get-Date -Format yyyyMMdd).zip"
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$items = Get-ChildItem -Path $RootDir -Recurse -File |
+    Where-Object { $_.FullName -notmatch 'node_modules|\.terraform|__pycache__|\.git' }
+
+$zipPath = Join-Path $OutputDir $ArchiveName
+if (Test-Path $zipPath) { Remove-Item $zipPath }
+Compress-Archive -Path $items.FullName -DestinationPath $zipPath
+
+$hash = Get-FileHash -Algorithm SHA256 -Path $zipPath
+"$($hash.Hash)  $ArchiveName" | Set-Content -Path (Join-Path $OutputDir "$ArchiveName.sha256")
+
+Write-Host "Package created at $zipPath"

--- a/scripts/package_zip.sh
+++ b/scripts/package_zip.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+OUTPUT_DIR="$ROOT_DIR/reports"
+ARCHIVE_NAME="portfolio-monorepo-$(date +%Y%m%d).tar.gz"
+
+mkdir -p "$OUTPUT_DIR"
+
+tar --exclude='node_modules' \
+    --exclude='*.pyc' \
+    --exclude='__pycache__' \
+    --exclude='.terraform' \
+    --exclude='.git' \
+    -czf "$OUTPUT_DIR/$ARCHIVE_NAME" -C "$ROOT_DIR" .
+
+(cd "$OUTPUT_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
+
+echo "Package created at $OUTPUT_DIR/$ARCHIVE_NAME"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,9 @@
+pip install -r requirements.txt
+pip install -r backend/requirements.txt
+Push-Location frontend
+npm install
+Pop-Location
+Push-Location monitoring
+pip install -r requirements.txt
+Pop-Location
+pre-commit install

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install -r requirements.txt
+pip install -r backend/requirements.txt
+(cd frontend && npm install)
+(cd monitoring && pip install -r requirements.txt)
+pre-commit install

--- a/tasks/ai_tasks_v1.4.csv
+++ b/tasks/ai_tasks_v1.4.csv
@@ -1,0 +1,13 @@
+id,area,title,status
+1,backend,Implement JWT authentication,Done
+2,backend,Create content CRUD endpoints,Done
+3,frontend,Build authenticated dashboard,Done
+4,frontend,Style pages with Tailwind,Done
+5,infra,Provision AWS network module,Done
+6,infra,Add compute auto scaling,Done
+7,monitoring,Expose Prometheus metrics,Done
+8,monitoring,Import Grafana dashboard,Done
+9,testing,Author Postman collection,Done
+10,testing,Configure k6 scenarios,Done
+11,docs,Write onboarding guide,Done
+12,automation,Publish manifest generator,Done

--- a/tasks/ai_tasks_v1.4.json
+++ b/tasks/ai_tasks_v1.4.json
@@ -1,0 +1,14 @@
+[
+  {"id": 1, "area": "backend", "title": "Implement JWT authentication", "status": "Done"},
+  {"id": 2, "area": "backend", "title": "Create content CRUD endpoints", "status": "Done"},
+  {"id": 3, "area": "frontend", "title": "Build authenticated dashboard", "status": "Done"},
+  {"id": 4, "area": "frontend", "title": "Style pages with Tailwind", "status": "Done"},
+  {"id": 5, "area": "infra", "title": "Provision AWS network module", "status": "Done"},
+  {"id": 6, "area": "infra", "title": "Add compute auto scaling", "status": "Done"},
+  {"id": 7, "area": "monitoring", "title": "Expose Prometheus metrics", "status": "Done"},
+  {"id": 8, "area": "monitoring", "title": "Import Grafana dashboard", "status": "Done"},
+  {"id": 9, "area": "testing", "title": "Author Postman collection", "status": "Done"},
+  {"id": 10, "area": "testing", "title": "Configure k6 scenarios", "status": "Done"},
+  {"id": 11, "area": "docs", "title": "Write onboarding guide", "status": "Done"},
+  {"id": 12, "area": "automation", "title": "Publish manifest generator", "status": "Done"}
+]

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Bump semantic versions across repository files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Tuple
+
+VERSION_PATTERN = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+TARGET_FILES = [
+    Path("package.json"),
+    Path("CHANGELOG.md"),
+    Path("README.md"),
+]
+
+
+def parse_version(version: str) -> Tuple[int, int, int]:
+    major, minor, patch = VERSION_PATTERN.fullmatch(version).groups()
+    return int(major), int(minor), int(patch)
+
+
+def bump(major: int, minor: int, patch: int, release: str) -> Tuple[int, int, int]:
+    if release == "major":
+        return major + 1, 0, 0
+    if release == "minor":
+        return major, minor + 1, 0
+    if release == "patch":
+        return major, minor, patch + 1
+    raise ValueError("Release must be major, minor, or patch")
+
+
+def update_file(path: Path, old: str, new: str) -> None:
+    if not path.exists():
+        return
+    content = path.read_text()
+    content = content.replace(old, new)
+    path.write_text(content)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("release", choices=["major", "minor", "patch"], help="Type of release bump")
+    parser.add_argument("current", help="Current semantic version (e.g., 1.4.0)")
+    args = parser.parse_args()
+
+    current_version = args.current
+    match = VERSION_PATTERN.fullmatch(current_version)
+    if not match:
+        raise ValueError("Current version must be in the form X.Y.Z")
+
+    new_version_tuple = bump(*parse_version(current_version), release=args.release)
+    new_version = ".".join(str(part) for part in new_version_tuple)
+
+    for file_path in TARGET_FILES:
+        update_file(file_path, current_version, new_version)
+
+    print(f"Version bumped from {current_version} to {new_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gen_manifest.py
+++ b/tools/gen_manifest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate a manifest describing the repository contents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List
+
+IGNORED_DIRS = {".git", "node_modules", "__pycache__", ".terraform", ".mypy_cache", ".pytest_cache"}
+
+
+def collect_file_info(root: Path) -> Dict[str, int]:
+    """Return a counter of file extensions under the root directory."""
+    counter: Counter[str] = Counter()
+    for path in root.rglob("*"):
+        if path.is_dir():
+            if path.name in IGNORED_DIRS:
+                continue
+        elif path.is_file():
+            ext = path.suffix or "<no-ext>"
+            counter[ext] += 1
+    return dict(counter)
+
+
+def list_services(root: Path) -> List[str]:
+    services = []
+    for directory in ["backend", "frontend", "infra", "monitoring", "e2e-tests"]:
+        if (root / directory).exists():
+            services.append(directory)
+    return services
+
+
+def build_manifest(root: Path) -> Dict[str, object]:
+    return {
+        "root": str(root),
+        "total_files": sum(1 for _ in root.rglob("*") if _.is_file()),
+        "extension_breakdown": collect_file_info(root),
+        "services": list_services(root),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True, help="File to write manifest JSON")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    manifest = build_manifest(root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2))
+    print(f"Manifest written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/update_status.py
+++ b/tools/update_status.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Update STATUS_BOARD.md with completion percentages based on task files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Tuple
+
+STATUS_TEMPLATE = """# Status Board\n\n| Area | Status | Notes |\n|------|--------|-------|\n| Backend service | {backend_status} | {backend_notes} |\n| Frontend service | {frontend_status} | {frontend_notes} |\n| Infrastructure | {infra_status} | {infra_notes} |\n| Monitoring | {monitoring_status} | {monitoring_notes} |\n| Testing | {testing_status} | {testing_notes} |\n| Documentation | {docs_status} | {docs_notes} |\n| Automation tooling | {automation_status} | {automation_notes} |\n"""
+
+
+STATUS_MAP = {
+    "complete": "🟢 Complete",
+    "in_progress": "🟠 In Progress",
+    "planned": "🔵 Planned",
+}
+
+
+def load_completion(task_csv: Path) -> Tuple[int, int]:
+    completed = 0
+    total = 0
+    with task_csv.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            total += 1
+            if row.get("status", "").lower() == "done":
+                completed += 1
+    return completed, total
+
+
+def determine_status(completed: int, total: int) -> str:
+    if total == 0:
+        return STATUS_MAP["planned"]
+    ratio = completed / total
+    if ratio >= 0.9:
+        return STATUS_MAP["complete"]
+    if ratio >= 0.4:
+        return STATUS_MAP["in_progress"]
+    return STATUS_MAP["planned"]
+
+
+def build_notes(completed: int, total: int) -> str:
+    if total == 0:
+        return "No tasks tracked"
+    return f"{completed}/{total} tasks complete"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", type=Path, default=Path("tasks/ai_tasks_v1.4.csv"))
+    parser.add_argument("--output", type=Path, default=Path("STATUS_BOARD.md"))
+    args = parser.parse_args()
+
+    completed, total = load_completion(args.csv)
+    status = determine_status(completed, total)
+    notes = build_notes(completed, total)
+
+    content = STATUS_TEMPLATE.format(
+        backend_status=status,
+        backend_notes=notes,
+        frontend_status=status,
+        frontend_notes=notes,
+        infra_status=status,
+        infra_notes=notes,
+        monitoring_status=status,
+        monitoring_notes=notes,
+        testing_status=status,
+        testing_notes=notes,
+        docs_status=status,
+        docs_notes=notes,
+        automation_status=status,
+        automation_notes=notes,
+    )
+    args.output.write_text(content)
+    print(f"Status board updated ({completed}/{total} complete)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- guard the FastAPI dependency against malformed JWT subjects and clarify route behavior with developer-facing comments
- add backend and frontend `.env.example` templates plus richer inline documentation across client components
- relocate automation-specific guidance into `internal/AI_NOTES.md` while refreshing the public prompt overview

## Testing
- pip install -r backend/requirements.txt *(fails: network proxy blocks package index access)*

------
https://chatgpt.com/codex/tasks/task_e_68f86944f8c083278062f379d42b766b