### PR TITLE
Add documentation suites for projects 16-23

### DIFF
--- a/projects/16-23/16-zero-downtime-migrations/README.md
+++ b/projects/16-23/16-zero-downtime-migrations/README.md
@@ -1,0 +1,10 @@
+# Zero Downtime Migrations
+
+Framework and tooling to execute database and service migrations without disrupting customer traffic.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/16-zero-downtime-migrations/docs/architecture.md
+++ b/projects/16-23/16-zero-downtime-migrations/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+
+## Overview
+A centralized orchestrator coordinates migration steps, guarded by validation services and observability hooks to guarantee safe rollouts.
+
+## Component Breakdown
+- **Migration Orchestrator:** Manages workflows, approvals, and sequencing for schema and API changes.
+- **Traffic Shaper:** Routes production requests between blue/green environments and controls read-only windows.
+- **Shadow Validator:** Mirrors live traffic to new versions and compares outputs for regressions.
+- **Observability Dashboard:** Aggregates metrics, traces, and logs into migration-specific views.
+
+## Diagrams & Flows
+```text
+Blue Environment ->|shadow traffic| Shadow Validator -> OK? -> Promote Green
+            Green Environment <- cutover - Traffic Shaper <- Migration Orchestrator
+            Observability Dashboard <- metrics/logs/traces - All components
+```

--- a/projects/16-23/16-zero-downtime-migrations/docs/future-roadmap.md
+++ b/projects/16-23/16-zero-downtime-migrations/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Expand orchestrator plugin model to include stateful message brokers.
+- Automate customer communication templates for planned migrations.
+- Explore machine learning anomaly detection on shadow traffic comparisons.
+
+## Open Questions
+- How should we prioritize support for regional data residency constraints?
+- Do we require dual writes for certain services prior to introducing blue/green?

--- a/projects/16-23/16-zero-downtime-migrations/docs/implementation-plan.md
+++ b/projects/16-23/16-zero-downtime-migrations/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Foundation (3 weeks):**
+  - Model migration workflows and required metadata in orchestrator.
+  - Integrate CI/CD hooks for migration artifact packaging.
+  - Stand up baseline observability dashboards for pilot services.
+- **Phase 2: Shadow + Cutover Automation (4 weeks):**
+  - Deploy traffic shaper with gradual ramp controls.
+  - Build shadow validation harness with golden request suites.
+  - Automate rollback execution including cache and queue resets.
+- **Phase 3: Expansion (4 weeks):**
+  - Document runbooks per migration archetype (schema, API, config).
+  - Onboard two additional services and capture lessons learned.
+  - Publish KPIs and SLO reporting for leadership dashboards.
+
+## Backlog Candidates
+- Add scenario simulator for large data set reindexing.
+- Support per-tenant throttling strategies.
+- Integrate change window approvals with corporate compliance system.

--- a/projects/16-23/16-zero-downtime-migrations/docs/operations-runbook.md
+++ b/projects/16-23/16-zero-downtime-migrations/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Trigger orchestrator deployment via GitOps workflow to staging then production.
+- Run smoke tests ensuring orchestrator API and UI respond within SLA.
+- Validate shadow validator connectivity to both blue and green stacks before enabling traffic shaping.
+
+## Monitoring & Alerting
+- Golden signals: migration duration, validation failure rate, traffic split health, rollback frequency.
+- Alert thresholds: validation failure > 0.5% for 5 min, rollback initiated, orchestrator API latency > 500 ms.
+- Dashboards segmented per service with pre/post metrics and customer impact overlay.
+
+## Rollback Procedures
+- Initiate orchestrator rollback command; confirm traffic shaper routes 100% to previous stack.
+- Revert schema migrations via automatically generated down scripts.
+- Run post-rollback data integrity checks and notify stakeholders in incident channel.
+
+## Service Level Objectives
+- 99.95% orchestrator availability.
+- <5 minutes mean time to rollback.
+- <0.2% customer error rate during migration windows.

--- a/projects/16-23/16-zero-downtime-migrations/docs/proposal.md
+++ b/projects/16-23/16-zero-downtime-migrations/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Critical microservices still require maintenance windows for database and API migrations, causing revenue-impacting downtime and forcing off-hours releases.
+
+## Goals
+- Design blue/green friendly workflows for schema and API version changes.
+- Introduce automated pre-flight validation and shadow traffic testing before cutovers.
+- Create reusable runbooks, metrics, and alerts for every migration class.
+
+## Success Criteria
+- Migrations complete with zero customer-facing errors and under 60 seconds of read-only mode.
+- Rollback executes within five minutes with full data consistency checks.
+- Teams self-serve migration playbooks for new services within two sprints of onboarding.

