### PR TITLE
Fix AdCreativeAI benefit normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for portfolio project utilities."""

--- a/src/advertising/__init__.py
+++ b/src/advertising/__init__.py
@@ -1,0 +1,5 @@
+"""Advertising tools for generating marketing copy."""
+
+from .core import AdCreativeAI
+
+__all__ = ["AdCreativeAI"]

--- a/src/advertising/core.py
+++ b/src/advertising/core.py
@@ -1,0 +1,73 @@
+"""Core advertising helpers used across the portfolio tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Dict, List
+
+
+class AdCreativeAI:
+    """Generate lightweight advertising copy for portfolio demos."""
+
+    DEFAULT_HEADLINE_TEMPLATE = "{product}: {benefits}"
+    DEFAULT_COPY_TEMPLATE = (
+        "Discover {benefits} with {product}. This {tone} message was generated "
+        "by the AdCreativeAI helper."
+    )
+
+    def __init__(
+        self,
+        *,
+        headline_template: str | None = None,
+        copy_template: str | None = None,
+        default_tone: str = "friendly",
+    ) -> None:
+        self.headline_template = headline_template or self.DEFAULT_HEADLINE_TEMPLATE
+        self.copy_template = copy_template or self.DEFAULT_COPY_TEMPLATE
+        self.default_tone = default_tone
+
+    def _normalize_benefits(self, benefits: Any) -> List[str]:
+        """Ensure benefits are stored as a list of human-friendly strings."""
+
+        if benefits is None:
+            return []
+
+        if isinstance(benefits, str):
+            candidates: Iterable[Any] = [benefits]
+        elif isinstance(benefits, Iterable):
+            candidates = list(benefits)
+        else:
+            candidates = [benefits]
+
+        normalized: List[str] = []
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            text = str(candidate).strip()
+            if text:
+                normalized.append(text)
+        return normalized
+
+    def generate(self, product_name: str, benefits: Any, tone: str | None = None) -> Dict[str, Any]:
+        """Return a dictionary containing the generated marketing assets."""
+
+        tone_value = (tone or self.default_tone).strip() or self.default_tone
+        product_label = str(product_name).strip() or "Unnamed Product"
+        benefit_list = self._normalize_benefits(benefits)
+
+        if benefit_list:
+            benefits_phrase = ", ".join(benefit_list)
+        else:
+            benefits_phrase = "standout benefits"
+
+        headline = self.headline_template.format(
+            product=product_label, benefits=benefits_phrase, tone=tone_value
+        )
+        copy = self.copy_template.format(product=product_label, benefits=benefits_phrase, tone=tone_value)
+
+        return {
+            "headline": headline,
+            "copy": copy,
+            "tone": tone_value,
+            "benefits": benefit_list,
+        }

--- a/tests/test_advertising.py
+++ b/tests/test_advertising.py
@@ -1,0 +1,26 @@
+"""Tests for advertising helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.advertising.core import AdCreativeAI
+
+
+def test_generate_handles_string_benefits_without_splitting() -> None:
+    """Ensure a string is treated as a single benefit, not character by character."""
+
+    ai = AdCreativeAI()
+    benefits = "Instant hydration boost"
+
+    result = ai.generate("Glow Serum", benefits=benefits)
+
+    assert result["benefits"] == [benefits]
+    assert benefits in result["headline"]
+    assert benefits in result["copy"]
+    assert "I, n, s" not in result["headline"]


### PR DESCRIPTION
## Summary
- add an advertising helper package with AdCreativeAI for generating headlines and copy
- normalize scalar benefit inputs so strings are kept intact instead of iterated character by character
- introduce a regression test covering the string benefit case

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa34d3e1b08327b0e8f561000856b7