### PR TITLE
Add docs, .gitignore and safer RDS variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+terraform.tfvars
+terraform.tfvars.json
+*.tfvars
+*.tfplan
+.terraform.lock.hcl
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDEs
+.vscode/
+.idea/
+*.iml
+
+# Scripts outputs
+*.log
+
+# Node
+node_modules/
+
+# Tests
+coverage/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+For security issues, please use GitHub's private vulnerability reporting feature or contact the repository owner.
+
+This repository includes a `docs/security.md` with general guidance. If you discover a vulnerability, please provide a clear report with steps to reproduce and any affected versions. Do not include exploit code in public reports.

--- a/docs/github-repository-setup-guide.md
+++ b/docs/github-repository-setup-guide.md
@@ -1,0 +1,41 @@
+# GitHub Repository Setup Guide
+
+This guide describes the minimal steps to get started with this repository locally and to configure CI/Deploy.
+
+Prerequisites
+- Git
+- Terraform 1.6.x (or compatible)
+- AWS CLI configured (if you will deploy)
+
+Quickstart
+1. Clone the repository
+   git clone https://github.com/samueljackson-collab/Portfolio-Project.git
+   cd Portfolio-Project
+
+2. Branching
+   Create a feature branch for changes:
+   git checkout -b feat/your-change
+
+3. Local Terraform variables
+   Copy the example tfvars and edit locally (do NOT commit secrets):
+   cp examples/terraform.tfvars.example terraform.tfvars
+   $EDITOR terraform.tfvars
+
+4. Validate infrastructure locally
+   cd infrastructure/terraform
+   terraform init -backend=false
+   terraform fmt -check -recursive
+   terraform validate
+
+5. Running CI checks
+   - CI runs terraform fmt, init, validate and tflint. Ensure those pass locally before opening a PR.
+
+6. Secrets and GitHub Actions
+   - Define necessary repository secrets in Settings > Secrets and variables > Actions (e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION).
+   - For production-grade usage prefer OIDC role assumption rather than long-lived access keys.
+
+7. Opening a Pull Request
+   Push your branch and open a PR targeting main. Provide a description of your change, relevant plan output for infra changes, and any cost/security implications.
+
+Notes
+- Never commit real passwords or secrets. Use GitHub Actions secrets or AWS Secrets Manager for runtime secrets.

--- a/infrastructure/terraform/modules/database/main.tf
+++ b/infrastructure/terraform/modules/database/main.tf
@@ -1,0 +1,184 @@
+variable "project_name" {
+  type        = string
+  description = "Project identifier"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID that hosts the database"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Master database username"
+}
+
+variable "db_password" {
+  type        = string
+  description = "Master database password"
+  sensitive   = true
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the database subnet group"
+}
+
+variable "allowed_security_group_ids" {
+  type        = list(string)
+  description = "Security groups permitted to reach the database"
+  default     = []
+}
+
+variable "instance_class" {
+  type        = string
+  description = "RDS instance class"
+  default     = "db.t3.small"
+}
+
+variable "allocated_storage" {
+  type        = number
+  description = "Allocated storage in GiB"
+  default     = 20
+}
+
+variable "max_allocated_storage" {
+  type        = number
+  description = "Maximum autoscaled storage in GiB"
+  default     = 100
+}
+
+variable "engine_version" {
+  type        = string
+  description = "PostgreSQL engine version"
+  default     = "15.4"
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "Deploy database in multiple availability zones"
+  default     = true
+}
+
+variable "backup_retention_period" {
+  type        = number
+  description = "Retention period for automated backups"
+  default     = 7
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection"
+  default     = false
+}
+
+# NEW: control final snapshot behavior (safe default: do not skip final snapshot)
+variable "skip_final_snapshot" {
+  type        = bool
+  description = "When true, skip creating a final snapshot on DB destroy. Defaults to false to protect data."
+  default     = false
+}
+
+# NEW: allow apply_immediately to be configurable (default preserved)
+variable "apply_immediately" {
+  type        = bool
+  description = "Control whether certain DB changes are applied immediately."
+  default     = true
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional resource tags"
+  default     = {}
+}
+
+locals {
+  name_prefix      = lower("${var.project_name}-${var.environment}")
+  sanitized_prefix = replace(local.name_prefix, "_", "-")
+
+  common_tags = merge({
+    Project     = var.project_name
+    Environment = var.environment
+  }, var.tags)
+}
+
+resource "aws_security_group" "db" {
+  name        = "${local.sanitized_prefix}-db-sg"
+  description = "Database access rules"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.allowed_security_group_ids
+
+    content {
+      description     = "Allow Postgres from application security group"
+      from_port       = 5432
+      to_port         = 5432
+      protocol        = "tcp"
+      security_groups = [ingress.value]
+    }
+  }
+
+  egress {
+    description = "Allow outbound access"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-db-sg"
+  })
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${local.sanitized_prefix}-db-subnets"
+  subnet_ids = var.subnet_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-db-subnets"
+  })
+}
+
+resource "aws_db_instance" "this" {
+  identifier              = replace("${local.name_prefix}-db", "_", "-")
+  engine                  = "postgres"
+  engine_version          = var.engine_version
+  instance_class          = var.instance_class
+  username                = var.db_username
+  password                = var.db_password
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = [aws_security_group.db.id]
+  allocated_storage       = var.allocated_storage
+  max_allocated_storage   = var.max_allocated_storage
+  storage_encrypted       = true
+  multi_az                = var.multi_az
+  backup_retention_period = var.backup_retention_period
+  auto_minor_version_upgrade = true
+  deletion_protection        = var.deletion_protection
+
+  # Use the configured variables for snapshot and apply behavior (safer defaults)
+  skip_final_snapshot = var.skip_final_snapshot
+  apply_immediately   = var.apply_immediately
+
+  publicly_accessible = false
+  port                = 5432
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-db"
+  })
+}
+
+output "db_endpoint" {
+  value = aws_db_instance.this.address
+}
+
+output "db_security_group_id" {
+  value = aws_security_group.db.id
+}


### PR DESCRIPTION
This PR adds contributor-friendly documentation and safer defaults for the RDS module:

Add .gitignore to exclude Terraform state, tfvars, IDE files and common temp files.
Add docs/github-repository-setup-guide.md with a quick start and CI guidance.
Add top-level SECURITY.md pointing to docs/security.md and responsible disclosure guidance.
Make the database module safer by adding variables:
skip_final_snapshot (default = false)
apply_immediately (default = true)
Wire these through from root variables to avoid an unconditional skip_final_snapshot that could cause data loss.
Files changed are on branch fix/terraform-docs; please review and merge when ready.

Open PR using GitHub CLI (If you have the GitHub CLI installed and authenticated, run:) gh pr create --base main --head fix/terraform-docs --title "Add docs, .gitignore and safer RDS variables" --body "Adds .gitignore, a GitHub repository setup guide, SECURITY.md, and makes RDS skip_final_snapshot/apply_immediately configurable (defaults: keep final snapshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive repository setup and contributor guide covering local development prerequisites, CI/CD configuration, secrets management, and pull request workflows.
  * Added security vulnerability reporting policy and procedures for responsible disclosure.

* **Chores**
  * Added .gitignore file with standard ignore patterns.

* **Infrastructure**
  * Added configurable AWS PostgreSQL RDS database deployment module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->