--- a/projects/16-23/17-observability-as-code/README.md
+++ b/projects/16-23/17-observability-as-code/README.md
@@ -1,0 +1,10 @@
+# Observability as Code
+
+Templates, modules, and policy guardrails that provision consistent metrics, logs, and traces across environments through code.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/17-observability-as-code/docs/architecture.md
+++ b/projects/16-23/17-observability-as-code/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Infrastructure-as-code pipelines orchestrate telemetry collectors, storage backends, and dashboards with policy enforcement.
+
+## Component Breakdown
+- **Terraform Modules:** Provision metrics, logs, and tracing infrastructure with opinionated defaults.
+- **Policy Engine:** Validates configurations against organizational guardrails before apply.
+- **Telemetry Collectors:** Agent and sidecar deployments shipping data to central backends.
+- **Developer Portal:** Publishes module documentation, quickstarts, and examples.
+
+## Diagrams & Flows
+```text
+Git Repo -> CI Lint -> Policy Engine -> Terraform Apply -> Observability Stack
+            Services -> Collectors -> Metrics/Logs/Traces Storage -> Dashboards/Alerts
+```

--- a/projects/16-23/17-observability-as-code/docs/future-roadmap.md
+++ b/projects/16-23/17-observability-as-code/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Introduce configuration visualizer with dependency graphs.
+- Bundle synthetic user journeys as code alongside service definitions.
+- Explore auto-remediation hooks for critical alerts.
+
+## Open Questions
+- Should we host module registry internally or rely on upstream Terraform Cloud?
+- What audit evidence is required for Sarbanes-Oxley compliance?

--- a/projects/16-23/17-observability-as-code/docs/implementation-plan.md
+++ b/projects/16-23/17-observability-as-code/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Baseline Modules (4 weeks):**
+  - Define metrics/logging/tracing Terraform modules with defaults for staging and production.
+  - Integrate static analysis to check SLO coverage and alert severity.
+  - Publish sample service repository using the modules.
+- **Phase 2: Policy + Automation (3 weeks):**
+  - Deploy policy engine with required tags, runbook links, and escalation info.
+  - Wire modules into CI/CD pipeline with preview plans and automated approvals.
+  - Create dashboards with dynamic service catalogs pulling metadata from Git.
+- **Phase 3: Enablement (4 weeks):**
+  - Deliver enablement workshops and office hours for service teams.
+  - Collect feedback loops and iterate on module ergonomics.
+  - Expand coverage to include synthetic monitoring and RUM.
+
+## Backlog Candidates
+- Support multi-cloud observability targets with provider-agnostic abstractions.
+- Add golden queries library for tiered alerting patterns.
+- Automate onboarding reports for compliance reviews.

--- a/projects/16-23/17-observability-as-code/docs/operations-runbook.md
+++ b/projects/16-23/17-observability-as-code/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Use GitOps merge to main to trigger Terraform apply with change approval gates.
+- Monitor apply logs for drift detection and record change tickets automatically.
+- Validate dashboards render expected data post-deploy using screenshot diffing.
+
+## Monitoring & Alerting
+- Track module adoption, failed lint counts, and alert coverage per service tier.
+- Alert on collector queue depth, exporter error rates, and policy engine latency.
+- Publish weekly SLO health report summarizing burn rates and incidents.
+
+## Rollback Procedures
+- Re-run Terraform with previous version tags to revert infrastructure changes.
+- Disable newly added alerts or dashboards via feature flags when necessary.
+- Document rollback outcomes in change log with follow-up actions.
+
+## Service Level Objectives
+- 99.9% availability for policy engine and module registry.
+- <2 hours time-to-detect missing telemetry coverage after onboarding.
+- Zero unauthorized configuration changes (enforced via CI).

--- a/projects/16-23/17-observability-as-code/docs/proposal.md
+++ b/projects/16-23/17-observability-as-code/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Every team provisions monitoring manually, leading to inconsistent coverage, missing alerts, and painful onboarding for new services.
+
+## Goals
+- Codify dashboards, alerts, and telemetry pipelines using reusable modules.
+- Enforce baseline SLO instrumentation across all services.
+- Provide self-service documentation and CI linting for observability configurations.
+
+## Success Criteria
+- All Tier 1 services managed via observability modules within two quarters.
+- Failed lint jobs for misconfigured alerts block deployments by default.
+- New service onboarding to production telemetry takes under one day.

