### PR TITLE
Fix frontend build assets and restore integration test

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,46 @@
+import importlib
+from typing import Any
+
+import pytest_asyncio
+from httpx import AsyncClient
+
+
+def _load_application() -> Any:
+    module_candidates = (
+        "backend.main",
+        "backend.app",
+        "app.main",
+        "app",
+    )
+    last_error: Exception | None = None
+    for module_name in module_candidates:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            last_error = exc
+            continue
+
+        if hasattr(module, "create_app"):
+            app = module.create_app()  # type: ignore[attr-defined]
+            if app is not None:
+                return app
+
+        app = getattr(module, "app", None)
+        if app is not None:
+            return app
+
+    raise RuntimeError(
+        "Unable to locate an ASGI application. Ensure the backend exposes "
+        "an 'app' instance or 'create_app' factory in backend.main."
+    ) from last_error
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncClient:
+    app = _load_application()
+    await app.router.startup()
+    try:
+        async with AsyncClient(app=app, base_url="http://testserver") as async_client:
+            yield async_client
+    finally:
+        await app.router.shutdown()

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,54 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_complete_user_workflow(client: AsyncClient):
+    # 1. Register
+    r = await client.post(
+        "/api/auth/register",
+        json={"email": "workflow@example.com", "password": "workflowpass123"},
+    )
+    assert r.status_code == 201
+    user_id = r.json()["id"]
+    assert user_id
+
+    # 2. Login
+    r = await client.post(
+        "/api/auth/login",
+        data={"username": "workflow@example.com", "password": "workflowpass123"},
+    )
+    assert r.status_code == 200
+    token = r.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # 3. Create
+    r = await client.post(
+        "/api/content/",
+        json={"title": "Integration Test", "body": "Full workflow test"},
+        headers=headers,
+    )
+    assert r.status_code == 201
+    cid = r.json()["id"]
+
+    # 4. Read
+    r = await client.get(f"/api/content/{cid}", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["title"] == "Integration Test"
+
+    # 5. Update
+    r = await client.put(
+        f"/api/content/{cid}",
+        json={"title": "Updated Title"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["title"] == "Updated Title"
+
+    # 6. Delete
+    r = await client.delete(f"/api/content/{cid}", headers=headers)
+    assert r.status_code == 204
+
+    # 7. Confirm deletion
+    r = await client.get(f"/api/content/{cid}", headers=headers)
+    assert r.status_code == 404

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci
 COPY . .
 RUN npm run build
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS production
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:80/ || exit 1
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,40 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
+
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Referrer-Policy "no-referrer-when-downgrade" always;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+
+  location /health {
+    access_log off;
+    return 200 "healthy\n";
+    add_header Content-Type text/plain;
+  }
+
+  location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+}


### PR DESCRIPTION
## Summary
- restore the multi-stage frontend Dockerfile so nginx starts correctly
- add the nginx configuration with caching and security headers
- recreate the backend integration test that exercises the full user workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7bd8e6f6083279182364c58433a1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration test covering user registration, login, and content management workflows via API.

* **Chores**
  * Containerized frontend application with optimized Docker build and Nginx configuration.
  * Enabled response compression and static asset caching for improved performance.
  * Added security headers and API request routing with health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->