### PR TITLE
Refactor EnterpriseWiki content into private module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.DS_Store
+dist
+npm-debug.log*
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Enterprise Portfolio Wiki</title>
+  </head>
+  <body class="bg-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "portfolio-project",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.344.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.1.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,7 @@
+import EnterpriseWiki from './components/EnterpriseWiki.jsx';
+
+const App = () => {
+  return <EnterpriseWiki />;
+};
+
+export default App;

--- a/src/components/EnterpriseWiki.jsx
+++ b/src/components/EnterpriseWiki.jsx
@@ -1,0 +1,317 @@
+import React, { useState } from 'react';
+import {
+  Book,
+  Server,
+  GitBranch,
+  TestTube,
+  Network,
+  ChevronRight,
+  FileText,
+  Code,
+  Shield,
+  Activity,
+  CheckCircle,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { roleLearningPaths } from '../private/roleLearningPaths.js';
+
+const roleThemes = {
+  sde: {
+    accentBg: 'bg-blue-600',
+    accentHover: 'hover:bg-blue-700',
+  },
+  devops: {
+    accentBg: 'bg-green-600',
+    accentHover: 'hover:bg-green-700',
+  },
+  qa: {
+    accentBg: 'bg-purple-600',
+    accentHover: 'hover:bg-purple-700',
+  },
+  architect: {
+    accentBg: 'bg-orange-500',
+    accentHover: 'hover:bg-orange-600',
+  },
+};
+
+const roles = {
+  sde: {
+    title: 'System Development Engineer',
+    icon: Server,
+    theme: roleThemes.sde,
+    description: 'Infrastructure, automation, and system reliability',
+    weeks: 8,
+  },
+  devops: {
+    title: 'DevOps Engineer',
+    icon: GitBranch,
+    theme: roleThemes.devops,
+    description: 'CI/CD, GitOps, and deployment automation',
+    weeks: 6,
+  },
+  qa: {
+    title: 'QA Engineer III',
+    icon: TestTube,
+    theme: roleThemes.qa,
+    description: 'Testing strategy, automation, and quality assurance',
+    weeks: 6,
+  },
+  architect: {
+    title: 'Solutions Architect',
+    icon: Network,
+    theme: roleThemes.architect,
+    description: 'System design, architecture patterns, and trade-offs',
+    weeks: 8,
+  },
+};
+
+// Role-specific learning plans (responsibilities, skills, week-by-week breakdowns) are stored in
+// src/private/roleLearningPaths.js so the UI layer here can focus on presentation and behavior.
+
+// The EnterpriseWiki component coordinates role selection with the detailed timeline view.
+// Local state tracks which role/week is active while the layout renders responsive Tailwind sections.
+const EnterpriseWiki = () => {
+  const [selectedRole, setSelectedRole] = useState('sde');
+  const [selectedWeek, setSelectedWeek] = useState(1);
+
+  const currentRole = roles[selectedRole];
+  const currentContent = roleLearningPaths[selectedRole];
+  const RoleIcon = currentRole.icon;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+      <div className="container mx-auto px-4 py-8">
+        <div className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-8 mb-8 shadow-2xl">
+          <div className="flex items-center gap-4 mb-4">
+            <Book className="w-12 h-12 text-white" />
+            <h1 className="text-4xl font-bold text-white">Enterprise Portfolio Wiki</h1>
+          </div>
+          <p className="text-blue-100 text-lg">Complete learning paths for all technical roles</p>
+        </div>
+
+        {/* Split layout: left column for navigation, right column for the active curriculum detail. */}
+        <div className="grid lg:grid-cols-4 gap-6">
+          <div className="lg:col-span-1">
+            {/* Role selector lists every persona with consistent styling and click handlers. */}
+            <div className="bg-slate-800 rounded-xl p-6 shadow-xl sticky top-4">
+              <h2 className="text-xl font-bold text-white mb-4">Select Role</h2>
+              <div className="space-y-3">
+                {Object.entries(roles).map(([key, role]) => {
+                  const Icon = role.icon;
+                  const { accentBg } = role.theme;
+
+                  return (
+                    <button
+                      type="button"
+                      key={key}
+                      onClick={() => {
+                        setSelectedRole(key);
+                        setSelectedWeek(1);
+                      }}
+                      className={clsx(
+                        'w-full p-4 rounded-lg transition-all',
+                        selectedRole === key
+                          ? [accentBg, 'text-white shadow-lg scale-105']
+                          : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <Icon className="w-6 h-6" />
+                        <div className="text-left">
+                          <div className="font-semibold">{role.title}</div>
+                          <div className="text-xs opacity-80">{role.weeks} weeks</div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="mt-6 pt-6 border-t border-slate-700">
+                <h3 className="text-sm font-semibold text-slate-400 mb-3">Your Progress</h3>
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs text-slate-400">
+                    <span>
+                      Week {selectedWeek} of {currentRole.weeks}
+                    </span>
+                    <span>{Math.round((selectedWeek / currentRole.weeks) * 100)}%</span>
+                  </div>
+                  <div className="w-full bg-slate-700 rounded-full h-2">
+                    <div
+                      className={clsx(currentRole.theme.accentBg, 'h-2 rounded-full transition-all')}
+                      style={{ width: `${(selectedWeek / currentRole.weeks) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="lg:col-span-3">
+            <div className="bg-slate-800 rounded-xl p-6 mb-6 shadow-xl">
+              <div className="flex items-center gap-4 mb-4">
+                <div className={clsx('p-3 rounded-lg', currentRole.theme.accentBg)}>
+                  <RoleIcon className="w-8 h-8 text-white" />
+                </div>
+                <div>
+                  <h2 className="text-2xl font-bold text-white">{currentRole.title}</h2>
+                  <p className="text-slate-400">{currentRole.description}</p>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6 mt-6">
+                <div>
+                  <h3 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
+                    <CheckCircle className="w-5 h-5 text-green-500" />
+                    Key Responsibilities
+                  </h3>
+                  <ul className="space-y-2">
+                    {currentContent.overview.responsibilities.map((resp, idx) => (
+                      <li key={idx} className="text-slate-300 text-sm flex items-start gap-2">
+                        <ChevronRight className="w-4 h-4 text-blue-500 mt-1 flex-shrink-0" />
+                        {resp}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
+                    <Code className="w-5 h-5 text-purple-500" />
+                    Core Skills
+                  </h3>
+                  <ul className="space-y-2">
+                    {currentContent.overview.skills.map((skill, idx) => (
+                      <li key={idx} className="text-slate-300 text-sm flex items-start gap-2">
+                        <ChevronRight className="w-4 h-4 text-purple-500 mt-1 flex-shrink-0" />
+                        {skill}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-slate-800 rounded-xl p-6 mb-6 shadow-xl">
+              <h3 className="text-xl font-bold text-white mb-4">Learning Path Timeline</h3>
+              {/* Week selector behaves like tabs, keeping the selected week in sync with the detail card below. */}
+              <div className="flex gap-2 overflow-x-auto pb-2">
+                {currentContent.weeks.map((week) => (
+                  <button
+                    type="button"
+                    key={week.number}
+                    onClick={() => setSelectedWeek(week.number)}
+                    className={clsx(
+                      'px-4 py-2 rounded-lg whitespace-nowrap transition-all',
+                      selectedWeek === week.number
+                        ? [currentRole.theme.accentBg, 'text-white shadow-lg']
+                        : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                    )}
+                  >
+                    Week {week.number}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {currentContent.weeks
+              .filter((week) => week.number === selectedWeek)
+              .map((week) => (
+                <div key={week.number} className="bg-slate-800 rounded-xl p-6 shadow-xl">
+                  {/* Header summarises the currently focused week and shows a quick status pill. */}
+                  <div className="flex items-center justify-between mb-6">
+                    <div>
+                      <h3 className="text-2xl font-bold text-white">
+                        Week {week.number}: {week.title}
+                      </h3>
+                      <p className="text-slate-400 mt-1">Duration: 5-7 days</p>
+                    </div>
+                    <div className={clsx('px-4 py-2 rounded-lg', currentRole.theme.accentBg)}>
+                      <span className="text-white font-semibold">In Progress</span>
+                    </div>
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-6">
+                    <div>
+                      <h4 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
+                        <FileText className="w-5 h-5 text-blue-500" />
+                        Topics Covered
+                      </h4>
+                      <ul className="space-y-2">
+                        {week.topics.map((topic, idx) => (
+                          <li key={idx} className="flex items-start gap-2">
+                            <div
+                              className={clsx(
+                                'w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5',
+                                currentRole.theme.accentBg
+                              )}
+                            >
+                              <span className="text-white text-xs font-bold">{idx + 1}</span>
+                            </div>
+                            <span className="text-slate-300">{topic}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
+                        <CheckCircle className="w-5 h-5 text-green-500" />
+                        Deliverables
+                      </h4>
+                      <ul className="space-y-2">
+                        {week.deliverables.map((deliverable, idx) => (
+                          <li key={idx} className="flex items-start gap-2">
+                            <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+                            <span className="text-slate-300">{deliverable}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+
+                  {/* Action buttons provide obvious next steps without wiring specific navigation yet. */}
+                  <div className="mt-6 pt-6 border-t border-slate-700 flex gap-4 flex-col sm:flex-row">
+                    <button
+                      type="button"
+                      className={clsx(
+                        'flex-1 py-3 px-6 text-white rounded-lg font-semibold transition-colors',
+                        currentRole.theme.accentBg,
+                        currentRole.theme.accentHover
+                      )}
+                    >
+                      View Detailed Guide
+                    </button>
+                    <button
+                      type="button"
+                      className="py-3 px-6 bg-slate-700 text-white rounded-lg font-semibold hover:bg-slate-600 transition-colors"
+                    >
+                      Access Resources
+                    </button>
+                  </div>
+                </div>
+              ))}
+
+            <div className="grid md:grid-cols-3 gap-4 mt-6">
+              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
+                <Code className="w-8 h-8 text-blue-500 mb-2" />
+                <h4 className="font-semibold text-white">Code Examples</h4>
+                <p className="text-sm text-slate-400">Full implementation samples</p>
+              </div>
+              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
+                <Activity className="w-8 h-8 text-green-500 mb-2" />
+                <h4 className="font-semibold text-white">Live Demos</h4>
+                <p className="text-sm text-slate-400">Interactive tutorials</p>
+              </div>
+              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
+                <Shield className="w-8 h-8 text-purple-500 mb-2" />
+                <h4 className="font-semibold text-white">Best Practices</h4>
+                <p className="text-sm text-slate-400">Industry standards</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EnterpriseWiki;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/private/roleLearningPaths.js
+++ b/src/private/roleLearningPaths.js
@@ -1,0 +1,532 @@
+// Centralised repository for learning path content. Keeping it separate from the UI makes
+// it easy to maintain and swap in new content without touching presentation logic.
+export const roleLearningPaths = {
+  sde: {
+    overview: {
+      responsibilities: [
+        'Design and implement highly available infrastructure',
+        'Automate infrastructure provisioning with Terraform',
+        'Implement monitoring and observability solutions',
+        'Ensure system reliability and performance',
+        'Manage multi-region deployments',
+      ],
+      skills: [
+        'Infrastructure as Code (Terraform, CloudFormation)',
+        'Cloud Platforms (AWS, Azure, GCP)',
+        'Container Orchestration (Kubernetes, ECS)',
+        'Monitoring & Observability (Prometheus, Grafana)',
+        'Scripting (Python, Bash, Go)',
+      ],
+    },
+    weeks: [
+      {
+        number: 1,
+        title: 'Infrastructure Foundations',
+        topics: [
+          'Terraform AWS Setup',
+          'VPC Design & Implementation',
+          'Multi-AZ Architecture',
+          'Security Groups & NACLs',
+        ],
+        deliverables: [
+          'Complete VPC infrastructure',
+          'Bastion host setup',
+          'Network diagram',
+          'Security documentation',
+        ],
+      },
+      {
+        number: 2,
+        title: 'Compute & Load Balancing',
+        topics: [
+          'EC2 Auto Scaling Groups',
+          'Application Load Balancer',
+          'Launch Templates',
+          'Health Checks',
+        ],
+        deliverables: [
+          'Auto-scaling configuration',
+          'ALB with SSL',
+          'Health check endpoints',
+          'Scaling policies',
+        ],
+      },
+      {
+        number: 3,
+        title: 'Database & Storage',
+        topics: [
+          'RDS PostgreSQL Multi-AZ',
+          'ElastiCache Redis Cluster',
+          'S3 Buckets & Policies',
+          'Database Backups',
+        ],
+        deliverables: [
+          'Production database',
+          'Cache configuration',
+          'Backup strategy',
+          'Recovery procedures',
+        ],
+      },
+      {
+        number: 4,
+        title: 'Container Orchestration',
+        topics: [
+          'EKS Cluster Setup',
+          'Node Groups Configuration',
+          'Pod Security Policies',
+          'Network Policies',
+        ],
+        deliverables: [
+          'Production EKS cluster',
+          'RBAC configuration',
+          'Network policies',
+          'Security scanning',
+        ],
+      },
+      {
+        number: 5,
+        title: 'Monitoring & Observability',
+        topics: [
+          'Prometheus Setup',
+          'Grafana Dashboards',
+          'AlertManager Configuration',
+          'Log Aggregation (ELK)',
+        ],
+        deliverables: [
+          'Complete monitoring stack',
+          'Custom dashboards',
+          'Alert rules',
+          'Log retention policies',
+        ],
+      },
+      {
+        number: 6,
+        title: 'Event-Driven Architecture',
+        topics: [
+          'SQS Queue Configuration',
+          'SNS Topics & Subscriptions',
+          'EventBridge Rules',
+          'Lambda Functions',
+        ],
+        deliverables: [
+          'Message queue setup',
+          'Event processing',
+          'Dead letter queues',
+          'Monitoring integration',
+        ],
+      },
+      {
+        number: 7,
+        title: 'Disaster Recovery',
+        topics: [
+          'Backup Automation',
+          'Cross-Region Replication',
+          'Failover Procedures',
+          'DR Testing',
+        ],
+        deliverables: [
+          'DR plan documentation',
+          'Automated backups',
+          'Failover runbooks',
+          'Test results',
+        ],
+      },
+      {
+        number: 8,
+        title: 'Security Hardening',
+        topics: [
+          'IAM Policies & Roles',
+          'Secrets Management',
+          'Security Scanning',
+          'Compliance Auditing',
+        ],
+        deliverables: [
+          'Security baseline',
+          'Secrets rotation',
+          'Audit reports',
+          'Compliance documentation',
+        ],
+      },
+    ],
+  },
+  devops: {
+    overview: {
+      responsibilities: [
+        'Design and maintain CI/CD pipelines',
+        'Implement GitOps workflows',
+        'Automate deployment processes',
+        'Manage configuration as code',
+        'Ensure zero-downtime deployments',
+      ],
+      skills: [
+        'CI/CD Tools (GitHub Actions, GitLab CI, Jenkins)',
+        'GitOps (ArgoCD, Flux)',
+        'Configuration Management (Ansible, Chef)',
+        'Container Technologies (Docker, Kubernetes)',
+        'Scripting & Automation',
+      ],
+    },
+    weeks: [
+      {
+        number: 1,
+        title: 'CI/CD Pipeline Setup',
+        topics: [
+          'GitHub Actions Workflows',
+          'Multi-stage Pipelines',
+          'Security Scanning',
+          'Artifact Management',
+        ],
+        deliverables: [
+          'Complete CI pipeline',
+          'Security gates',
+          'Test automation',
+          'Build optimization',
+        ],
+      },
+      {
+        number: 2,
+        title: 'GitOps Implementation',
+        topics: [
+          'ArgoCD Installation',
+          'Application Manifests',
+          'Automated Sync',
+          'Rollback Strategies',
+        ],
+        deliverables: [
+          'ArgoCD setup',
+          'GitOps repository',
+          'Sync policies',
+          'Rollback procedures',
+        ],
+      },
+      {
+        number: 3,
+        title: 'Configuration Management',
+        topics: [
+          'Ansible Playbooks',
+          'Inventory Management',
+          'Role Development',
+          'Vault Integration',
+        ],
+        deliverables: [
+          'Ansible repository',
+          'Server configuration',
+          'Secret management',
+          'Deployment automation',
+        ],
+      },
+      {
+        number: 4,
+        title: 'Container Registry',
+        topics: [
+          'Registry Setup',
+          'Image Scanning',
+          'Vulnerability Management',
+          'Image Signing',
+        ],
+        deliverables: [
+          'Container registry',
+          'Scanning pipeline',
+          'Security policies',
+          'Image lifecycle',
+        ],
+      },
+      {
+        number: 5,
+        title: 'Deployment Strategies',
+        topics: [
+          'Blue-Green Deployments',
+          'Canary Releases',
+          'Rolling Updates',
+          'Feature Flags',
+        ],
+        deliverables: [
+          'Deployment manifests',
+          'Traffic management',
+          'Rollback automation',
+          'Feature flag system',
+        ],
+      },
+      {
+        number: 6,
+        title: 'Pipeline Optimization',
+        topics: [
+          'Build Caching',
+          'Parallel Execution',
+          'Resource Optimization',
+          'Cost Management',
+        ],
+        deliverables: [
+          'Optimized pipelines',
+          'Performance metrics',
+          'Cost analysis',
+          'Best practices guide',
+        ],
+      },
+    ],
+  },
+  qa: {
+    overview: {
+      responsibilities: [
+        'Design comprehensive test strategies',
+        'Implement test automation frameworks',
+        'Perform security and performance testing',
+        'Establish quality gates',
+        'Lead testing best practices',
+      ],
+      skills: [
+        'Test Automation (Cypress, Playwright, Selenium)',
+        'API Testing (Postman, REST Assured)',
+        'Performance Testing (K6, JMeter)',
+        'Security Testing (OWASP ZAP, Burp Suite)',
+        'Test Strategy & Planning',
+      ],
+    },
+    weeks: [
+      {
+        number: 1,
+        title: 'Test Framework Setup',
+        topics: [
+          'Jest Configuration',
+          'Cypress Setup',
+          'Test Structure',
+          'Code Coverage',
+        ],
+        deliverables: [
+          'Unit test framework',
+          'E2E test suite',
+          'Coverage reports',
+          'Testing guidelines',
+        ],
+      },
+      {
+        number: 2,
+        title: 'API Testing',
+        topics: [
+          'REST API Testing',
+          'GraphQL Testing',
+          'Contract Testing',
+          'Mock Services',
+        ],
+        deliverables: [
+          'API test suite',
+          'Contract tests',
+          'Mock server setup',
+          'Test data management',
+        ],
+      },
+      {
+        number: 3,
+        title: 'E2E Testing',
+        topics: [
+          'User Flow Testing',
+          'Cross-browser Testing',
+          'Mobile Testing',
+          'Visual Regression',
+        ],
+        deliverables: [
+          'E2E test scenarios',
+          'Browser matrix',
+          'Visual tests',
+          'Test reports',
+        ],
+      },
+      {
+        number: 4,
+        title: 'Performance Testing',
+        topics: [
+          'Load Testing',
+          'Stress Testing',
+          'Spike Testing',
+          'Endurance Testing',
+        ],
+        deliverables: [
+          'Performance test suite',
+          'Load profiles',
+          'Performance benchmarks',
+          'Optimization recommendations',
+        ],
+      },
+      {
+        number: 5,
+        title: 'Security Testing',
+        topics: [
+          'OWASP Top 10',
+          'Penetration Testing',
+          'Vulnerability Scanning',
+          'Security Reports',
+        ],
+        deliverables: [
+          'Security test plan',
+          'Vulnerability reports',
+          'Remediation tracking',
+          'Security baseline',
+        ],
+      },
+      {
+        number: 6,
+        title: 'CI/CD Integration',
+        topics: [
+          'Automated Testing',
+          'Quality Gates',
+          'Test Reporting',
+          'Failure Analysis',
+        ],
+        deliverables: [
+          'CI test integration',
+          'Quality metrics',
+          'Automated reports',
+          'Failure handling',
+        ],
+      },
+    ],
+  },
+  architect: {
+    overview: {
+      responsibilities: [
+        'Design scalable system architectures',
+        'Make technology decisions',
+        'Define architecture patterns',
+        'Ensure security and compliance',
+        'Lead technical reviews',
+      ],
+      skills: [
+        'System Design & Architecture Patterns',
+        'Cloud Architecture (AWS, Azure, Multi-cloud)',
+        'Microservices & Event-driven Architecture',
+        'Security & Compliance',
+        'Technical Leadership',
+      ],
+    },
+    weeks: [
+      {
+        number: 1,
+        title: 'Architecture Fundamentals',
+        topics: [
+          'Design Principles',
+          'Architecture Patterns',
+          'Trade-off Analysis',
+          'System Requirements',
+        ],
+        deliverables: [
+          'Architecture principles',
+          'Pattern catalog',
+          'Decision framework',
+          'Requirements template',
+        ],
+      },
+      {
+        number: 2,
+        title: 'Microservices Design',
+        topics: [
+          'Service Boundaries',
+          'API Gateway Patterns',
+          'Service Mesh',
+          'Data Management',
+        ],
+        deliverables: [
+          'Service architecture',
+          'API specifications',
+          'Data flow diagrams',
+          'Integration patterns',
+        ],
+      },
+      {
+        number: 3,
+        title: 'Event-Driven Architecture',
+        topics: [
+          'Event Sourcing',
+          'CQRS Pattern',
+          'Message Brokers',
+          'Event Choreography',
+        ],
+        deliverables: [
+          'Event architecture',
+          'Message schemas',
+          'Event flows',
+          'Consistency patterns',
+        ],
+      },
+      {
+        number: 4,
+        title: 'Scalability Patterns',
+        topics: [
+          'Horizontal Scaling',
+          'Caching Strategies',
+          'Database Sharding',
+          'CDN Integration',
+        ],
+        deliverables: [
+          'Scaling strategy',
+          'Cache architecture',
+          'Database design',
+          'Performance plan',
+        ],
+      },
+      {
+        number: 5,
+        title: 'Security Architecture',
+        topics: [
+          'Zero Trust Security',
+          'Identity & Access',
+          'Data Encryption',
+          'Compliance Framework',
+        ],
+        deliverables: [
+          'Security architecture',
+          'IAM design',
+          'Encryption strategy',
+          'Compliance checklist',
+        ],
+      },
+      {
+        number: 6,
+        title: 'Resilience Patterns',
+        topics: [
+          'Circuit Breakers',
+          'Retry Policies',
+          'Bulkheads',
+          'Chaos Engineering',
+        ],
+        deliverables: [
+          'Resilience patterns',
+          'Fault tolerance',
+          'Recovery procedures',
+          'Testing strategy',
+        ],
+      },
+      {
+        number: 7,
+        title: 'Multi-Region Architecture',
+        topics: [
+          'Global Load Balancing',
+          'Data Replication',
+          'Disaster Recovery',
+          'Latency Optimization',
+        ],
+        deliverables: [
+          'Multi-region design',
+          'Replication strategy',
+          'DR plan',
+          'Performance metrics',
+        ],
+      },
+      {
+        number: 8,
+        title: 'Cost Optimization',
+        topics: [
+          'Resource Optimization',
+          'Reserved Capacity',
+          'Right-sizing',
+          'Cost Monitoring',
+        ],
+        deliverables: [
+          'Cost architecture',
+          'Optimization plan',
+          'Budget forecasts',
+          'Cost dashboards',
+        ],
+      },
+    ],
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- move the learning path instructions into src/private/roleLearningPaths.js to keep the presentation component lean
- update EnterpriseWiki to import the centralised data and document the layout flow with developer-facing comments

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68f84abe53e08327ad7033a820ff7843