--- a/projects/16-23/18-customer-360-data-lake/README.md
+++ b/projects/16-23/18-customer-360-data-lake/README.md
@@ -1,0 +1,10 @@
+# Customer 360 Data Lake
+
+Unified storage, governance, and analytics stack delivering near-real-time customer profiles for marketing and support teams.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/18-customer-360-data-lake/docs/architecture.md
+++ b/projects/16-23/18-customer-360-data-lake/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Event-driven ingestion feeds a lakehouse with curated zones, governed by metadata services and served through analytics interfaces.
+
+## Component Breakdown
+- **Ingestion Pipelines:** Capture CDC streams and batch extracts from CRM, billing, and support.
+- **Lakehouse Storage:** Bronze/Silver/Gold zones with schema evolution and quality checks.
+- **Metadata Catalog:** Tracks data lineage, privacy classifications, and stewardship ownership.
+- **Serving Layer:** SQL warehouse and API endpoints exposing unified customer profiles.
+
+## Diagrams & Flows
+```text
+Sources -> CDC/Bulk Ingest -> Bronze -> Quality Checks -> Silver -> Feature Engineering -> Gold -> SQL/API Consumers
+            Metadata Catalog spans all zones with governance hooks.
+```

--- a/projects/16-23/18-customer-360-data-lake/docs/future-roadmap.md
+++ b/projects/16-23/18-customer-360-data-lake/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Launch reverse ETL connectors pushing insights back into CRM and marketing tools.
+- Introduce real-time segmentation powered by streaming SQL.
+- Evaluate data mesh patterns for domain-oriented ownership.
+
+## Open Questions
+- What privacy requirements apply for cross-border data replication?
+- Do we retain raw data indefinitely or apply lifecycle policies after 18 months?

--- a/projects/16-23/18-customer-360-data-lake/docs/implementation-plan.md
+++ b/projects/16-23/18-customer-360-data-lake/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Foundation (5 weeks):**
+  - Provision lakehouse infrastructure and storage tiers.
+  - Onboard CRM and billing sources with CDC streams.
+  - Implement data quality checks for critical dimensions and metrics.
+- **Phase 2: Curation (4 weeks):**
+  - Define unified customer schema and identity resolution rules.
+  - Build gold layer aggregate tables supporting marketing segmentation use cases.
+  - Integrate access controls with privacy policy enforcement.
+- **Phase 3: Enablement (4 weeks):**
+  - Launch analytics workspace with starter dashboards.
+  - Provide API endpoints for support tooling to query customer insights.
+  - Run data literacy sessions with marketing and support teams.
+
+## Backlog Candidates
+- Integrate product telemetry for behavioral insights.
+- Add ML feature store exports for personalization models.
+- Support GDPR subject access request automation.

--- a/projects/16-23/18-customer-360-data-lake/docs/operations-runbook.md
+++ b/projects/16-23/18-customer-360-data-lake/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Terraform infrastructure updates across ingestion, storage, and serving layers.
+- Orchestrate pipelines via Airflow with blue/green DAG deployments.
+- Run validation suites covering schema drift and data freshness before go-live.
+
+## Monitoring & Alerting
+- Track data freshness, ingestion lag, and quality scorecards per data source.
+- Alert on failed DAG runs, schema mismatches, and access violations.
+- Publish weekly adoption metrics for workspace usage.
+
+## Rollback Procedures
+- Use versioned data lake snapshots to revert to previous curated tables.
+- Disable impacted pipelines via Airflow tags while investigating failures.
+- Notify privacy office if rollback touches regulated datasets.
+
+## Service Level Objectives
+- 99% of data delivered within five minutes of source updates.
+- <1% failed pipeline executions per week.
+- 100% traceability for data access events.

--- a/projects/16-23/18-customer-360-data-lake/docs/proposal.md
+++ b/projects/16-23/18-customer-360-data-lake/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Customer data lives in silos across CRM, billing, support, and product analytics, preventing cohesive insights and personalization.
+
+## Goals
+- Ingest authoritative data sources into a governed lakehouse with harmonized schemas.
+- Provide curated feature views consumable by analytics, ML, and downstream APIs.
+- Implement role-based access controls and audit trails meeting privacy regulations.
+
+## Success Criteria
+- Single customer profile accessible within five minutes of source updates.
+- Self-service queries served via SQL warehouse with <5 second latency for 95th percentile.
+- Access requests fulfilled with automated approvals and complete audit history.

