### PR TITLE
Add Terraform module for network infrastructure

### DIFF
--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,307 @@
+# ============================================================================
+# MODULE: Network
+# File: infra/modules/network/main.tf
+# Purpose: VPC, Subnets, IGW, NAT, Security Groups
+# ============================================================================
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-vpc"
+  })
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-igw"
+  })
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count                   = length(var.availability_zones)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-public-${count.index + 1}"
+    Tier = "public"
+  })
+}
+
+# Private Subnets (Application)
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone = var.availability_zones[count.index]
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-private-${count.index + 1}"
+    Tier = "private"
+  })
+}
+
+# Database Subnets
+resource "aws_subnet" "database" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 20)
+  availability_zone = var.availability_zones[count.index]
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-database-${count.index + 1}"
+    Tier = "database"
+  })
+}
+
+# Elastic IPs for NAT Gateways
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 0
+  domain = "vpc"
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-nat-eip-${count.index + 1}"
+  })
+  
+  depends_on = [aws_internet_gateway.main]
+}
+
+# NAT Gateways
+resource "aws_nat_gateway" "main" {
+  count         = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 0
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[var.single_nat_gateway ? 0 : count.index].id
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-nat-${count.index + 1}"
+  })
+  
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Route Tables
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-public-rt"
+  })
+}
+
+resource "aws_route_table" "private" {
+  count  = var.enable_nat_gateway ? length(var.availability_zones) : 0
+  vpc_id = aws_vpc.main.id
+  
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = var.single_nat_gateway ? aws_nat_gateway.main[0].id : aws_nat_gateway.main[count.index].id
+  }
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-private-rt-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table" "database" {
+  vpc_id = aws_vpc.main.id
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-database-rt"
+  })
+}
+
+# Route Table Associations
+resource "aws_route_table_association" "public" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = var.enable_nat_gateway ? length(var.availability_zones) : 0
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+resource "aws_route_table_association" "database" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.database[count.index].id
+  route_table_id = aws_route_table.database.id
+}
+
+# VPC Flow Logs
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  name              = "/aws/vpc/${var.project_name}-${var.environment}"
+  retention_in_days = 7
+  
+  tags = var.tags
+}
+
+resource "aws_iam_role" "flow_logs" {
+  name = "${var.project_name}-${var.environment}-vpc-flow-logs"
+  
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "vpc-flow-logs.amazonaws.com"
+      }
+    }]
+  })
+  
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  name = "${var.project_name}-${var.environment}-vpc-flow-logs"
+  role = aws_iam_role.flow_logs.id
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "main" {
+  iam_role_arn    = aws_iam_role.flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-flow-logs"
+  })
+}
+
+# Security Groups
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.project_name}-${var.environment}-alb-"
+  description = "Security group for Application Load Balancer"
+  vpc_id      = aws_vpc.main.id
+  
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTPS from internet"
+  }
+  
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTP from internet"
+  }
+  
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound traffic"
+  }
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-alb-sg"
+  })
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "app" {
+  name_prefix = "${var.project_name}-${var.environment}-app-"
+  description = "Security group for application servers"
+  vpc_id      = aws_vpc.main.id
+  
+  ingress {
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+    description     = "HTTP from ALB"
+  }
+  
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTPS to internet"
+  }
+  
+  egress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.database.id]
+    description     = "PostgreSQL to database"
+  }
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-app-sg"
+  })
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "database" {
+  name_prefix = "${var.project_name}-${var.environment}-db-"
+  description = "Security group for RDS database"
+  vpc_id      = aws_vpc.main.id
+  
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+    description     = "PostgreSQL from application"
+  }
+  
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound traffic"
+  }
+  
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-database-sg"
+  })
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}


### PR DESCRIPTION
## Summary
- add a Terraform module that provisions core networking resources including VPC, subnets, gateways, and routing
- configure CloudWatch flow logs and IAM roles for VPC flow logging
- define security groups for the load balancer, application, and database tiers with appropriate ingress and egress rules

## Testing
- `terraform fmt` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f058010483278ec71e06a1729b4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Network infrastructure module now enables provisioning of complete VPC topology across multiple availability zones with segmented subnets and configurable routing.
* Built-in network monitoring via traffic logs and automated security policies for web, application, and database layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->