### PR TITLE
Move backend guidance into private notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+*.egg-info/
+dist/
+build/
+
+# Node
+node_modules/
+dist/
+build/
+*.log
+.env.local
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+
+# Environment
+.env
+*.env
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+
+# Docker
+*.log

--- a/.internal/backend_notes.md
+++ b/.internal/backend_notes.md
@@ -1,0 +1,33 @@
+# Backend Maintenance Notes (Internal)
+
+This document captures the rationale behind the trimmed in-code comments.
+Keep it private to the team; do not publish externally.
+
+## Configuration
+- `app/config.py` exposes the `Settings` object consumed throughout the
+  application. Set `DATABASE_URL` to either an asyncpg or aiosqlite DSN.
+- The `testing` flag disables startup/shutdown hooks so pytest can swap the
+  database dependency safely.
+
+## Database Layer
+- `app/database.py` builds an async engine. SQLite runs with `StaticPool` and
+  `check_same_thread=False` to share connections across tasks.
+- `get_db()` wraps each request in a transaction. Commit happens on success and
+  a rollback is issued on failure.
+
+## Authentication Helpers
+- `app/auth.py` centralises password hashing (bcrypt) and JWT handling. Tokens
+  carry a `sub` claim that matches the user email.
+
+## HTTP Layer
+- `app/routers/` contains the FastAPI routers. Health probes expose readiness
+  checks, auth exposes registration/login, and content implements CRUD with
+  access control (owners see drafts; anonymous users see published records).
+
+## Testing
+- `backend/tests/conftest.py` provisions an in-memory SQLite database, toggles
+  `settings.testing`, and overrides `get_db` so API tests run against the
+  ephemeral schema.
+- Auth/content/health tests ensure the main workflows continue to operate.
+
+Update this document whenever the architecture changes materially.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,24 @@
+# Application Settings
+APP_NAME=Portfolio API
+DEBUG=False
+VERSION=1.0.0
+TESTING=False
+
+# Server Settings
+HOST=0.0.0.0
+PORT=8000
+RELOAD=False
+
+# Database Settings
+DATABASE_URL=postgresql+asyncpg://portfolio_user:securepassword@localhost:5432/portfolio_db
+
+# Security Settings (CHANGE THESE!)
+SECRET_KEY=your-secret-key-min-32-characters-long-change-this-in-production
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+# CORS Settings
+CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
+
+# Logging
+LOG_LEVEL=INFO

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application package initialisation."""
+
+from app.main import app
+
+__all__ = ["app"]

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,60 @@
+"""Authentication helpers for password hashing and JWT handling."""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import HTTPException, status
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from app.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=12)
+
+
+def hash_password(password: str) -> str:
+    """Hash a plain text password using bcrypt."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Compare a plain password to a stored bcrypt hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Generate a signed JWT access token with the supplied payload."""
+    to_encode = data.copy()
+    if expires_delta is not None:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
+
+    to_encode.update({"exp": expire, "iat": datetime.utcnow()})
+
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+
+
+def decode_access_token(token: str) -> dict:
+    """Validate and decode a JWT token returning its payload."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    except JWTError as exc:  # pragma: no cover - defensive
+        raise credentials_exception from exc
+
+    subject = payload.get("sub")
+    if subject is None:
+        raise credentials_exception
+
+    return payload
+
+
+def get_password_hash_info(hashed_password: str) -> dict:
+    """Return metadata embedded in a bcrypt hash (for diagnostics/tests)."""
+    return pwd_context.hash_info(hashed_password)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,64 @@
+"""Application configuration management."""
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    app_name: str = Field(default="Portfolio API", description="Application name")
+    debug: bool = Field(default=False, description="Debug mode flag")
+    testing: bool = Field(default=False, description="Testing mode flag")
+    version: str = Field(default="1.0.0", description="API version")
+
+    host: str = Field(default="0.0.0.0", description="Server bind address")
+    port: int = Field(default=8000, description="Server port")
+    reload: bool = Field(default=False, description="Auto-reload on code changes")
+
+    database_url: str = Field(
+        ..., description="PostgreSQL connection URL",
+        examples=["postgresql+asyncpg://user:pass@localhost:5432/dbname"],
+    )
+
+    secret_key: str = Field(
+        ..., min_length=32, description="Secret key for JWT tokens (min 32 characters)"
+    )
+    algorithm: str = Field(default="HS256", description="JWT algorithm")
+    access_token_expire_minutes: int = Field(
+        default=30, description="JWT token expiration in minutes"
+    )
+
+    cors_origins: list[str] = Field(
+        default=["http://localhost:3000", "http://localhost:5173"],
+        description="Allowed CORS origins",
+    )
+
+    log_level: str = Field(default="INFO", description="Logging level")
+
+    @field_validator("database_url")
+    @classmethod
+    def validate_database_url(cls, value: str) -> str:
+        allowed_prefixes = ("postgresql+asyncpg://", "sqlite+aiosqlite://")
+        if not value.startswith(allowed_prefixes):
+            raise ValueError(
+                "DATABASE_URL must use asyncpg (PostgreSQL) or aiosqlite drivers"
+            )
+        return value
+
+    @field_validator("secret_key")
+    @classmethod
+    def validate_secret_key(cls, value: str) -> str:
+        if len(value) < 32:
+            raise ValueError("SECRET_KEY must be at least 32 characters long")
+        return value
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+settings = Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,61 @@
+"""Database configuration and session management."""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings
+
+if settings.database_url.startswith("sqlite+aiosqlite://"):
+    engine = create_async_engine(
+        settings.database_url,
+        echo=settings.debug,
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+else:
+    engine = create_async_engine(
+        settings.database_url,
+        echo=settings.debug,
+        future=True,
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=10,
+    )
+
+AsyncSessionLocal = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
+)
+
+Base = declarative_base()
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Provide a transactional database session for request handlers."""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+
+async def init_db() -> None:
+    """Create all tables defined on the declarative base."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def close_db() -> None:
+    """Dispose of the engine and close all pooled connections."""
+    await engine.dispose()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,106 @@
+"""Reusable FastAPI dependencies for authentication and database access."""
+
+from typing import Annotated, Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import decode_access_token
+from app.database import get_db
+from app.models import User
+
+security = HTTPBearer(
+    scheme_name="Bearer Token",
+    description="Paste a JWT obtained from the /auth/login endpoint",
+)
+optional_security = HTTPBearer(
+    scheme_name="Bearer Token (optional)",
+    auto_error=False,
+    description="Optional JWT token for endpoints that support anonymous access",
+)
+
+
+async def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> User:
+    """Resolve and return the authenticated user from the provided token."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = decode_access_token(credentials.credentials)
+    except HTTPException as exc:  # pragma: no cover - delegated behavior
+        raise exc
+
+    email: Optional[str] = payload.get("sub")
+    if email is None:
+        raise credentials_exception
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        raise credentials_exception
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Inactive user account"
+        )
+
+    return user
+
+
+async def get_current_active_user(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> User:
+    """Ensure the authenticated user has an active account."""
+    if not current_user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inactive user",
+        )
+    return current_user
+
+
+async def get_optional_current_user(
+    credentials: Annotated[Optional[HTTPAuthorizationCredentials], Depends(optional_security)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Optional[User]:
+    """Return the authenticated user if a valid token is supplied, otherwise None."""
+
+    if credentials is None:
+        return None
+
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = decode_access_token(credentials.credentials)
+    except HTTPException as exc:  # pragma: no cover - delegated behavior
+        raise exc
+
+    email: Optional[str] = payload.get("sub")
+    if email is None:
+        raise credentials_exception
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+
+    if user is None or not user.is_active:
+        raise credentials_exception
+
+    return user
+
+
+CurrentUser = Annotated[User, Depends(get_current_user)]
+OptionalCurrentUser = Annotated[Optional[User], Depends(get_optional_current_user)]
+DatabaseSession = Annotated[AsyncSession, Depends(get_db)]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,39 @@
+"""FastAPI application instance and configuration."""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.config import settings
+from app.database import close_db, init_db
+from app.routers import auth, content, health
+
+
+def create_application() -> FastAPI:
+    """Instantiate and configure the FastAPI application."""
+    app = FastAPI(title=settings.app_name, version=settings.version, debug=settings.debug)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.include_router(health.router)
+    app.include_router(auth.router)
+    app.include_router(content.router)
+
+    if not settings.testing:
+        @app.on_event("startup")
+        async def on_startup() -> None:
+            await init_db()
+
+        @app.on_event("shutdown")
+        async def on_shutdown() -> None:
+            await close_db()
+
+    return app
+
+
+app = create_application()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,64 @@
+"""SQLAlchemy ORM models for application entities."""
+
+import uuid
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class User(Base):
+    """User model capturing authentication and profile fields."""
+
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    hashed_password = Column(String(255), nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    content_items = relationship(
+        "Content",
+        back_populates="owner",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<User(id={self.id}, email={self.email})>"
+
+
+class Content(Base):
+    """Content model representing portfolio posts or assets."""
+
+    __tablename__ = "content"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title = Column(String(255), nullable=False)
+    body = Column(Text, nullable=True)
+    owner_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    is_published = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    owner = relationship("User", back_populates="content_items")
+
+    __table_args__ = (Index("ix_content_owner_created", "owner_id", "created_at"),)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Content(id={self.id}, title={self.title})>"

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""Router package exports."""
+
+from . import auth, content, health
+
+__all__ = ["auth", "content", "health"]

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,84 @@
+"""Authentication API endpoints for registration and login."""
+
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import create_access_token, hash_password, verify_password
+from app.config import settings
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models import User
+from app.schemas import Token, UserCreate, UserLogin, UserResponse
+
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+
+@router.post(
+    "/register",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register a new user",
+)
+async def register(user_data: UserCreate, db: AsyncSession = Depends(get_db)) -> User:
+    """Create a new user account if the email address is unused."""
+    result = await db.execute(select(User).where(User.email == user_data.email))
+    existing_user = result.scalar_one_or_none()
+
+    if existing_user is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    new_user = User(email=user_data.email, hashed_password=hash_password(user_data.password))
+    db.add(new_user)
+    await db.commit()
+    await db.refresh(new_user)
+
+    return new_user
+
+
+@router.post(
+    "/login",
+    response_model=Token,
+    status_code=status.HTTP_200_OK,
+    summary="Authenticate a user and return a JWT",
+)
+async def login(credentials: UserLogin, db: AsyncSession = Depends(get_db)) -> Token:
+    """Validate user credentials and issue an access token."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Incorrect email or password",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    result = await db.execute(select(User).where(User.email == credentials.email))
+    user = result.scalar_one_or_none()
+
+    if user is None or not verify_password(credentials.password, user.hashed_password):
+        raise credentials_exception
+
+    if not user.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Account is inactive")
+
+    access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
+    access_token = create_access_token(data={"sub": user.email}, expires_delta=access_token_expires)
+
+    return Token(
+        access_token=access_token,
+        token_type="bearer",
+        expires_in=int(access_token_expires.total_seconds()),
+    )
+
+
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get information about the authenticated user",
+)
+async def get_current_user_info(current_user: User = Depends(get_current_user)) -> User:
+    """Return the profile of the authenticated user."""
+    return current_user

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -1,0 +1,171 @@
+"""Content management API endpoints."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user, get_optional_current_user
+from app.models import Content, User
+from app.schemas import ContentCreate, ContentListResponse, ContentResponse, ContentUpdate
+
+router = APIRouter(prefix="/content", tags=["Content"])
+
+
+@router.get(
+    "",
+    response_model=ContentListResponse,
+    summary="List content items",
+    description="Return a paginated list of content items with optional filters.",
+)
+async def list_content(
+    db: AsyncSession = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_current_user),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(10, ge=1, le=100, description="Items per page"),
+    published_only: bool = Query(True, description="Return only published content"),
+    search: Optional[str] = Query(None, description="Search string for title/body"),
+) -> ContentListResponse:
+    """Return content items visible to the requester."""
+
+    # Start with a base select statement; filters below tailor visibility.
+    base_query = select(Content)
+
+    if current_user is not None:
+        base_query = base_query.where(
+            or_(Content.owner_id == current_user.id, Content.is_published.is_(True))
+        )
+    elif published_only:
+        base_query = base_query.where(Content.is_published.is_(True))
+
+    if search:
+        pattern = f"%{search}%"
+        base_query = base_query.where(
+            or_(Content.title.ilike(pattern), Content.body.ilike(pattern))
+        )
+
+    count_query = select(func.count()).select_from(base_query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    offset = (page - 1) * page_size
+    items_result = await db.execute(
+        base_query.order_by(Content.created_at.desc()).offset(offset).limit(page_size)
+    )
+    items = items_result.scalars().all()
+
+    pages = (total + page_size - 1) // page_size if total else 0
+
+    return ContentListResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=pages,
+    )
+
+
+@router.get(
+    "/{content_id}",
+    response_model=ContentResponse,
+    summary="Retrieve a content item",
+)
+async def get_content(
+    content_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_current_user),
+) -> Content:
+    """Retrieve a single content item respecting publication status."""
+    result = await db.execute(select(Content).where(Content.id == content_id))
+    content = result.scalar_one_or_none()
+
+    if content is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+
+    if not content.is_published and (current_user is None or current_user.id != content.owner_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+
+    return content
+
+
+@router.post(
+    "",
+    response_model=ContentResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create content",
+)
+async def create_content(
+    content_data: ContentCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Content:
+    """Create a new content item owned by the authenticated user."""
+    new_content = Content(**content_data.model_dump(), owner_id=current_user.id)
+    db.add(new_content)
+    await db.commit()
+    await db.refresh(new_content)
+
+    return new_content
+
+
+@router.put(
+    "/{content_id}",
+    response_model=ContentResponse,
+    summary="Update content",
+)
+async def update_content(
+    content_id: UUID,
+    content_data: ContentUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Content:
+    """Update an existing content item if the requester is the owner."""
+    result = await db.execute(select(Content).where(Content.id == content_id))
+    content = result.scalar_one_or_none()
+
+    if content is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+
+    if content.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to update this content",
+        )
+
+    update_fields = content_data.model_dump(exclude_unset=True)
+    for key, value in update_fields.items():
+        setattr(content, key, value)
+
+    await db.commit()
+    await db.refresh(content)
+
+    return content
+
+
+@router.delete(
+    "/{content_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete content",
+)
+async def delete_content(
+    content_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a content item if the requester is the owner."""
+    result = await db.execute(select(Content).where(Content.id == content_id))
+    content = result.scalar_one_or_none()
+
+    if content is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+
+    if content.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to delete this content",
+        )
+
+    await db.delete(content)
+    await db.commit()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,61 @@
+"""Health check endpoints for monitoring systems and load balancers."""
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_db
+from app.schemas import HealthResponse
+
+router = APIRouter(prefix="/health", tags=["Health"])
+
+
+@router.get(
+    "",
+    response_model=HealthResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Service health check",
+    description="Return API status, version, and database connectivity state.",
+)
+async def health_check(db: AsyncSession = Depends(get_db)) -> HealthResponse:
+    """Return health indicators for the service and database."""
+    try:
+        await db.execute(text("SELECT 1"))
+        database_status = "connected"
+        overall_status = "healthy"
+    except Exception:  # pragma: no cover - defensive path
+        database_status = "disconnected"
+        overall_status = "unhealthy"
+
+    return HealthResponse(status=overall_status, version=settings.version, database=database_status)
+
+
+@router.get(
+    "/liveness",
+    status_code=status.HTTP_200_OK,
+    summary="Liveness probe",
+    description="Lightweight probe to confirm the application process is running.",
+)
+async def liveness() -> dict[str, str]:
+    """Return a static response indicating the process is alive."""
+    return {"status": "alive"}
+
+
+@router.get(
+    "/readiness",
+    status_code=status.HTTP_200_OK,
+    summary="Readiness probe",
+    description="Probe used by orchestrators to determine if the service can accept traffic.",
+)
+async def readiness(db: AsyncSession = Depends(get_db)) -> Response:
+    """Return readiness information including database connectivity."""
+    try:
+        await db.execute(text("SELECT 1"))
+        return Response(content='{"status": "ready"}', media_type="application/json")
+    except Exception:  # pragma: no cover - defensive path
+        return Response(
+            content='{"status": "not ready"}',
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,187 @@
+"""Pydantic schemas for validating and serialising API payloads."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator
+
+
+class TimestampMixin(BaseModel):
+    """Mixin providing timestamp fields with ISO8601 serialisation."""
+
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    model_config = ConfigDict(json_encoders={datetime: lambda value: value.isoformat()})
+
+
+class UserBase(BaseModel):
+    """Fields common to multiple user-related payloads."""
+
+    email: EmailStr = Field(..., description="User email address")
+
+    @field_validator("email")
+    @classmethod
+    def normalise_email(cls, value: str) -> str:
+        return value.lower().strip()
+
+
+class UserCreate(UserBase):
+    """Payload for creating a user account."""
+
+    password: str = Field(..., min_length=8, max_length=100, description="User password")
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_strength(cls, value: str) -> str:
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if not any(char.isupper() for char in value):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not any(char.islower() for char in value):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not any(char.isdigit() for char in value):
+            raise ValueError("Password must contain at least one digit")
+        return value
+
+
+class UserLogin(BaseModel):
+    """Payload for user login attempts."""
+
+    email: EmailStr
+    password: str
+
+
+class UserResponse(UserBase, TimestampMixin):
+    """User details returned by the API."""
+
+    id: UUID = Field(..., description="User unique identifier")
+    is_active: bool = Field(..., description="Account activity flag")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserUpdate(BaseModel):
+    """Payload for partial user profile updates."""
+
+    email: Optional[EmailStr] = Field(default=None, description="Updated email address")
+    password: Optional[str] = Field(default=None, min_length=8, description="Updated password")
+
+    @field_validator("password")
+    @classmethod
+    def validate_optional_password(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return UserCreate.validate_password_strength(value)
+
+
+class Token(BaseModel):
+    """Response structure for OAuth2-compatible access tokens."""
+
+    access_token: str
+    token_type: str = Field(default="bearer")
+    expires_in: int
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                "token_type": "bearer",
+                "expires_in": 1800,
+            }
+        }
+    )
+
+
+class TokenData(BaseModel):
+    """Decoded token payload fields utilised internally."""
+
+    email: Optional[str] = None
+    user_id: Optional[UUID] = None
+
+
+class ContentBase(BaseModel):
+    """Fields common across content operations."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    body: Optional[str] = Field(default=None, max_length=10000)
+    is_published: bool = Field(default=False)
+
+
+class ContentCreate(ContentBase):
+    """Payload for creating new content entries."""
+
+    pass
+
+
+class ContentUpdate(BaseModel):
+    """Payload for updating existing content entries."""
+
+    title: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    body: Optional[str] = Field(default=None, max_length=10000)
+    is_published: Optional[bool] = None
+
+
+class ContentResponse(ContentBase, TimestampMixin):
+    """Content item returned by the API."""
+
+    id: UUID
+    owner_id: UUID
+    owner: UserResponse
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ContentListResponse(BaseModel):
+    """Paginated response for content listings."""
+
+    items: list[ContentResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "items": [],
+                "total": 0,
+                "page": 1,
+                "page_size": 10,
+                "pages": 0,
+            }
+        }
+    )
+
+
+class ErrorDetail(BaseModel):
+    """Detailed validation error information."""
+
+    loc: list[str]
+    msg: str
+    type: str
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response envelope."""
+
+    detail: str | list[ErrorDetail]
+
+
+class HealthResponse(BaseModel):
+    """Payload returned by health check endpoints."""
+
+    status: str
+    version: str
+    database: str
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "healthy",
+                "version": "1.0.0",
+                "database": "connected",
+            }
+        }
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,34 @@
+# Web Framework
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+python-multipart==0.0.6
+
+# Database
+sqlalchemy[asyncio]==2.0.23
+asyncpg==0.29.0
+alembic==1.12.1
+
+# Authentication
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+python-dateutil==2.8.2
+
+# Environment
+pydantic==2.5.0
+pydantic-settings==2.1.0
+python-dotenv==1.0.0
+
+# Development
+pytest==7.4.3
+pytest-asyncio==0.21.1
+pytest-cov==4.1.0
+httpx==0.25.1
+faker==20.1.0
+
+# Code Quality
+ruff==0.1.6
+black==23.11.0
+mypy==1.7.1
+
+# Testing
+coverage==7.3.2

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,156 @@
+"""Shared pytest fixtures for FastAPI integration tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import AsyncGenerator, Callable
+from pathlib import Path
+from typing import Awaitable
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+# Ensure the backend package is importable when running tests from repository root.
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Provide default environment configuration for tests before importing settings.
+os.environ.setdefault("TESTING", "true")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "0123456789abcdefghijklmnopqrstuv")
+
+from app.auth import create_access_token, hash_password  # noqa: E402
+from app.config import settings  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_application  # noqa: E402
+from app.models import Content, User  # noqa: E402
+
+settings.testing = True
+
+
+@pytest_asyncio.fixture()
+async def engine() -> AsyncGenerator:
+    """Provide a SQLite engine backed by an in-memory database."""
+    engine = create_async_engine(
+        settings.database_url,
+        echo=False,
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest.fixture()
+def session_factory(engine) -> async_sessionmaker[AsyncSession]:
+    """Return an async session factory bound to the temporary engine."""
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest_asyncio.fixture()
+async def client(session_factory: async_sessionmaker[AsyncSession]):
+    """Return an HTTP client bound to a FastAPI test application."""
+
+    app = create_application()
+
+    async def _get_test_db() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:  # pragma: no cover - defensive rollback
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[get_db] = _get_test_db
+
+    async with AsyncClient(app=app, base_url="http://testserver") as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture()
+async def create_user(session_factory: async_sessionmaker[AsyncSession]):
+    """Factory fixture for creating persisted users."""
+
+    async def _create_user(
+        *,
+        email: str | None = None,
+        password: str = "ValidPass123!",
+        is_active: bool = True,
+    ) -> tuple[User, str]:
+        actual_email = email or f"user-{uuid4().hex}@example.com"
+        async with session_factory() as session:
+            user = User(
+                email=actual_email,
+                hashed_password=hash_password(password),
+                is_active=is_active,
+            )
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+        return user, password
+
+    return _create_user
+
+
+@pytest_asyncio.fixture()
+async def create_content(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> Callable[..., Awaitable[Content]]:
+    """Factory fixture for creating content rows tied to users."""
+
+    async def _create_content(
+        *,
+        owner: User,
+        title: str = "Sample Title",
+        body: str | None = "Sample body",
+        is_published: bool = True,
+    ) -> Content:
+        async with session_factory() as session:
+            content = Content(
+                title=title,
+                body=body,
+                owner_id=owner.id,
+                is_published=is_published,
+            )
+            session.add(content)
+            await session.commit()
+            await session.refresh(content)
+        return content
+
+    return _create_content
+
+
+@pytest_asyncio.fixture()
+async def auth_headers(create_user):
+    """Return an authorization header for a newly created active user."""
+
+    user, _ = await create_user()
+    token = create_access_token({"sub": user.email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture()
+async def authenticated_user(create_user):
+    """Return a tuple of a user and bearer token headers for that user."""
+
+    user, _ = await create_user()
+    token = create_access_token({"sub": user.email})
+    return user, {"Authorization": f"Bearer {token}"}

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,85 @@
+"""Authentication flow tests covering registration and login endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from app.auth import create_access_token, decode_access_token, hash_password, verify_password
+from app.models import User
+
+
+@pytest.mark.auth
+def test_hash_and_verify_password_round_trip() -> None:
+    """Plain passwords should hash and verify using bcrypt."""
+    plain = "StrongPass123!"
+    hashed = hash_password(plain)
+
+    assert hashed != plain
+    assert hashed.startswith("$2b$")
+    assert verify_password(plain, hashed)
+
+
+@pytest.mark.auth
+async def test_register_and_login_flow(client, session_factory) -> None:
+    """Register a user, log in, and fetch the authenticated profile."""
+    payload = {"email": "flow@example.com", "password": "FlowPass123!"}
+
+    register_response = await client.post("/auth/register", json=payload)
+    assert register_response.status_code == 201
+    register_body = register_response.json()
+    assert register_body["email"] == payload["email"].lower()
+    assert register_body["is_active"] is True
+
+    async with session_factory() as session:
+        result = await session.execute(select(User).where(User.email == payload["email"].lower()))
+        user = result.scalar_one()
+        assert user.hashed_password != payload["password"]
+
+    login_response = await client.post("/auth/login", json=payload)
+    assert login_response.status_code == 200
+    token_payload = login_response.json()
+    token = token_payload["access_token"]
+    assert token_payload["token_type"] == "bearer"
+
+    decoded = decode_access_token(token)
+    assert decoded["sub"] == payload["email"].lower()
+
+    profile_response = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert profile_response.status_code == 200
+    profile_body = profile_response.json()
+    assert profile_body["email"] == payload["email"].lower()
+
+
+@pytest.mark.auth
+async def test_login_rejects_invalid_credentials(client, create_user) -> None:
+    """An incorrect password should yield HTTP 401."""
+    user, _ = await create_user(email="existing@example.com")
+
+    response = await client.post(
+        "/auth/login",
+        json={"email": user.email, "password": "WrongPassword999!"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.auth
+async def test_register_rejects_duplicate_email(client, create_user) -> None:
+    """Attempting to reuse an email address should raise HTTP 400."""
+    user, password = await create_user(email="duplicate@example.com")
+
+    duplicate_attempt = await client.post(
+        "/auth/register",
+        json={"email": user.email, "password": password},
+    )
+    assert duplicate_attempt.status_code == 400
+
+
+@pytest.mark.auth
+def test_decode_access_token_with_invalid_signature() -> None:
+    """Tokens signed with the wrong secret should raise HTTP 401."""
+    token = create_access_token({"sub": "user@example.com"})
+
+    with pytest.raises(HTTPException):
+        decode_access_token(token + "tampered")

--- a/backend/tests/test_content.py
+++ b/backend/tests/test_content.py
@@ -1,0 +1,107 @@
+"""Tests for content CRUD API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.auth import create_access_token
+from app.models import Content
+
+
+@pytest.mark.content
+async def test_create_content_requires_authentication(client) -> None:
+    """Unauthenticated users should receive 401 when creating content."""
+    response = await client.post(
+        "/content",
+        json={"title": "Unauthorized", "body": "Should fail", "is_published": True},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.content
+async def test_create_content_persists_and_returns_item(client, authenticated_user) -> None:
+    """Authenticated users can create content and receive persisted data."""
+    user, headers = authenticated_user
+    payload = {"title": "First Post", "body": "Hello", "is_published": True}
+
+    response = await client.post("/content", json=payload, headers=headers)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["title"] == payload["title"]
+    assert body["owner_id"] == str(user.id)
+
+
+@pytest.mark.content
+async def test_list_content_filters_unpublished_for_anonymous_users(
+    client, create_content, create_user
+) -> None:
+    """Anonymous requests should not see unpublished content from others."""
+    owner, _ = await create_user(email="owner@example.com")
+    await create_content(owner=owner, title="Draft", is_published=False)
+    await create_content(owner=owner, title="Published", is_published=True)
+
+    response = await client.get("/content")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Published"
+
+
+@pytest.mark.content
+async def test_list_content_includes_unpublished_for_owner(
+    client, authenticated_user, create_content
+) -> None:
+    """Authenticated owners should see their unpublished drafts."""
+    user, headers = authenticated_user
+    await create_content(owner=user, title="Draft", is_published=False)
+
+    response = await client.get("/content", headers=headers)
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Draft"
+
+
+@pytest.mark.content
+async def test_update_content_requires_ownership(
+    client, authenticated_user, create_content, create_user
+) -> None:
+    """Updating content should be limited to the owner."""
+    owner, owner_headers = authenticated_user
+    content = await create_content(owner=owner, title="Original", is_published=True)
+
+    intruder, _ = await create_user(email="intruder@example.com")
+    intruder_token = create_access_token({"sub": intruder.email})
+    intruder_headers = {"Authorization": f"Bearer {intruder_token}"}
+
+    forbidden = await client.put(
+        f"/content/{content.id}",
+        json={"title": "Hacked"},
+        headers=intruder_headers,
+    )
+    assert forbidden.status_code == 403
+
+    allowed = await client.put(
+        f"/content/{content.id}",
+        json={"title": "Updated"},
+        headers=owner_headers,
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["title"] == "Updated"
+
+
+@pytest.mark.content
+async def test_delete_content_removes_record(
+    client, authenticated_user, create_content, session_factory
+) -> None:
+    """Owners can delete their content permanently."""
+    user, headers = authenticated_user
+    content = await create_content(owner=user, title="Disposable", is_published=True)
+
+    response = await client.delete(f"/content/{content.id}", headers=headers)
+    assert response.status_code == 204
+
+    async with session_factory() as session:
+        result = await session.execute(select(Content).where(Content.id == content.id))
+        assert result.scalar_one_or_none() is None

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,32 @@
+"""Health endpoint tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.health
+async def test_health_check_returns_service_status(client) -> None:
+    """The primary health endpoint should report service status and version."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert "version" in body
+    assert "database" in body
+
+
+@pytest.mark.health
+async def test_liveness_endpoint_returns_alive(client) -> None:
+    """Liveness probe should always return an alive status."""
+    response = await client.get("/health/liveness")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+@pytest.mark.health
+async def test_readiness_endpoint_returns_ready(client) -> None:
+    """Readiness endpoint should indicate readiness when database calls succeed."""
+    response = await client.get("/health/readiness")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = backend/tests
+python_files = test_*.py
+asyncio_mode = auto
+addopts = -q
+markers =
+    auth: tests covering authentication flows
+    content: tests covering content management endpoints
+    health: tests covering service health checks


### PR DESCRIPTION
## Summary
- relocate the high level backend guidance into `.internal/backend_notes.md` so the code stays focused on implementation details
- clarify the content listing endpoint by documenting how the base query is constructed and filtered

## Testing
- PYTHONPATH=backend pytest *(fails: ModuleNotFoundError: No module named 'pytest_asyncio' because third-party packages are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f84a2ae23883278ea5a8d8067dda61