--- a/projects/16-23/19-incident-response-automation/README.md
+++ b/projects/16-23/19-incident-response-automation/README.md
@@ -1,0 +1,10 @@
+# Incident Response Automation
+
+Automated triage, enrichment, and collaboration tooling to reduce mean time to respond for Sev1 and Sev2 incidents.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/19-incident-response-automation/docs/architecture.md
+++ b/projects/16-23/19-incident-response-automation/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Event-driven automations integrate paging, collaboration, and observability platforms to guide responders end-to-end.
+
+## Component Breakdown
+- **Event Listener:** Subscribes to critical alerts and opens incidents via incident management platform.
+- **Enrichment Service:** Pulls deployment history, impacted services, and runbook references.
+- **Collaboration Bot:** Creates channels, invites roles, and posts checklists.
+- **Analytics Store:** Captures incident timeline events and metrics for reporting.
+
+## Diagrams & Flows
+```text
+Alert -> Event Listener -> Incident Platform -> Collaboration Bot -> Responders
+            Incident Data -> Enrichment Service -> Analytics Store -> Reporting Dashboards
+```

--- a/projects/16-23/19-incident-response-automation/docs/future-roadmap.md
+++ b/projects/16-23/19-incident-response-automation/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Leverage machine learning to recommend responders based on incident history.
+- Enable automated verification steps post-mitigation.
+- Explore integration with change management for proactive risk surfacing.
+
+## Open Questions
+- Which compliance constraints govern automated stakeholder messaging?
+- How do we store incident data long term while respecting privacy rules?

--- a/projects/16-23/19-incident-response-automation/docs/implementation-plan.md
+++ b/projects/16-23/19-incident-response-automation/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Foundations (3 weeks):**
+  - Integrate paging provider webhooks with automation entrypoint.
+  - Implement enrichment adapters for deployment history and service metadata.
+  - Create standard incident channel template and communications checklist.
+- **Phase 2: Guided Response (4 weeks):**
+  - Develop interactive runbooks with branching logic for top five incidents.
+  - Automate stakeholder updates and status page integration.
+  - Enable severity tagging and escalation policies via configuration.
+- **Phase 3: Metrics & Insights (3 weeks):**
+  - Capture timeline events automatically and surface in analytics dashboards.
+  - Add feedback loop for responders to submit improvement ideas.
+  - Publish monthly MTTA/MTTR and incident volume reporting.
+
+## Backlog Candidates
+- Integrate with knowledge base for suggested remediation articles.
+- Automate post-incident survey distribution.
+- Support regional on-call rotations with follow-the-sun scheduling.

--- a/projects/16-23/19-incident-response-automation/docs/operations-runbook.md
+++ b/projects/16-23/19-incident-response-automation/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Deploy automation services via container platform with canary releases.
+- Validate webhook subscriptions and API credentials post-deploy.
+- Run synthetic alert to confirm end-to-end channel creation.
+
+## Monitoring & Alerting
+- Track automation success rate, enrichment latency, and bot response times.
+- Alert on failed playbook executions or missing stakeholder notifications.
+- Review monthly incident metrics for regression in MTTA/MTTR.
+
+## Rollback Procedures
+- Scale down new automation version and redeploy prior container image.
+- Disable newly introduced playbooks while investigating issues.
+- Communicate rollback to on-call roster via incident management platform.
+
+## Service Level Objectives
+- 99.9% availability for automation services.
+- <60 seconds time to produce enriched context after alert receipt.
+- <1% automation failure rate per week.

--- a/projects/16-23/19-incident-response-automation/docs/proposal.md
+++ b/projects/16-23/19-incident-response-automation/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+On-call engineers juggle multiple tools manually, causing slow triage, missed context, and inconsistent stakeholder communication.
+
+## Goals
+- Automate enrichment workflows pulling runbook links, dashboards, and recent deploys into incident channels.
+- Provide guided remediation playbooks with decision trees for common failure modes.
+- Instrument incident metrics with MTTA/MTTR reporting for leadership reviews.
+
+## Success Criteria
+- Median time from alert to engaged responders under five minutes.
+- Automated incident channel creation with enriched context in under 60 seconds.
+- Quarterly retrospectives include data-driven insights with less than 5% manual data correction.

