### PR TITLE
Add TwistedMonk namespace scaffolding and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "twistedmonk"
+version = "0.1.0"
+description = "Shared utilities and service scaffolding for TwistedMonk workstreams"
+authors = [{name = "Sam Jackson"}]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/sams-jackson"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/src/twistedmonk/__init__.py
+++ b/src/twistedmonk/__init__.py
@@ -1,0 +1,6 @@
+"""TwistedMonk shared utilities and service packages."""
+
+from .config import AppConfig, load_config
+from .logging import configure_logging
+
+__all__ = ["AppConfig", "load_config", "configure_logging"]

--- a/src/twistedmonk/ads/__init__.py
+++ b/src/twistedmonk/ads/__init__.py
@@ -1,0 +1,5 @@
+"""Advertising automation services."""
+
+from .services import AdAutomationService
+
+__all__ = ["AdAutomationService"]

--- a/src/twistedmonk/ads/services.py
+++ b/src/twistedmonk/ads/services.py
@@ -1,0 +1,28 @@
+"""Advertising automation service layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class AdAutomationService:
+    """Handles campaign planning, creative testing, and reporting stubs."""
+
+    account_id: str
+
+    def plan_campaigns(self, objectives: Iterable[str]) -> List[str]:
+        """Stub for generating campaign plans for ad objectives."""
+        return [f"Plan for {objective}" for objective in objectives]
+
+    def launch_creatives(self, creatives: Iterable[str]) -> Dict[str, bool]:
+        """Stub for launching creatives across channels."""
+        return {creative: True for creative in creatives}
+
+    def compile_reports(self, period: str) -> Dict[str, str]:
+        """Stub for compiling ad performance reports."""
+        return {"period": period, "status": "generated"}
+
+
+__all__ = ["AdAutomationService"]

--- a/src/twistedmonk/automation/__init__.py
+++ b/src/twistedmonk/automation/__init__.py
@@ -1,0 +1,5 @@
+"""Automation orchestration services."""
+
+from .services import AutomationOrchestrator
+
+__all__ = ["AutomationOrchestrator"]

--- a/src/twistedmonk/automation/services.py
+++ b/src/twistedmonk/automation/services.py
@@ -1,0 +1,28 @@
+"""Automation and orchestration utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class AutomationOrchestrator:
+    """Coordinates runbooks, schedules, and pipeline triggers."""
+
+    workflow_name: str
+
+    def register_runbook(self, name: str) -> str:
+        """Stub for registering an automation runbook."""
+        return f"Runbook {name} registered"
+
+    def schedule_jobs(self, jobs: Iterable[str]) -> List[str]:
+        """Stub for scheduling automation jobs."""
+        return list(jobs)
+
+    def trigger_pipeline(self, pipeline: str) -> bool:
+        """Stub for triggering a pipeline."""
+        return bool(pipeline)
+
+
+__all__ = ["AutomationOrchestrator"]

--- a/src/twistedmonk/competitors/__init__.py
+++ b/src/twistedmonk/competitors/__init__.py
@@ -1,0 +1,5 @@
+"""Competitive intelligence services."""
+
+from .services import CompetitorIntelEngine
+
+__all__ = ["CompetitorIntelEngine"]

--- a/src/twistedmonk/competitors/services.py
+++ b/src/twistedmonk/competitors/services.py
@@ -1,0 +1,28 @@
+"""Competitive intelligence workflow services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class CompetitorIntelEngine:
+    """Coordinates research, monitoring, and insight summarization."""
+
+    market: str
+
+    def collect_sources(self, sources: Iterable[str]) -> List[str]:
+        """Stub for collecting competitor intelligence sources."""
+        return list(sources)
+
+    def analyze_signals(self, signals: Iterable[str]) -> Dict[str, str]:
+        """Stub for analyzing competitor signals."""
+        return {signal: "analyzed" for signal in signals}
+
+    def summarize_findings(self) -> str:
+        """Stub for summarizing competitor research findings."""
+        return "Summary pending"
+
+
+__all__ = ["CompetitorIntelEngine"]

--- a/src/twistedmonk/config.py
+++ b/src/twistedmonk/config.py
@@ -1,0 +1,42 @@
+"""Configuration loading for TwistedMonk services."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """Runtime configuration loaded from environment variables."""
+
+    environment: str = "development"
+    log_level: str = "INFO"
+    default_timezone: str = "UTC"
+    secrets_backend: str = "env"
+    feature_flags: Optional[str] = None
+
+    @property
+    def flags(self) -> tuple[str, ...]:
+        """Expose feature flags as a normalized tuple."""
+        if not self.feature_flags:
+            return tuple()
+        return tuple(flag.strip() for flag in self.feature_flags.split(",") if flag.strip())
+
+
+@lru_cache(maxsize=1)
+def load_config() -> AppConfig:
+    """Load the configuration from environment variables, caching the result."""
+
+    return AppConfig(
+        environment=os.getenv("TWISTEDMONK_ENV", "development"),
+        log_level=os.getenv("TWISTEDMONK_LOG_LEVEL", "INFO"),
+        default_timezone=os.getenv("TWISTEDMONK_TZ", "UTC"),
+        secrets_backend=os.getenv("TWISTEDMONK_SECRETS_BACKEND", "env"),
+        feature_flags=os.getenv("TWISTEDMONK_FEATURE_FLAGS"),
+    )
+
+
+__all__ = ["AppConfig", "load_config"]

--- a/src/twistedmonk/logging.py
+++ b/src/twistedmonk/logging.py
@@ -1,0 +1,48 @@
+"""Logging helpers shared across TwistedMonk services."""
+
+from __future__ import annotations
+
+import logging
+from logging.config import dictConfig
+from typing import Any, Dict, Optional
+
+from .config import load_config
+
+
+DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+        }
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+}
+
+
+def configure_logging(config: Optional[Dict[str, Any]] = None) -> None:
+    """Configure application logging using the shared defaults."""
+
+    merged = dict(DEFAULT_LOGGING_CONFIG)
+    if config:
+        merged.update(config)
+
+    runtime_config = load_config()
+    merged.setdefault("root", {})
+    merged["root"].setdefault("level", runtime_config.log_level)
+    dictConfig(merged)
+
+    logging.getLogger(__name__).debug("Logging configured with level %s", runtime_config.log_level)
+
+
+__all__ = ["configure_logging", "DEFAULT_LOGGING_CONFIG"]

--- a/src/twistedmonk/seo/__init__.py
+++ b/src/twistedmonk/seo/__init__.py
@@ -1,0 +1,5 @@
+"""SEO automation services."""
+
+from .services import ContentAISuite
+
+__all__ = ["ContentAISuite"]

--- a/src/twistedmonk/seo/services.py
+++ b/src/twistedmonk/seo/services.py
@@ -1,0 +1,28 @@
+"""SEO-focused service layer for content automation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class ContentAISuite:
+    """High-level facade for the SEO content automation workflow."""
+
+    project_name: str
+
+    def generate_keywords(self, seed_terms: Iterable[str]) -> List[str]:
+        """Stub for keyword expansion based on provided seed terms."""
+        return list(seed_terms)
+
+    def optimize_brief(self, topic: str) -> str:
+        """Stub for generating an optimized content brief for a topic."""
+        return f"Optimized brief for {topic}"
+
+    def publish_to_cms(self, slug: str) -> bool:
+        """Stub for publishing generated content to a CMS."""
+        return bool(slug)
+
+
+__all__ = ["ContentAISuite"]

