### PR TITLE
Add portfolio starter scaffolding, tooling, and CI pipeline

### DIFF
--- a/docs/presentation_outline.md
+++ b/docs/presentation_outline.md
@@ -1,0 +1,60 @@
+# Portfolio Platform Presentation Outline
+
+1. **Title Slide**
+   - Project name, presenter, date
+
+2. **Overview**
+   - Project goals and problem statement
+   - Key capabilities delivered
+
+3. **Architecture** *(Include diagram: high-level system components and interactions)*
+   - Backend, frontend, database, infrastructure layers
+   - Communication flows between services
+
+4. **Backend** *(Include diagram: API request lifecycle)*
+   - FastAPI services and authentication flow
+   - Database schema and session handling
+
+5. **Frontend** *(Include diagram: component hierarchy)*
+   - React app structure and routing
+   - Health check and API integration
+
+6. **Infrastructure** *(Include diagram: Terraform VPC layout)*
+   - AWS networking modules and subnets
+   - Container orchestration approach
+
+7. **Testing Strategy** *(Include diagram: testing pyramid)*
+   - Unit, integration, and e2e coverage
+   - Tooling and automation hooks
+
+8. **Security** *(Include diagram: auth + secrets flow)*
+   - Password hashing, JWT issuance, and validation
+   - Dependency scanning and container hardening
+
+9. **Observability** *(Include diagram: metrics/logging pipeline)*
+   - Health endpoints and planned telemetry
+   - Future monitoring/alerting roadmap
+
+10. **CI/CD Pipeline** *(Include diagram: workflow stages)*
+    - Quality, testing, security, and deployment jobs
+    - Artifact management and gating
+
+11. **Demo Plan**
+    - Steps to showcase API and UI
+    - Expected outcomes and data setup
+
+12. **Performance** *(Include diagram: load test stages)*
+    - k6 scenarios and target metrics
+    - Scaling considerations
+
+13. **Lessons Learned**
+    - Key takeaways from implementation
+    - Challenges and mitigations
+
+14. **Future Work**
+    - Enhancements and roadmap items
+    - Upcoming automation and integrations
+
+15. **Thank You**
+    - Contact information
+    - Q&A invitation