--- a/projects/16-23/20-secure-remote-access/README.md
+++ b/projects/16-23/20-secure-remote-access/README.md
@@ -1,0 +1,10 @@
+# Secure Remote Access Platform
+
+Zero-trust remote access solution combining strong identity, device posture, and policy-based gateways for distributed teams.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/20-secure-remote-access/docs/architecture.md
+++ b/projects/16-23/20-secure-remote-access/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+
+## Overview
+Zero-trust brokers validate identity, device, and context before granting session tokens to application gateways.
+
+## Component Breakdown
+- **Identity Provider:** Centralizes SSO, MFA, and adaptive risk scoring.
+- **Device Posture Service:** Validates OS patch level, disk encryption, and endpoint protection.
+- **Access Gateway:** Proxies authenticated traffic to internal web, SSH, and RDP services.
+- **Audit Pipeline:** Streams session metadata and recordings to SIEM for monitoring.
+
+## Diagrams & Flows
+```text
+User -> Identity Provider -> Policy Engine -> Access Gateway -> Internal App
+            Device -> Posture Service -> Policy Decision
+            Audit Pipeline -> SIEM / Monitoring
+```

--- a/projects/16-23/20-secure-remote-access/docs/future-roadmap.md
+++ b/projects/16-23/20-secure-remote-access/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Integrate SaaS proxying to cover third-party administrative portals.
+- Adopt continuous device compliance scoring with automated remediation.
+- Evaluate mesh-based networking to remove site-to-site VPN dependencies.
+
+## Open Questions
+- What is the long-term strategy for supporting BYOD access?
+- How will we store and rotate session recordings securely?

--- a/projects/16-23/20-secure-remote-access/docs/implementation-plan.md
+++ b/projects/16-23/20-secure-remote-access/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Pilot (4 weeks):**
+  - Deploy access gateway in staging with integration to identity provider.
+  - Configure device posture checks for corporate-managed laptops.
+  - Run pilot with security and infrastructure teams to validate workflows.
+- **Phase 2: Expansion (5 weeks):**
+  - Roll out zero-trust access to admin SSH and web consoles.
+  - Enable session recording and centralized logging.
+  - Deliver training and migration plan for remote workforce.
+- **Phase 3: Hardening (4 weeks):**
+  - Implement adaptive policies based on risk scoring and geo-velocity.
+  - Integrate with ticketing for just-in-time access approvals.
+  - Conduct penetration testing and remediation of findings.
+
+## Backlog Candidates
+- Support contractor access with isolated device profiles.
+- Introduce passwordless authentication using hardware security keys.
+- Automate certificate issuance for service accounts accessing gateways.

--- a/projects/16-23/20-secure-remote-access/docs/operations-runbook.md
+++ b/projects/16-23/20-secure-remote-access/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Leverage infrastructure-as-code to roll out additional gateways across regions.
+- Validate SSO integration, MFA prompts, and device checks during canary releases.
+- Run traffic replay tests to ensure application compatibility.
+
+## Monitoring & Alerting
+- Observe gateway CPU/memory, session counts, and auth success rate.
+- Alert on failed posture checks spikes or unusual geographic access patterns.
+- Review audit pipeline delivery latency and SIEM ingestion status.
+
+## Rollback Procedures
+- Fail back to previous gateway images via blue/green deployment.
+- Temporarily relax policies for critical access while investigating issues.
+- Notify security operations and impacted teams of rollback rationale and remediation steps.
+
+## Service Level Objectives
+- 99.95% availability for access gateways.
+- <30 seconds average authentication time including posture checks.
+- 100% session logging coverage for privileged systems.

--- a/projects/16-23/20-secure-remote-access/docs/proposal.md
+++ b/projects/16-23/20-secure-remote-access/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Legacy VPN concentrators are overloaded, lack granular access policies, and provide minimal visibility into session activity.
+
+## Goals
+- Implement identity-aware proxies with per-application access policies.
+- Enforce device posture checks before granting access to sensitive resources.
+- Provide unified auditing and session recording for critical systems.
+
+## Success Criteria
+- All remote admin access flows through zero-trust gateways with MFA enforced.
+- Device posture compliance above 98% across remote workforce.
+- Security operations receives real-time alerts for anomalous session behavior.

--- a/projects/16-23/21-developer-self-service-portal/README.md
+++ b/projects/16-23/21-developer-self-service-portal/README.md
@@ -1,0 +1,10 @@
+# Developer Self-Service Portal
+
+Unified portal empowering engineers to provision environments, request credentials, and access documentation without tickets.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/21-developer-self-service-portal/docs/architecture.md
+++ b/projects/16-23/21-developer-self-service-portal/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Event-driven workflows backed by service catalog and policy engines deliver resources via infrastructure APIs and surface docs in the portal.
+
+## Component Breakdown
+- **Service Catalog:** Tracks golden path templates, resource metadata, and ownership.
+- **Workflow Engine:** Executes provisioning pipelines with approval logic.
+- **UI Portal:** Provides intuitive interface, search, and status tracking.
+- **Integration Hub:** Connects to CI/CD, secrets management, and documentation repositories.
+
+## Diagrams & Flows
+```text
+Portal UI -> Workflow Engine -> Cloud APIs / CI/CD / Secrets
+            Workflow Engine -> Service Catalog updates -> Observability & Docs
+```

