### PR TITLE
Add 21-day execution schedule for AIML automation project

### DIFF
--- a/projects/07-aiml-automation/PRJ-AIML-002/README.md
+++ b/projects/07-aiml-automation/PRJ-AIML-002/README.md
@@ -1,0 +1,51 @@
+# PRJ-AIML-002 · AI Marketing Automation Sprint
+
+## Overview
+This project packages a 3-week execution sprint to stand up, validate, and operationalize an AI-driven marketing automation loop. The intent is to combine data collection, SEO intelligence, and generative content workflows into a repeatable pipeline with clear ownership, instrumentation, and escalation paths.
+
+## Phasing Plan
+| Phase | Duration | Objectives | Tooling Anchor |
+| --- | --- | --- | --- |
+| Discovery & Intake | Days 1–5 | Confirm goals, map data sources, and capture current SEO/content baselines. | Notion, Screaming Frog, Airbyte |
+| Build & Automate | Days 6–15 | Stand up ingestion, modeling, and automation layers with quality gates. | dbt, LangChain, FastAPI, Zapier |
+| Launch & Optimize | Days 16–21 | Ship to production, harden monitoring, and tune based on live feedback. | Grafana, TestRail, OpenAI APIs |
+
+## 21-Day Execution Schedule
+| Day | Functional Focus | Primary Deliverable | Dependencies | Owner |
+| --- | --- | --- | --- | --- |
+| Day 1 | Kickoff & Intake | Align success criteria, confirm access matrix, populate Notion roadmap. | Executive sponsor availability | Sam Jackson (Project Lead) |
+| Day 2 | SEO Intelligence | Run Screaming Frog crawl, log critical SEO fixes, distribute Jira tickets. | CMS credentials, crawl budget approvals | Priya Mehta (SEO Specialist) |
+| Day 3 | Data Ingestion | Configure Airbyte connectors for web analytics and CRM data. | API keys for GA4, HubSpot | Luis Romero (Data Engineer) |
+| Day 4 | Data Quality | Execute dbt source freshness + schema tests; publish data health report. | Successful Day 3 sync | Luis Romero (Data Engineer) |
+| Day 5 | Automation Blueprint | Draft LangChain + Zapier orchestration diagram and sequence chart. | Intake notes, approved use cases | Morgan Lee (Automation Architect) |
+| Day 6 | **Weekend Buffer** | Swap rule: triage backlog or advance low-risk fixes; log carryover in Notion. | Outstanding Day 1–5 actions | Sam Jackson (On-call) |
+| Day 7 | Knowledge Base | Stand up shared Confluence/Notion workspace; import SOP templates. | Workspace licenses, template approvals | Casey Grant (Delivery PM) |
+| Day 8 | Model Selection | Evaluate GPT prompt patterns vs. in-house models; decide pilot stack. | Cleaned datasets, OpenAI billing OK | Avery Chen (ML Engineer) |
+| Day 9 | Model Tuning | Run fine-tuning experiments and capture evaluation metrics in Weights & Biases. | Approved Day 8 stack, GPU credits | Avery Chen (ML Engineer) |
+| Day 10 | API Layer | Build FastAPI wrapper with authentication and rate limiting in place. | Tuning outputs, secrets vault access | Jamie Patel (Automation Developer) |
+| Day 11 | QA Automation | Author PyTest + Playwright regression suite covering primary flows. | Stable Day 10 endpoints | Riley Owens (QA Lead) |
+| Day 12 | Monitoring & Alerting | Deploy Grafana dashboards, Loki logs, and PagerDuty alert policies. | Observability cluster credentials | Taylor Brooks (SRE) |
+| Day 13 | **Weekend Buffer** | Swap rule: finish QA debt or prepare enablement material; note deferrals. | QA status from Day 11 | Sam Jackson (On-call) |
+| Day 14 | SEO Content Loop | Automate keyword clusters into Notion briefs via Zapier + GPT actions. | Validated prompts, Zapier premium seats | Priya Mehta (SEO Specialist) |
+| Day 15 | Stakeholder Playback | Run Miro playback, capture sign-off, and prioritize launch blockers. | Cross-functional availability | Casey Grant (Delivery PM) |
+| Day 16 | Staging Deployment | Deploy automation stack to staging; validate with smoke scripts. | Sign-off from Day 15, infra windows | Jamie Patel (Automation Developer) |
+| Day 17 | UAT & Training | Facilitate TestRail-guided UAT, collect feedback, schedule enablement. | UAT participants, staging stability | Riley Owens (QA Lead) |
+| Day 18 | Runbooks & SOPs | Publish Ops/Support runbooks, escalation ladders, and rollback procedures. | Finalized workflows, UAT notes | Morgan Lee (Automation Architect) |
+| Day 19 | Production Launch | Execute release checklist, monitor first-run metrics, and confirm alerts. | Change advisory approval | Taylor Brooks (SRE) |
+| Day 20 | **Weekend Buffer** | Swap rule: hold hypercare stand-up, address Sev-2/3, prep for retro. | Production metrics from Day 19 | Sam Jackson (On-call) |
+| Day 21 | Retrospective & Handoff | Lead blameless retro, finalize success metrics, transition to operations. | All previous deliverables, metrics snapshot | Sam Jackson (Project Lead) |
+
+**Weekend Buffers & Swap Rules:** Days 6, 13, and 20 are intentionally light-touch. They operate under a swap rule—if the prior weekday closes cleanly, the owner may pull forward Day 22+ backlog items; otherwise, they stabilize open issues. Weekend blockers escalate immediately via Slack `#aiml-delivery` to Sam Jackson (Project Lead) and, if unresolved within 4 hours, to Alex Rivera (Executive Sponsor) for resourcing.
+
+**Escalation Contacts:**
+- **Primary:** Sam Jackson — Project Lead (Slack `@sam.jackson`, email `sam@samsjackson.dev`).
+- **Secondary:** Alex Rivera — Executive Sponsor (Slack `@alex.rivera`).
+- **Tertiary:** Taylor Brooks — SRE On-Call (PagerDuty schedule `AIML-Auto`).
+
+**Communication Cadence:** Daily stand-up (09:00 PT), weekend async check-in (11:00 PT via Slack thread), and blocker triage windows at 14:00 PT on weekdays ensure issues surface before they impact downstream owners.
+
+**Adjustment Guidance:**
+- **Push/Pull Rules:** If a dependency slips, push the affected task to the next available buffer (Days 6, 13, or 20) and pull in a ready backlog item of equal or lesser effort to keep throughput steady.
+- **Fallback Priorities:** Prioritize restoring data integrity (Days 3–4 outputs), preserving automation stability (Days 10–12), and keeping stakeholder alignment (Day 15) before reintroducing lower-impact enhancements.
+- **Escalation Triggers:** Any slip longer than one business day or affecting production launch readiness must be escalated to Alex Rivera for decisioning on additional resourcing or scope trade-offs.
+- **Re-Baselining Protocol:** Document variance in Notion, capture revised due dates, and circulate an updated schedule via the weekly status memo; avoid wholesale re-planning unless two or more critical path items slip simultaneously.


### PR DESCRIPTION
## Summary
- create PRJ-AIML-002 project README with overview and phased delivery context
- document a 21-day execution schedule with tooling-aligned tasks, weekend buffers, and escalation guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9a8cecb0083278da3926dd89de176