### PR TITLE
Add security testing references and pentest access guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Overview
+
+This portfolio repository captures the processes, documentation, and representative evidence used to secure the showcased projects. The goals are to demonstrate a mature security posture while keeping sensitive artifacts out of the public export.
+
+## Security Governance
+- Ownership for security policies, vulnerability management, and incident response sits with the **Security & Reliability** working group (primary contact: `security@samsjackson.dev`).
+- All changes to infrastructure or application code require code review, automated testing, and adherence to the documented change management checklist before promotion to production-like environments.
+
+## Security Testing
+- **Security test plan:** Review the repeatable verification activities, tooling, and cadences that are applied across projects in [`documentation/security/security-test-plan.md`](./documentation/security/security-test-plan.md).
+- **Penetration testing evidence:** Sanitized summaries are provided in [`documentation/security/pentest-reports/`](./documentation/security/pentest-reports/). Raw reports remain access-controlled; follow the instructions in that directory to request time-bound access to full findings and remediation tracking assets.
+
+## Reporting an Issue
+To report a suspected vulnerability or security incident, email `security@samsjackson.dev` with the affected project, reproduction steps, and any relevant evidence. Public disclosure is requested to follow a 90-day coordinated timeline unless immediate risk warrants faster action.

--- a/documentation/security/pentest-reports/README.md
+++ b/documentation/security/pentest-reports/README.md
@@ -1,0 +1,17 @@
+# Penetration Test Reports
+
+The raw penetration test reports for this portfolio are not included in the public export because they contain scoped system details, tooling outputs, and remediation notes that are restricted to vetted partners.
+
+This directory instead provides an access summary so stakeholders understand what is available and how to request it.
+
+## Available Artifacts
+- **Redacted executive summary (PDF)** – high-level findings, risk ratings, and remediation status.
+- **Full pentest report (encrypted ZIP)** – methodology, evidence, screenshots, and ticket references.
+- **Remediation tracking workbook (spreadsheet)** – issue owners, target dates, and verification logs.
+
+## Access Process
+1. Email `security@samsjackson.dev` from an organization-managed account describing the engagement context.
+2. Sign the standard non-disclosure agreement (NDA) that will be provided in reply.
+3. Upon verification, a time-bound download link and decryption key will be shared over separate channels.
+
+For urgent security incidents, call the on-call line listed in the incident response plan to expedite review.

--- a/documentation/security/security-test-plan.md
+++ b/documentation/security/security-test-plan.md
@@ -1,0 +1,20 @@
+# Security Test Plan Overview
+
+This document outlines the repeatable security verification activities that accompany each portfolio project deployment.
+
+## Scope
+- Cloud infrastructure baselines (AWS Organizations, IAM, networking)
+- Application services (web apps, APIs, and supporting data stores)
+- Developer tooling and CI/CD pipelines
+
+## Testing Cadence
+- **Quarterly:** External vulnerability scans, dependency audits, and tabletop incident drills.
+- **Bi-annually:** Third-party penetration testing engagements focused on critical services.
+- **Pre-release:** Static and dynamic analysis incorporated into CI workflows for major features.
+
+## Tooling & Automation
+- Dependency review via GitHub Advanced Security and OWASP Dependency-Check.
+- Infrastructure drift detection with Terraform plan pipelines and policy-as-code gates.
+- Dynamic security testing via OWASP ZAP scripted scans in staging environments.
+
+Refer to individual project folders for system-specific runbooks and acceptance criteria.


### PR DESCRIPTION
## Summary
- add a SECURITY.md overview with governance, testing details, and reporting contacts
- create a documentation/security/pentest-reports/ folder that explains access constraints for penetration test artifacts
- document the security testing plan that is referenced from the security overview

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f94c814db88327aa4b8eb5ea5dc04a