--- a/projects/16-23/21-developer-self-service-portal/docs/future-roadmap.md
+++ b/projects/16-23/21-developer-self-service-portal/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Introduce budget guardrails with cost anomaly detection alerts.
+- Provide automated compliance evidence packages for provisioned environments.
+- Launch community-contributed templates with review workflow.
+
+## Open Questions
+- How do we align portal governance with change management processes?
+- Which metrics best capture developer productivity improvements?

--- a/projects/16-23/21-developer-self-service-portal/docs/implementation-plan.md
+++ b/projects/16-23/21-developer-self-service-portal/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: MVP (4 weeks):**
+  - Launch portal with service scaffolding and sandbox environment provisioning.
+  - Implement single sign-on and role-based access control.
+  - Integrate docs search with existing knowledge base.
+- **Phase 2: Automation (5 weeks):**
+  - Add approval workflows tied to policy engine for production resources.
+  - Introduce secrets broker integration for API keys and certificates.
+  - Enable observability bootstrap packages for new services.
+- **Phase 3: Optimization (4 weeks):**
+  - Collect usage analytics and run usability testing to streamline flows.
+  - Expand to data platform requests with automated cost estimation.
+  - Publish onboarding curriculum leveraging portal guides.
+
+## Backlog Candidates
+- ChatOps integration for portal commands via messaging platforms.
+- Recommendations engine suggesting next steps based on service maturity.
+- Automated drift detection and remediation for provisioned resources.

--- a/projects/16-23/21-developer-self-service-portal/docs/operations-runbook.md
+++ b/projects/16-23/21-developer-self-service-portal/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Use blue/green deployments for portal UI and API with automated smoke tests.
+- Run contract tests against integration hub connectors prior to release.
+- Update service catalog schemas via migration scripts tracked in Git.
+
+## Monitoring & Alerting
+- Track request throughput, completion times, and failure reasons.
+- Monitor user satisfaction via in-portal surveys and NPS scoring.
+- Alert on provisioning queue backlogs and integration errors.
+
+## Rollback Procedures
+- Flip traffic to previous portal version if new release fails health checks.
+- Revert workflow definitions using versioned templates in Git.
+- Communicate rollback status via engineering announcements channel.
+
+## Service Level Objectives
+- 99.9% availability for portal APIs.
+- <30 minutes median fulfillment time for sandbox requests.
+- <1% failed provisioning requests per week.

--- a/projects/16-23/21-developer-self-service-portal/docs/proposal.md
+++ b/projects/16-23/21-developer-self-service-portal/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Engineers wait days for infrastructure requests and must navigate disparate systems for documentation and approvals.
+
+## Goals
+- Consolidate golden paths for service creation, environment provisioning, and secret access.
+- Automate approvals with guardrails aligned to compliance controls.
+- Deliver actionable documentation and telemetry for every provisioned resource.
+
+## Success Criteria
+- 80% reduction in manual infrastructure tickets within two quarters.
+- New service skeleton generated in under 15 minutes with CI/CD ready.
+- Portal satisfaction score above 4.5/5 from quarterly surveys.

--- a/projects/16-23/22-ai-documentation-assistant/README.md
+++ b/projects/16-23/22-ai-documentation-assistant/README.md
@@ -1,0 +1,10 @@
+# AI Documentation Assistant
+
+AI-assisted documentation pipeline generating drafts, code annotations, and summaries to accelerate knowledge sharing.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/22-ai-documentation-assistant/docs/architecture.md
+++ b/projects/16-23/22-ai-documentation-assistant/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Pipeline ingests repositories and tickets, passes content through LLM services with guardrails, and opens change requests for human review.
+
+## Component Breakdown
+- **Ingestion Connectors:** Pull code diffs, commit messages, and ticket updates.
+- **LLM Orchestrator:** Applies prompts, context windows, and policy filters for doc generation.
+- **Review Console:** Allows SMEs to approve edits, leave feedback, and publish updates.
+- **Documentation Portal:** Publishes final docs with freshness metadata and search.
+
+## Diagrams & Flows
+```text
+Code/Tickets -> Ingestion -> LLM Orchestrator -> Draft Docs -> Review Console -> Documentation Portal
+            Guardrails Service monitors PII/redaction across pipeline.
+```