--- a/portfolio/.editorconfig
+++ b/portfolio/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/portfolio/.github/workflows/ci.yml
+++ b/portfolio/.github/workflows/ci.yml
@@ -1,0 +1,351 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20'
+  TERRAFORM_VERSION: '1.9.5'
+
+jobs:
+  quality:
+    name: Quality & Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('portfolio/backend/requirements.txt', 'tools/dupefinder/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install Python tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff==0.6.9 bandit==1.7.9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('portfolio/frontend/package-lock.json', 'portfolio/frontend/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - name: Install frontend dependencies
+        run: |
+          cd portfolio/frontend
+          npm install
+      - name: Prepare report directory
+        run: mkdir -p reports
+      - name: Ruff Lint
+        run: |
+          ruff check portfolio/backend --output-format full --output-file reports/ruff.txt
+      - name: Bandit Security Scan
+        run: |
+          bandit -r portfolio/backend -f txt -o reports/bandit.txt
+      - name: ESLint
+        run: |
+          cd portfolio/frontend
+          npx eslint "src/**/*.{ts,tsx}" -f stylish -o ../reports/eslint.txt
+      - name: Prettier Check
+        run: |
+          cd portfolio/frontend
+          npx prettier --check "src/**/*.{ts,tsx}" | tee ../reports/prettier.txt
+      - name: npm Audit
+        run: |
+          cd portfolio/frontend
+          npm audit --audit-level=high | tee ../reports/npm-audit.txt
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+      - name: Cache Terraform plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: ${{ runner.os }}-tf-${{ env.TERRAFORM_VERSION }}-${{ hashFiles('portfolio/infra/**/*.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-tf-
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          working_directory: portfolio/infra
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+      - name: TFLint
+        run: |
+          cd portfolio/infra
+          tflint --init
+          tflint
+      - name: Trivy Filesystem Scan
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          path: .
+          format: table
+          output: reports/trivy.txt
+      - name: Upload quality artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-reports
+          path: reports
+      - name: Annotate PR on failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `❌ Quality checks failed in run ${context.runId}. See details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-unit-${{ hashFiles('portfolio/backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-unit-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r portfolio/backend/requirements.txt
+      - name: Run pytest
+        run: |
+          cd portfolio/backend
+          pytest -q --maxfail=1 --disable-warnings --cov=app --cov-report=xml:coverage.xml --cov-report=term
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage
+          path: portfolio/backend/coverage.xml
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: unit
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-integration-${{ hashFiles('portfolio/backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-integration-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r portfolio/backend/requirements.txt
+      - name: Run integration tests
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/app
+        run: |
+          cd portfolio/backend
+          pytest tests/test_integration.py -q --maxfail=1 --disable-warnings --cov=app --cov-report=xml:integration-coverage.xml
+      - name: Upload integration coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-coverage
+          path: portfolio/backend/integration-coverage.xml
+
+  e2e:
+    name: Playwright E2E (skeleton)
+    runs-on: ubuntu-latest
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install frontend dependencies
+        run: |
+          cd portfolio/frontend
+          npm ci || npm install
+      - name: Playwright stub
+        run: |
+          if [ -d "portfolio/e2e" ]; then
+            cd portfolio/e2e
+            npx playwright install --with-deps
+            npx playwright test || true
+          else
+            echo "Playwright tests not yet implemented" | tee playwright.txt
+          fi
+      - name: Upload e2e log
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: |
+            playwright.txt
+          if-no-files-found: ignore
+
+  docker:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    needs: [integration, e2e]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: portfolio/backend
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository }}/backend:latest
+      - name: Build frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: portfolio/frontend
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository }}/frontend:latest
+
+  sbom:
+    name: SBOM Generation
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Generate CycloneDX SBOM (frontend)
+        run: |
+          cd portfolio/frontend
+          npm ci
+          npx @cyclonedx/cyclonedx-npm --output-file ../frontend-sbom.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Generate CycloneDX SBOM (backend)
+        run: |
+          python -m pip install --upgrade pip
+          pip install cyclonedx-bom
+          cd portfolio/backend
+          cyclonedx-py --format json --output ../backend-sbom.json
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            portfolio/frontend-sbom.json
+            portfolio/backend-sbom.json
+
+  deploy_staging:
+    name: Deploy Staging (Helm)
+    runs-on: ubuntu-latest
+    needs: sbom
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Helm upgrade (dry-run)
+        run: |
+          if [ -d "charts/portfolio" ]; then
+            helm upgrade --install portfolio charts/portfolio --namespace staging --dry-run --set image.tag=${{ github.sha }}
+          else
+            echo "Charts/portfolio not present - staging deployment skipped"
+          fi
+
+  performance:
+    name: k6 Performance Tests
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+      - uses: actions/checkout@v4
+      - uses: grafana/setup-k6-action@v1
+      - name: Run k6 smoke test
+        run: |
+          if [ -f "perf/smoke.js" ]; then
+            k6 run perf/smoke.js --vus 5 --duration 30s
+          else
+            echo "No k6 scripts defined" > k6.txt
+          fi
+      - name: Upload k6 results
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-results
+          path: |
+            k6.txt
+          if-no-files-found: ignore
+
+  deploy_prod:
+    name: Deploy Production
+    runs-on: ubuntu-latest
+    needs: [deploy_staging, performance]
+    if: github.event_name == 'release'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Helm upgrade production
+        run: |
+          if [ -d "charts/portfolio" ]; then
+            helm upgrade --install portfolio charts/portfolio --namespace production --set image.tag=${{ github.event.release.tag_name }}
+          else
+            echo "Charts/portfolio not present - production deployment skipped"
+          fi

--- a/portfolio/.pre
+++ b/portfolio/.pre
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks: [{ id: black }]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.6.9
+    hooks: [{ id: ruff }]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks: [{ id: isort }]

--- a/portfolio/Makefile
+++ b/portfolio/Makefile
@@ -1,0 +1,18 @@
+SHELL := /bin/bash
+
+.PHONY: dev up down test fmt build
+
+dev: up
+up:
+docker compose -f compose/docker-compose.yml --env-file compose/.env.example up -d --build
+down:
+docker compose -f compose/docker-compose.yml --env-file compose/.env.example down -v
+test:
+cd backend && pytest -q --maxfail=1 --disable-warnings --cov=app
+fmt:
+ruff check --fix backend || true; black backend || true; isort backend || true
+prettier -w frontend || true; eslint -c frontend/.eslintrc.cjs "frontend/src/**/*.{ts,tsx}" || true
+build:
+cd frontend && npm ci && npm run build
+docker build -t portfolio-frontend:local ./frontend
+docker build -t portfolio-backend:local ./backend

--- a/portfolio/backend/app/auth.py
+++ b/portfolio/backend/app/auth.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta, timezone
+from jose import jwt
+from passlib.hash import bcrypt
+
+SECRET = "CHANGE_ME"
+ALGO = "HS256"
+ACCESS_MIN = 30
+
+
+def hash_pw(pw: str) -> str:
+    return bcrypt.hash(pw)
+
+
+def verify_pw(pw: str, hashed: str) -> bool:
+    return bcrypt.verify(pw, hashed)
+
+
+def make_token(sub: str) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {"sub": sub, "iat": int(now.timestamp()), "exp": int((now + timedelta(minutes=ACCESS_MIN)).timestamp())}
+    return jwt.encode(payload, SECRET, algorithm=ALGO)

--- a/portfolio/backend/app/db.py
+++ b/portfolio/backend/app/db.py
@@ -1,0 +1,25 @@
+import os
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import StaticPool
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+
+if DATABASE_URL.startswith("sqlite"):
+    engine = create_async_engine(
+        DATABASE_URL,
+        future=True,
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+else:
+    engine = create_async_engine(DATABASE_URL, future=True, echo=False)
+
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+Base = declarative_base()
+
+
+async def get_session() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session

--- a/portfolio/backend/app/deps.py
+++ b/portfolio/backend/app/deps.py
@@ -1,0 +1,15 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+SECRET = "CHANGE_ME"
+ALGO = "HS256"
+
+
+def current_user_id(token: str = Depends(oauth2_scheme)) -> str:
+    try:
+        payload = jwt.decode(token, SECRET, algorithms=[ALGO])
+        return payload.get("sub")
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")

--- a/portfolio/backend/app/main.py
+++ b/portfolio/backend/app/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from .db import Base, engine, get_session
+from .models import User
+from .schemas import UserCreate, Token
+from .auth import hash_pw, verify_pw, make_token
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.ext.asyncio import AsyncSession
+
+app = FastAPI(title="Portfolio API")
+
+
+@app.on_event("startup")
+async def on_startup():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/api/auth/register", status_code=201)
+async def register(payload: UserCreate, db: AsyncSession = Depends(get_session)):
+    user = User(email=payload.email, password_hash=hash_pw(payload.password))
+    db.add(user)
+    try:
+        await db.commit()
+        await db.refresh(user)
+        return {"id": user.id, "email": user.email}
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Email exists")
+
+
+@app.post("/api/auth/login", response_model=Token)
+async def login(form: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_session)):
+    res = await db.execute(select(User).where(User.email == form.username))
+    user = res.scalar_one_or_none()
+    if not user or not verify_pw(form.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Bad credentials")
+    return {"access_token": make_token(str(user.id))}

--- a/portfolio/backend/app/models.py
+++ b/portfolio/backend/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import String, Integer
+from .db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    password_hash: Mapped[str] = mapped_column(String(255))

--- a/portfolio/backend/app/schemas.py
+++ b/portfolio/backend/app/schemas.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/portfolio/backend/requirements.txt
+++ b/portfolio/backend/requirements.txt
@@ -1,0 +1,11 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pydantic==2.9.2
+SQLAlchemy==2.0.36
+asyncpg==0.29.0
+alembic==1.13.2
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+httpx==0.27.2
+pytest==8.3.3
+pytest-asyncio==0.24.0

--- a/portfolio/backend/tests/test_integration.py
+++ b/portfolio/backend/tests/test_integration.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+
+# Ensure the app uses an isolated SQLite database for test runs.
+_fd, _path = tempfile.mkstemp(prefix="portfolio-test-", suffix=".sqlite")
+os.close(_fd)
+os.environ.setdefault("DATABASE_URL", f"sqlite+aiosqlite:///{_path}")
+
+from app.main import app  # noqa: E402  (import after env setup)
+
+
+@pytest.mark.asyncio
+async def test_complete_user_workflow():
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        r = await client.post(
+            "/api/auth/register",
+            json={"email": "workflow@example.com", "password": "workflowpass123"},
+        )
+        assert r.status_code == status.HTTP_201_CREATED
+        r = await client.post(
+            "/api/auth/login",
+            data={"username": "workflow@example.com", "password": "workflowpass123"},
+        )
+        assert r.status_code == status.HTTP_200_OK
+        token = r.json()["access_token"]
+        assert isinstance(token, str) and token

--- a/portfolio/compose/.env.example
+++ b/portfolio/compose/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8000

--- a/portfolio/compose/docker-compose.yml
+++ b/portfolio/compose/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  backend:
+    image: portfolio-backend:local
+    build: ../backend
+    ports: ["8000:8000"]
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/app
+    depends_on: [postgres]
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+  frontend:
+    image: portfolio-frontend:local
+    build: ../frontend
+    ports: ["5173:80"]
+    environment:
+      - VITE_API_BASE=http://localhost:8000
+    depends_on: [backend]
+  postgres:
+    image: postgres:16
+    ports: ["5432:5432"]
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app

--- a/portfolio/frontend/.eslintrc.cjs
+++ b/portfolio/frontend/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['dist', 'node_modules'],
+};

--- a/portfolio/frontend/Dockerfile
+++ b/portfolio/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine as builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK CMD wget -q -O- http://localhost/health || exit 1
+CMD ["nginx","-g","daemon off;"]

--- a/portfolio/frontend/index.html
+++ b/portfolio/frontend/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Portfolio</title></head>
+  <body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body>
+</html>

--- a/portfolio/frontend/nginx.conf
+++ b/portfolio/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+  location / { try_files $uri $uri/ /index.html; }
+  location /health { return 200 "ok\n"; add_header Content-Type text/plain; }
+  location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+  }
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer-when-downgrade" always;
+  gzip on; gzip_types text/plain text/css application/json application/javascript;
+}

--- a/portfolio/frontend/package.json
+++ b/portfolio/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "portfolio-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5173"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "tailwindcss": "^3.4.13",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "@types/node": "^20.11.30",
+    "eslint": "^9.12.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@typescript-eslint/parser": "^7.16.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.0"
+  }
+}

--- a/portfolio/frontend/postcss.config.cjs
+++ b/portfolio/frontend/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/portfolio/frontend/src/App.tsx
+++ b/portfolio/frontend/src/App.tsx
@@ -1,0 +1,7 @@
+import { useEffect, useState } from 'react'
+import axios from './lib/api'
+export default function App(){
+  const [status,setStatus]=useState('loading')
+  useEffect(()=>{ axios.get('/health').then(res=>setStatus(res.data.status)).catch(()=>setStatus('down')) },[])
+  return <main style={{padding:24}}><h1>Portfolio Frontend</h1><p>API status: {status}</p></main>
+}

--- a/portfolio/frontend/src/lib/api.ts
+++ b/portfolio/frontend/src/lib/api.ts
@@ -1,0 +1,3 @@
+import axios from 'axios'
+const api = axios.create({ baseURL: import.meta.env.VITE_API_BASE || 'http://localhost:8000' })
+export default api

--- a/portfolio/frontend/src/main.tsx
+++ b/portfolio/frontend/src/main.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+createRoot(document.getElementById('root')!).render(<BrowserRouter><App/></BrowserRouter>)

--- a/portfolio/frontend/tailwind.config.ts
+++ b/portfolio/frontend/tailwind.config.ts
@@ -1,0 +1,1 @@
+export default { content: ['./index.html','./src/**/*.{ts,tsx}'], theme: { extend: {} }, plugins: [] }

--- a/portfolio/frontend/vite.config.ts
+++ b/portfolio/frontend/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+export default defineConfig({ plugins: [react()], server: { port: 5173 } })

--- a/portfolio/infra/backend.tf
+++ b/portfolio/infra/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "portfolio-terraform-state"
+    key            = "portfolio/terraform.tfstate"
+    region         = "us-west-2"
+    encrypt        = true
+    dynamodb_table = "portfolio-terraform-locks"
+  }
+}

--- a/portfolio/infra/main.tf
+++ b/portfolio/infra/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = { source = "hashicorp/aws", version="~>5.0" }
+    random = { source = "hashicorp/random", version="~>3.6" }
+  }
+}
+module "network" {
+  source             = "./modules/network"
+  project_name       = var.project_name
+  environment        = var.environment
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = var.availability_zones
+}

--- a/portfolio/infra/modules/network/main.tf
+++ b/portfolio/infra/modules/network/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers { aws = { source = "hashicorp/aws", version="~>5.0" } }
+}
+provider "aws" { region = "us-west-2" }
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = { Name = "${var.project_name}-${var.environment}-vpc" }
+}
+
+resource "aws_internet_gateway" "igw" { vpc_id = aws_vpc.main.id }
+
+resource "aws_subnet" "public" {
+  count                   = length(var.availability_zones)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+  tags = { Name = "${var.project_name}-${var.environment}-public-${count.index+1}", Tier="public" }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone = var.availability_zones[count.index]
+  tags = { Name = "${var.project_name}-${var.environment}-private-${count.index+1}", Tier="private" }
+}

--- a/portfolio/infra/outputs.tf
+++ b/portfolio/infra/outputs.tf
@@ -1,0 +1,1 @@
+output "vpc_id" { value = module.network.vpc_id }

--- a/portfolio/infra/variables.tf
+++ b/portfolio/infra/variables.tf
@@ -1,0 +1,6 @@
+variable "project_name" { type = string  default = "portfolio" }
+variable "environment"  { type = string  default = "dev" }
+variable "vpc_cidr"     { type = string  default = "10.10.0.0/16" }
+variable "availability_zones" { type = list(string) default = ["us-west-2a","us-west-2b"] }
+variable "enable_nat_gateway" { type = bool default = true }
+variable "enable_vpn_gateway" { type = bool default = false }

--- a/prompts/agents.json
+++ b/prompts/agents.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "InstructionalExplainer",
+    "description": "Transforms technical changes into step-by-step explainers for broad audiences.",
+    "input": "Engineering change log, feature diff, or task summary requiring explanation.",
+    "output": "Narrative walkthrough highlighting goals, rationale, and how-to guidance.",
+    "approach": "Summarize context, outline sequence of actions, emphasize purpose of each step, and end with next-step suggestions.",
+    "tools": ["markdown", "glossary_lookup"]
+  },
+  {
+    "name": "TechGuideWriter",
+    "description": "Produces implementation guides and runbooks for developers and operators.",
+    "input": "System design notes, API references, or operational procedures needing documentation.",
+    "output": "Structured guide with prerequisites, commands, verification steps, and rollback notes.",
+    "approach": "Gather requirements, map dependencies, document commands/configs, and validate against acceptance criteria.",
+    "tools": ["shell", "diagramming", "code_snippets"]
+  },
+  {
+    "name": "DiagramBuilder",
+    "description": "Creates architectural diagrams and visual system breakdowns from textual requirements.",
+    "input": "Architecture descriptions, deployment topologies, or workflow narratives.",
+    "output": "Diagram specification outlining components, relationships, and annotations.",
+    "approach": "Identify key actors, map data flows, choose appropriate diagram style, and define node/edge labels.",
+    "tools": ["mermaid", "plantuml", "drawio"]
+  }
+]

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,0 +1,69 @@
+"""Generate the starter Portfolio monorepo tree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def write(path: Path, content: str) -> None:
+    """Create ``path`` and populate it with ``content``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.strip("\n") + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    readme = """# Portfolio Monorepo Starter\n\nGenerated project skeleton with FastAPI backend, React frontend, and infrastructure helpers."""
+    write(ROOT / "README.md", readme)
+
+    write(
+        ROOT / "portfolio/Makefile",
+        """SHELL := /bin/bash\n\n.PHONY: dev up down test fmt build\n\ndev: up\nup:\n\tdocker compose -f compose/docker-compose.yml --env-file compose/.env.example up -d --build\ndown:\n\tdocker compose -f compose/docker-compose.yml --env-file compose/.env.example down -v\ntest:\n\tcd backend && pytest -q --maxfail=1 --disable-warnings --cov=app\nfmt:\n\truff check --fix backend || true; black backend || true; isort backend || true\n\tprettier -w frontend || true; eslint -c frontend/.eslintrc.cjs \"frontend/src/**/*.{ts,tsx}\" || true\nbuild:\n\tcd frontend && npm ci && npm run build\n\tdocker build -t portfolio-frontend:local ./frontend\n\tdocker build -t portfolio-backend:local ./backend""",
+    )
+
+    write(
+        ROOT / "portfolio/backend/app/main.py",
+        """from fastapi import FastAPI, Depends, HTTPException\nfrom sqlalchemy import select\nfrom sqlalchemy.exc import IntegrityError\nfrom .db import Base, engine, get_session\nfrom .models import User\nfrom .schemas import UserCreate, Token\nfrom .auth import hash_pw, verify_pw, make_token\nfrom fastapi.security import OAuth2PasswordRequestForm\nfrom sqlalchemy.ext.asyncio import AsyncSession\n\napp = FastAPI(title=\"Portfolio API\")\n\n\n@app.on_event(\"startup\")\nasync def on_startup():\n    async with engine.begin() as conn:\n        await conn.run_sync(Base.metadata.create_all)\n\n\n@app.get(\"/health\")\ndef health():\n    return {\"status\": \"ok\"}\n\n\n@app.post(\"/api/auth/register\", status_code=201)\nasync def register(payload: UserCreate, db: AsyncSession = Depends(get_session)):\n    user = User(email=payload.email, password_hash=hash_pw(payload.password))\n    db.add(user)\n    try:\n        await db.commit()\n        await db.refresh(user)\n        return {\"id\": user.id, \"email\": user.email}\n    except IntegrityError:\n        await db.rollback()\n        raise HTTPException(status_code=409, detail=\"Email exists\")\n\n\n@app.post(\"/api/auth/login\", response_model=Token)\nasync def login(form: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_session)):\n    res = await db.execute(select(User).where(User.email == form.username))\n    user = res.scalar_one_or_none()\n    if not user or not verify_pw(form.password, user.password_hash):\n        raise HTTPException(status_code=401, detail=\"Bad credentials\")\n    return {\"access_token\": make_token(str(user.id))}""",
+    )
+
+    write(
+        ROOT / "portfolio/backend/app/db.py",
+        """from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker\nfrom sqlalchemy.orm import declarative_base\n\nDATABASE_URL = \"postgresql+asyncpg://postgres:postgres@postgres:5432/app\"\nengine = create_async_engine(DATABASE_URL, future=True, echo=False)\nSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)\nBase = declarative_base()\n\n\nasync def get_session() -> AsyncSession:\n    async with SessionLocal() as session:\n        yield session""",
+    )
+
+    write(
+        ROOT / "portfolio/frontend/src/App.tsx",
+        """import { useEffect, useState } from 'react'\nimport axios from './lib/api'\nexport default function App(){\n  const [status,setStatus]=useState('loading')\n  useEffect(()=>{ axios.get('/health').then(res=>setStatus(res.data.status)).catch(()=>setStatus('down')) },[])\n  return <main style={{padding:24}}><h1>Portfolio Frontend</h1><p>API status: {status}</p></main>\n}""",
+    )
+
+    write(
+        ROOT / "portfolio/frontend/src/main.tsx",
+        """import React from 'react'\nimport { createRoot } from 'react-dom/client'\nimport { BrowserRouter } from 'react-router-dom'\nimport App from './App'\ncreateRoot(document.getElementById('root')!).render(<BrowserRouter><App/></BrowserRouter>)""",
+    )
+
+    write(
+        ROOT / "portfolio/frontend/src/lib/api.ts",
+        """import axios from 'axios'\nconst api = axios.create({ baseURL: import.meta.env.VITE_API_BASE || 'http://localhost:8000' })\nexport default api""",
+    )
+
+    write(
+        ROOT / "portfolio/frontend/index.html",
+        """<!doctype html>\n<html>\n  <head><meta charset=\"UTF-8\" /><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /><title>Portfolio</title></head>\n  <body><div id=\"root\"></div><script type=\"module\" src=\"/src/main.tsx\"></script></body>\n</html>""",
+    )
+
+    write(
+        ROOT / "portfolio/compose/docker-compose.yml",
+        """services:\n  backend:\n    image: portfolio-backend:local\n    build: ../backend\n    ports: [\"8000:8000\"]\n    environment:\n      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/app\n    depends_on: [postgres]\n    command: uvicorn app.main:app --host 0.0.0.0 --port 8000\n  frontend:\n    image: portfolio-frontend:local\n    build: ../frontend\n    ports: [\"5173:80\"]\n    environment:\n      - VITE_API_BASE=http://localhost:8000\n    depends_on: [backend]\n  postgres:\n    image: postgres:16\n    ports: [\"5432:5432\"]\n    environment:\n      POSTGRES_USER: postgres\n      POSTGRES_PASSWORD: postgres\n      POSTGRES_DB: app""",
+    )
+
+    write(ROOT / "portfolio/compose/.env.example", "VITE_API_BASE=http://localhost:8000")
+
+
+def __main__() -> None:  # pragma: no cover - backward compat shim
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dupefinder/README.md
+++ b/tools/dupefinder/README.md
@@ -1,0 +1,30 @@
+# DupeFinder
+
+Minimal toolkit for indexing media libraries and surfacing potential duplicates.
+
+## Installation
+
+```bash
+pip install -r tools/dupefinder/requirements.txt
+```
+
+Optional extras (CLIP, pHash, Chromaprint, FAISS) are detected automatically when installed.
+
+## Usage
+
+```bash
+python -m tools.dupefinder.cli index /mnt/media --db dupefinder.db
+python -m tools.dupefinder.cli match --threshold 0.85 --db dupefinder.db
+```
+
+## Development
+
+- Database models live in `tools/dupefinder/models.py`
+- Matching heuristics are in `tools/dupefinder/service.py`
+- CLI entrypoint is `tools/dupefinder/cli.py`
+
+Run tests with:
+
+```bash
+pytest -q
+```

--- a/tools/dupefinder/__init__.py
+++ b/tools/dupefinder/__init__.py
@@ -1,0 +1,5 @@
+"""Media duplicate finder toolkit."""
+
+from .service import DupeFinderService
+
+__all__ = ["DupeFinderService"]

--- a/tools/dupefinder/audiofp.py
+++ b/tools/dupefinder/audiofp.py
@@ -1,0 +1,25 @@
+"""Audio fingerprint helpers with optional Chromaprint support."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Optional, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import acoustid
+    import chromaprint
+except Exception:  # noqa: BLE001 - optional dependencies may be missing
+    acoustid = None  # type: ignore
+    chromaprint = None  # type: ignore
+
+
+def compute_fingerprint(path: Path) -> Tuple[Optional[str], Optional[int]]:
+    """Return a Chromaprint-style fingerprint when available, else a stub hash."""
+
+    if acoustid is not None and chromaprint is not None:  # pragma: no cover
+        duration, fp = acoustid.fingerprint_file(str(path))
+        return fp, duration
+    data = path.read_bytes()
+    digest = hashlib.md5(data).hexdigest()
+    return digest[:32], None

--- a/tools/dupefinder/cli.py
+++ b/tools/dupefinder/cli.py
@@ -1,0 +1,53 @@
+"""Command line interface for the duplicate finder service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import typer
+
+from .service import DupeFinderService
+
+app = typer.Typer(help="Media duplicate finder utilities")
+
+
+def _service(db: Path) -> DupeFinderService:
+    database_url = f"sqlite:///{db}" if db != Path(":memory:") else "sqlite:///:memory:"
+    return DupeFinderService(database_url=database_url)
+
+
+@app.command()
+def index(
+    path: Path = typer.Argument(..., exists=True, file_okay=False, readable=True),
+    db: Path = typer.Option(Path("dupefinder.db"), "--db", help="SQLite database location."),
+) -> None:
+    """Index all media files within ``path``."""
+
+    service = _service(db.resolve())
+    count = service.index_path(path.resolve())
+    typer.echo(f"Indexed {count} files from {path}")
+
+
+@app.command()
+def match(
+    threshold: float = typer.Option(0.85, min=0.0, max=1.0, help="Similarity threshold."),
+    db: Path = typer.Option(Path("dupefinder.db"), "--db", help="SQLite database location."),
+) -> None:
+    """Find potential duplicates and print them to stdout."""
+
+    service = _service(db.resolve())
+    results = service.match(threshold=threshold)
+    if not results:
+        typer.echo("No potential duplicates found.")
+        raise typer.Exit(code=0)
+    for group in results:
+        typer.echo(f"{group.score:.2f}\t{group.reason}\t{', '.join(group.paths)}")
+
+
+def main() -> None:
+    """Entry point allowing invocation from ``python -m``."""
+
+    app(standalone_mode=True, prog_name="dupefinder")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/dupefinder/embeddings.py
+++ b/tools/dupefinder/embeddings.py
@@ -1,0 +1,63 @@
+"""Lightweight embedding helpers with optional CLIP integration."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+    import torch
+    from transformers import CLIPModel, CLIPProcessor
+except Exception:  # noqa: BLE001 - intentional broad catch for optional deps
+    Image = None  # type: ignore
+    CLIPModel = None  # type: ignore
+    CLIPProcessor = None  # type: ignore
+    torch = None  # type: ignore
+
+_MODEL = None
+_PROCESSOR = None
+
+
+def _load_clip() -> bool:
+    """Attempt to lazily load CLIP if available."""
+
+    global _MODEL, _PROCESSOR
+    if CLIPModel is None or CLIPProcessor is None or torch is None:
+        return False
+    if _MODEL is None or _PROCESSOR is None:
+        _MODEL = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")  # pragma: no cover - heavy path
+        _PROCESSOR = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+    return True
+
+
+def embed_path(path: Path) -> Optional[List[float]]:
+    """Generate a deterministic embedding for a file.
+
+    Falls back to a stable hash-based embedding when CLIP is unavailable.
+    """
+
+    if Image is not None and _load_clip():  # pragma: no cover - requires heavy deps
+        image = Image.open(path)
+        inputs = _PROCESSOR(images=image, return_tensors="pt")
+        outputs = _MODEL.get_image_features(**inputs)
+        return outputs.detach().numpy().flatten().tolist()
+    data = path.read_bytes()
+    digest = hashlib.sha256(data).digest()
+    return [int(b) / 255 for b in digest[:16]]
+
+
+def cosine_similarity(a: Iterable[float], b: Iterable[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+
+    vec_a = list(a)
+    vec_b = list(b)
+    if not vec_a or not vec_b or len(vec_a) != len(vec_b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(vec_a, vec_b))
+    norm_a = sum(x * x for x in vec_a) ** 0.5
+    norm_b = sum(y * y for y in vec_b) ** 0.5
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/tools/dupefinder/indexer.py
+++ b/tools/dupefinder/indexer.py
@@ -1,0 +1,44 @@
+"""Vector index abstraction with optional FAISS/HNSW backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore
+except Exception:  # noqa: BLE001
+    faiss = None  # type: ignore
+
+from .embeddings import cosine_similarity
+
+
+@dataclass
+class SimpleVectorIndex:
+    """In-memory fallback index used when FAISS/HNSW is unavailable."""
+
+    dimension: int
+    items: Dict[str, List[float]] = field(default_factory=dict)
+
+    def add(self, key: str, vector: Iterable[float]) -> None:
+        data = list(vector)
+        if len(data) != self.dimension:
+            raise ValueError("vector dimension mismatch")
+        self.items[key] = data
+
+    def query(self, vector: Iterable[float], k: int = 5) -> List[Tuple[str, float]]:
+        probe = list(vector)
+        if len(probe) != self.dimension:
+            return []
+        scores = [(key, cosine_similarity(probe, vec)) for key, vec in self.items.items()]
+        scores.sort(key=lambda item: item[1], reverse=True)
+        return scores[:k]
+
+
+def create_index(dimension: int):
+    """Create a FAISS index if available, otherwise fall back to the simple implementation."""
+
+    if faiss is not None:  # pragma: no cover - heavy dep
+        index = faiss.IndexFlatIP(dimension)
+        return index
+    return SimpleVectorIndex(dimension)

--- a/tools/dupefinder/models.py
+++ b/tools/dupefinder/models.py
@@ -1,0 +1,58 @@
+"""Database models for the duplicate finder."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy import DateTime, String, create_engine, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
+
+
+class Base(DeclarativeBase):
+    """Declarative base used across the package."""
+
+
+class MediaItem(Base):
+    """Represents a single indexed media asset."""
+
+    __tablename__ = "media_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    path: Mapped[str] = mapped_column(String(512), unique=True, index=True)
+    size: Mapped[int] = mapped_column(default=0)
+    sha1: Mapped[str | None] = mapped_column(String(40), index=True)
+    phash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    kind: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+def get_engine(database_url: str):
+    """Return a SQLAlchemy engine, ensuring parent directories exist for SQLite paths."""
+
+    if database_url.startswith("sqlite"):
+        if database_url == "sqlite:///:memory:":
+            return create_engine(database_url, future=True)
+        path = database_url.split("sqlite:///", maxsplit=1)[-1]
+        if path:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+    return create_engine(database_url, future=True)
+
+
+def get_session(database_url: str) -> Generator[Session, None, None]:
+    """Yield a session connected to the provided database URL."""
+
+    engine = get_engine(database_url)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/tools/dupefinder/phash.py
+++ b/tools/dupefinder/phash.py
@@ -1,0 +1,25 @@
+"""Perceptual hashing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+    import imagehash
+except Exception:  # noqa: BLE001 - broad for optional deps
+    Image = None  # type: ignore
+    imagehash = None  # type: ignore
+
+
+def compute_phash(path: Path) -> Optional[str]:
+    """Compute a perceptual hash if dependencies are available."""
+
+    if imagehash is not None and Image is not None:  # pragma: no cover
+        with Image.open(path) as img:
+            return str(imagehash.phash(img))
+    # Fallback to a deterministic but simple hash for testability.
+    digest = hashlib.sha1(path.read_bytes()).hexdigest()
+    return digest[:16]

--- a/tools/dupefinder/requirements.txt
+++ b/tools/dupefinder/requirements.txt
@@ -1,0 +1,4 @@
+typer==0.12.5
+SQLAlchemy==2.0.36
+# Optional extras (install manually if needed):
+# Pillow, imagehash, acoustid, chromaprint, faiss-cpu, torch, transformers

--- a/tools/dupefinder/service.py
+++ b/tools/dupefinder/service.py
@@ -1,0 +1,109 @@
+"""High level orchestration for indexing and duplicate detection."""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import MediaItem, get_session
+from .phash import compute_phash
+
+
+@dataclass
+class MatchResult:
+    """Represents a potential duplicate group."""
+
+    paths: List[str]
+    score: float
+    reason: str
+
+
+class DupeFinderService:
+    """Service responsible for indexing and matching media files."""
+
+    def __init__(self, database_url: str = "sqlite:///:memory:") -> None:
+        self.database_url = database_url
+
+    @contextmanager
+    def _session(self) -> Iterator[Session]:
+        generator = get_session(self.database_url)
+        session = next(generator)
+        try:
+            yield session
+            session.commit()
+        except Exception:  # noqa: BLE001 - ensure rollback on any failure
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def index_path(self, root: Path) -> int:
+        """Index every file under ``root`` recursively."""
+
+        if not root.exists():
+            raise FileNotFoundError(root)
+        files = [p for p in root.rglob("*") if p.is_file()]
+        if not files:
+            return 0
+        with self._session() as session:
+            count = 0
+            for file_path in files:
+                record = session.scalar(select(MediaItem).where(MediaItem.path == str(file_path)))
+                if record is None:
+                    record = MediaItem(path=str(file_path))
+                stat = file_path.stat()
+                record.size = stat.st_size
+                record.sha1 = hashlib.sha1(file_path.read_bytes()).hexdigest()
+                record.phash = compute_phash(file_path)
+                record.kind = file_path.suffix.lower().lstrip(".") or None
+                session.add(record)
+                count += 1
+            return count
+
+    def match(self, threshold: float = 0.85) -> List[MatchResult]:
+        """Return possible duplicates with a configurable similarity threshold."""
+
+        with self._session() as session:
+            items = session.scalars(select(MediaItem)).all()
+        if not items:
+            return []
+        results: List[MatchResult] = []
+        by_hash: Dict[str, List[MediaItem]] = {}
+        for item in items:
+            if item.sha1:
+                by_hash.setdefault(item.sha1, []).append(item)
+        for sha, group in by_hash.items():
+            if len(group) > 1:
+                results.append(
+                    MatchResult(paths=[entry.path for entry in group], score=1.0, reason=f"sha1:{sha}")
+                )
+        if threshold >= 1.0:
+            return results
+        # Approximate matches using perceptual hash similarity when available.
+        phashed = [item for item in items if item.phash]
+        for left, right in itertools.combinations(phashed, 2):
+            score = _phash_similarity(left.phash, right.phash)
+            if score >= threshold:
+                pair = sorted({left.path, right.path})
+                if not any(set(pair).issubset(set(result.paths)) and result.score >= score for result in results):
+                    results.append(MatchResult(paths=pair, score=score, reason="phash"))
+        results.sort(key=lambda item: item.score, reverse=True)
+        return results
+
+
+def _phash_similarity(left: str | None, right: str | None) -> float:
+    """Compute a similarity ratio between two hexadecimal hashes."""
+
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    left_bits = bin(int(left, 16))[2:].zfill(len(left) * 4)
+    right_bits = bin(int(right, 16))[2:].zfill(len(right) * 4)
+    matches = sum(l == r for l, r in zip(left_bits, right_bits))
+    return matches / len(left_bits)

--- a/tools/dupefinder/tests/test_basic.py
+++ b/tools/dupefinder/tests/test_basic.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from tools.dupefinder.cli import app
+from tools.dupefinder.service import DupeFinderService
+
+
+def _write_file(path: Path, content: bytes) -> None:
+    path.write_bytes(content)
+
+
+def test_service_index_and_match(tmp_path):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    _write_file(media_dir / "photo1.jpg", b"duplicate content")
+    _write_file(media_dir / "photo2.jpg", b"duplicate content")
+    _write_file(media_dir / "unique.png", b"unique content")
+
+    db_path = tmp_path / "dupes.sqlite"
+    service = DupeFinderService(database_url=f"sqlite:///{db_path}")
+    indexed = service.index_path(media_dir)
+    assert indexed == 3
+
+    matches = service.match(threshold=0.85)
+    assert matches, "Expected at least one duplicate suggestion"
+    assert any(len(result.paths) >= 2 for result in matches)
+
+
+def test_cli_integration(tmp_path):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    _write_file(media_dir / "song1.mp3", b"audio sample")
+    _write_file(media_dir / "song1_copy.mp3", b"audio sample")
+
+    db = tmp_path / "cli.sqlite"
+    runner = CliRunner()
+    result_index = runner.invoke(app, ["index", str(media_dir), "--db", str(db)])
+    assert result_index.exit_code == 0
+    assert "Indexed 2 files" in result_index.stdout
+
+    result_match = runner.invoke(app, ["match", "--db", str(db), "--threshold", "0.8"])
+    assert result_match.exit_code == 0
+    assert "song1.mp3" in result_match.stdout
+    assert "song1_copy.mp3" in result_match.stdout


### PR DESCRIPTION
## Summary
- scaffold backend FastAPI API, frontend React app, Docker compose stack, and Terraform infrastructure skeleton under `portfolio/`
- add comprehensive CI workflow covering linting, testing, security scans, container builds, SBOM generation, and staged deployments
- introduce documentation artifacts, reusable prompt agents, dupefinder Python toolkit with CLI/tests, and bootstrap generator script

## Testing
- pytest -q *(fails: missing Python dependencies due to offline package index access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c3b8393c8327b1e6e5a2d34e11e7