--- a/src/twistedmonk/video/__init__.py
+++ b/src/twistedmonk/video/__init__.py
@@ -1,0 +1,5 @@
+"""Video automation services."""
+
+from .services import VideoAIPipeline
+
+__all__ = ["VideoAIPipeline"]

--- a/src/twistedmonk/video/services.py
+++ b/src/twistedmonk/video/services.py
@@ -1,0 +1,28 @@
+"""Video automation workflows and orchestration primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class VideoAIPipeline:
+    """Coordinates the AI-driven video production pipeline."""
+
+    channel: str
+
+    def ingest_assets(self, assets: Iterable[str]) -> List[str]:
+        """Stub for ingesting creative assets into the pipeline."""
+        return list(assets)
+
+    def assemble_storyboard(self, script: str) -> str:
+        """Stub for assembling a storyboard from a script."""
+        return f"Storyboard for {script}"
+
+    def publish_video(self, destination: str) -> bool:
+        """Stub for publishing the rendered video."""
+        return bool(destination)
+
+
+__all__ = ["VideoAIPipeline"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest fixtures and configuration for the test suite."""
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for configuration utilities."""
+
+from twistedmonk.config import AppConfig, load_config
+
+
+def test_default_config_values(monkeypatch):
+    """Configuration should provide sensible defaults when env vars are missing."""
+
+    for env_var in (
+        "TWISTEDMONK_ENV",
+        "TWISTEDMONK_LOG_LEVEL",
+        "TWISTEDMONK_TZ",
+        "TWISTEDMONK_SECRETS_BACKEND",
+        "TWISTEDMONK_FEATURE_FLAGS",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    load_config.cache_clear()
+    config = load_config()
+
+    assert isinstance(config, AppConfig)
+    assert config.environment == "development"
+    assert config.log_level == "INFO"
+    assert config.default_timezone == "UTC"
+    assert config.secrets_backend == "env"
+    assert config.flags == tuple()
+
+
+def test_feature_flag_parsing(monkeypatch):
+    """Feature flags should be normalized to a tuple of trimmed values."""
+
+    monkeypatch.setenv("TWISTEDMONK_FEATURE_FLAGS", "alpha,beta , gamma")
+
+    load_config.cache_clear()
+    config = load_config()
+
+    assert config.flags == ("alpha", "beta", "gamma")
+
+    load_config.cache_clear()
+    monkeypatch.delenv("TWISTEDMONK_FEATURE_FLAGS", raising=False)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,21 @@
+"""Ensure service modules import and expose expected classes."""
+
+import twistedmonk
+from twistedmonk.ads import AdAutomationService
+from twistedmonk.automation import AutomationOrchestrator
+from twistedmonk.competitors import CompetitorIntelEngine
+from twistedmonk.seo import ContentAISuite
+from twistedmonk.video import VideoAIPipeline
+
+
+def test_namespace_exports():
+    assert hasattr(twistedmonk, "load_config")
+    assert hasattr(twistedmonk, "configure_logging")
+
+
+def test_service_instantiation():
+    assert ContentAISuite(project_name="demo").publish_to_cms("slug")
+    assert VideoAIPipeline(channel="primary").publish_video("yt")
+    assert AdAutomationService(account_id="acct").compile_reports("weekly")
+    assert CompetitorIntelEngine(market="global").summarize_findings() == "Summary pending"
+    assert AutomationOrchestrator(workflow_name="ops").trigger_pipeline("deploy")


### PR DESCRIPTION
## Summary
- add a setuptools-backed pyproject that exposes the `twistedmonk` namespace from `src/`
- scaffold service classes for SEO, video, ads, competitor, and automation workstreams with workflow stubs
- implement shared configuration/logging helpers and seed pytest smoke tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9a8cd0f688327942efee23eb96374