--- a/projects/16-23/22-ai-documentation-assistant/docs/future-roadmap.md
+++ b/projects/16-23/22-ai-documentation-assistant/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Launch conversational assistant for doc Q&A.
+- Introduce summarization of design reviews and architecture decision records.
+- Evaluate on-prem inference for regulated environments.
+
+## Open Questions
+- What data retention policies apply to LLM prompts and responses?
+- How do we measure and improve trust in AI-generated documentation?

--- a/projects/16-23/22-ai-documentation-assistant/docs/implementation-plan.md
+++ b/projects/16-23/22-ai-documentation-assistant/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: Prototype (3 weeks):**
+  - Build ingestion connectors for Git and ticketing systems.
+  - Integrate hosted LLM with prompt templates and redaction filters.
+  - Deliver MVP review console with Git-based change requests.
+- **Phase 2: Guardrails & UX (4 weeks):**
+  - Implement human-in-the-loop approval workflows and audit logs.
+  - Add style guides and doc templates for consistent output.
+  - Surface freshness indicators and doc status on portal pages.
+- **Phase 3: Scale (4 weeks):**
+  - Optimize inference cost with caching and batching strategies.
+  - Support multi-language documentation and localization reviewers.
+  - Roll out to two pilot product areas with enablement training.
+
+## Backlog Candidates
+- Fine-tune models on internal documentation style corpus.
+- Automate translation to PDF and presentation formats.
+- Integrate voice dictation for SME feedback loops.

--- a/projects/16-23/22-ai-documentation-assistant/docs/operations-runbook.md
+++ b/projects/16-23/22-ai-documentation-assistant/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Deploy orchestrator as containerized service with autoscaling policies.
+- Validate LLM provider connectivity and fallback models prior to release.
+- Run redaction regression tests against synthetic sensitive data.
+
+## Monitoring & Alerting
+- Track generation success rate, reviewer approval time, and doc freshness score.
+- Alert on elevated hallucination risk metrics or redaction failures.
+- Monitor inference cost budgets and API latency.
+
+## Rollback Procedures
+- Disable automated publishing and revert to manual docs while issues resolved.
+- Roll back to previous orchestrator container image and prompt set.
+- Notify compliance teams if content exposure is suspected.
+
+## Service Level Objectives
+- 95% of doc drafts generated within 2 hours of new commits.
+- <5% reviewer rejection rate due to inaccuracies.
+- 99.5% availability for review console.

--- a/projects/16-23/22-ai-documentation-assistant/docs/proposal.md
+++ b/projects/16-23/22-ai-documentation-assistant/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Teams struggle to keep documentation updated, resulting in stale runbooks and knowledge silos that slow onboarding and incident response.
+
+## Goals
+- Generate first-draft documentation from code repositories and issue trackers.
+- Enable reviewers to approve, edit, or reject AI-suggested changes with audit trails.
+- Integrate with documentation portals to surface freshness indicators.
+
+## Success Criteria
+- Reduce time to produce post-incident reports by 50%.
+- Automated doc refresh suggestions generated weekly for all Tier 1 services.
+- Maintain reviewer approval accuracy above 95%.

--- a/projects/16-23/23-compliance-evidence-automation/README.md
+++ b/projects/16-23/23-compliance-evidence-automation/README.md
@@ -1,0 +1,10 @@
+# Compliance Evidence Automation
+
+Pipeline that collects, normalizes, and packages compliance evidence for audits with minimal manual effort.
+
+## Documentation
+- [Proposal](./docs/proposal.md)
+- [Architecture](./docs/architecture.md)
+- [Implementation Plan](./docs/implementation-plan.md)
+- [Operations Runbook](./docs/operations-runbook.md)
+- [Future Roadmap](./docs/future-roadmap.md)

--- a/projects/16-23/23-compliance-evidence-automation/docs/architecture.md
+++ b/projects/16-23/23-compliance-evidence-automation/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Overview
+Scheduled collectors gather evidence into a normalized store, while workflow engines manage approvals and package delivery.
+
+## Component Breakdown
+- **Evidence Collectors:** Pull configuration states, policies, and logs from systems of record.
+- **Normalization Layer:** Transforms raw data into standardized control artifacts with metadata.
+- **Workflow Engine:** Routes evidence for review, exception handling, and sign-off.
+- **Audit Portal:** Provides dashboards and secure download links for auditors.
+
+## Diagrams & Flows
+```text
+Collectors -> Normalization Store -> Workflow Engine -> Audit Portal -> Auditors
+            Exception Queue -> Control Owners -> Resolution -> Updated Evidence
+```

--- a/projects/16-23/23-compliance-evidence-automation/docs/future-roadmap.md
+++ b/projects/16-23/23-compliance-evidence-automation/docs/future-roadmap.md
@@ -1,0 +1,10 @@
+# Future Roadmap
+
+## Planned Enhancements
+- Integrate continuous control monitoring with risk scoring.
+- Provide predictive forecasting for upcoming audit evidence workloads.
+- Investigate blockchain-backed immutability for high-trust controls.
+
+## Open Questions
+- What jurisdictions require data residency for evidence artifacts?
+- How do we align retention policies with audit and privacy requirements?

--- a/projects/16-23/23-compliance-evidence-automation/docs/implementation-plan.md
+++ b/projects/16-23/23-compliance-evidence-automation/docs/implementation-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Phases & Milestones
+- **Phase 1: MVP Controls (4 weeks):**
+  - Implement collectors for IAM, infrastructure config, and CI/CD logs.
+  - Stand up normalization schema with immutability guarantees.
+  - Deliver basic dashboard showing control status and evidence freshness.
+- **Phase 2: Workflow Automation (4 weeks):**
+  - Integrate ticketing for exception tracking and remediation plans.
+  - Automate evidence reviews with digital signatures and audit trails.
+  - Provide scheduled export packages aligned with SOC2 controls.
+- **Phase 3: Scaling (5 weeks):**
+  - Expand collector coverage to Kubernetes, data warehouse, and endpoint security.
+  - Introduce auditor access portal with granular permissions.
+  - Run mock audit to validate end-to-end readiness and gather feedback.
+
+## Backlog Candidates
+- Support ISO 27001 and HIPAA control mappings.
+- Add evidence quality scoring based on completeness and age.
+- Enable API access for GRC tools to fetch evidence programmatically.

--- a/projects/16-23/23-compliance-evidence-automation/docs/operations-runbook.md
+++ b/projects/16-23/23-compliance-evidence-automation/docs/operations-runbook.md
@@ -1,0 +1,21 @@
+# Operations Runbook
+
+## Deployment
+- Deploy collectors via serverless functions with staggered schedules.
+- Apply infrastructure-as-code for normalization store and workflow services.
+- Test audit portal authentication and encryption prior to launches.
+
+## Monitoring & Alerting
+- Track evidence freshness, collector success rates, and workflow SLA adherence.
+- Alert on overdue controls, failed exports, and unauthorized access attempts.
+- Review storage integrity via periodic hash verification.
+
+## Rollback Procedures
+- Disable problematic collectors while investigating data quality issues.
+- Restore previous schema versions via migration scripts and backups.
+- Communicate rollback status to compliance and audit stakeholders.
+
+## Service Level Objectives
+- Evidence freshness under 24 hours for automated controls.
+- <1% collector failure rate per run.
+- 100% audit trail completeness for approvals and access.

--- a/projects/16-23/23-compliance-evidence-automation/docs/proposal.md
+++ b/projects/16-23/23-compliance-evidence-automation/docs/proposal.md
@@ -1,0 +1,14 @@
+# Proposal
+
+## Problem Statement
+Audits require weeks of manual screenshotting and data collection, leading to delays, inconsistencies, and burnout for control owners.
+
+## Goals
+- Automate evidence collection from cloud APIs, CI/CD logs, and identity systems.
+- Provide reviewers with dashboards tracking control status and exceptions.
+- Generate auditor-ready packages with tamper-evident storage and access logs.
+
+## Success Criteria
+- 80% of recurring evidence requests satisfied automatically.
+- Exception handling workflow resolves outstanding issues within five business days.
+- Auditors accept automated packages without additional manual screenshots.


### PR DESCRIPTION
## Summary
- add documentation directories for each project under `projects/16-23`
- capture proposals, architecture, implementation plans, operations runbooks, and future roadmaps for every project
- link the new documentation set from each project README so stakeholders can navigate to the assets quickly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fa4186291883278b9a873fa83d2420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation for eight strategic initiatives: Zero Downtime Migrations, Observability as Code, Customer 360 Data Lake, Incident Response Automation, Secure Remote Access, Developer Self-Service Portal, AI Documentation Assistant, and Compliance Evidence Automation. Each includes proposal, architecture, implementation plan, operations runbook, and future roadmap documentation to support planning and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->