### PR TITLE
Move PRJ-AIML-002 plan into private docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/private/** export-ignore

--- a/docs/private/projects/07-aiml-automation/PRJ-AIML-002/implementation-plan.md
+++ b/docs/private/projects/07-aiml-automation/PRJ-AIML-002/implementation-plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan — PRJ-AIML-002: Document Packaging Automation
+
+> Internal use only. This plan was migrated from the project README to keep AI workflow guidance and prompt engineering notes in a restricted location.
+
+## 1. Objectives
+- Automate generation of packaged deliverables (Docs, PDFs, XLSX) from structured prompts and datasets.
+- Provide a repeatable CLI entry point for engineers to run targeted packaging jobs or scheduled batches.
+- Capture intermediate artefacts (prompt inputs, raw model responses, validation logs) for auditability.
+
+## 2. System Outline
+- **Source adapters** read project briefs, tabular data, and template fragments from Git, SharePoint exports, or local folders.
+- **Prompt builder** composes LLM-ready instructions using YAML/JSON templates plus inline substitution of dataset values.
+- **Generation engine** fans out prompts across selected models (OpenAI-compatible HTTP APIs or local inference endpoints).
+- **Post-processing** normalises Markdown/HTML, merges tables, and produces final Docx/PDF/XLSX bundles.
+- **Orchestrator** (Prefect or lightweight asyncio runner) coordinates adapters → prompt builder → generation → export, persisting run metadata in SQLite.
+
+## 3. Milestones & Tasks
+
+### Milestone A — Data & Template Layer (Week 1)
+1. Finalise repository layout (`src/` package, `config/` for adapter settings, `templates/` for prompt scaffolds).
+2. Build file-system adapter with schema validation and support for CSV/Excel ingestion.
+3. Define template syntax (`${placeholder}`) and implement loader with Jinja2 environment + safety filters.
+4. Unit tests for adapter edge cases (missing columns, invalid encodings, template parse errors).
+
+### Milestone B — Prompt Engineering Layer (Week 2)
+1. Create prompt catalogue YAML describing task, tone, output schema, retry policy.
+2. Implement prompt assembly service that injects dataset rows, chunking large tables, and appends guardrails.
+3. Provide dry-run mode that renders prompts without dispatching to models.
+4. Add snapshot logging for assembled prompts and evaluation rubric used per job.
+
+### Milestone C — Generation & QA (Week 3)
+1. Integrate OpenAI-compatible client with retry, exponential backoff, and rate-limit tracking.
+2. Normalize responses (Markdown to HTML) and enforce schema via Pydantic models.
+3. Implement QA hooks: structural validation, grammar/lint checks, and diffing vs previous outputs.
+4. Persist validated payloads and metadata, including prompt hashes and model IDs.
+
+### Milestone D — Packaging & Distribution (Week 4)
+1. Produce multi-format exports (Docx via python-docx, PDF via wkhtmltopdf container, XLSX via openpyxl).
+2. Bundle outputs with manifest.json summarizing source data, prompts used, and QA verdicts.
+3. Ship CLI commands: `package run <job>`, `package validate <job>`, and `package report <job>`.
+4. Document hand-off checklist (permissions review, delivery log update, archival to S3 bucket).
+
+## 4. Testing Strategy
+- Pytest suites for adapters, prompt builder, generation workflow, and CLI commands.
+- Golden-sample fixtures stored under `tests/fixtures/` for regression comparisons.
+- CI pipeline steps: lint (`ruff`), type-check (`mypy`), unit tests, and optional nightly integration test hitting sandbox LLM endpoint.
+
+## 5. Operations & Access Controls
+- Secrets (API keys, SharePoint tokens) sourced from `.env` or Azure Key Vault; never committed.
+- `docs/private/**` flagged with `export-ignore` in `.gitattributes` to keep internal docs out of packaged releases.
+- Run metadata stored in local SQLite during development; promote to PostgreSQL instance for staging/production.
+
+## 6. Open Questions & Follow-Ups
+- Evaluate whether to standardise on Prefect or custom asyncio orchestrator for long-running jobs.
+- Confirm licensing for wkhtmltopdf container usage in client environments.
+- Determine retention policy for generated artefacts and decide between S3 lifecycle rules or manual cleanup CLI.

--- a/projects/07-aiml-automation/PRJ-AIML-002/README.md
+++ b/projects/07-aiml-automation/PRJ-AIML-002/README.md
@@ -1,0 +1,39 @@
+# PRJ-AIML-002 — Document Packaging Automation
+
+This folder contains the developer-facing scaffolding for the document packaging
+pipeline. Runtime automation combines tabular datasets, reusable prompt
+templates, and light-weight orchestration so engineers can stage document
+bundles without copying the AI playbook into public documentation.
+
+## Directory Layout
+- `src/` – Python package implementing dataset adapters, prompt assembly, and
+  orchestration helpers.
+- `src/cli.py` – Minimal CLI wrapper used for smoke-testing the workflow
+  locally. The real deployment swaps out the default runner with a model
+  integration.
+
+## Module Summary
+- `adapters.py` – Parses CSV/TSV/JSON sources into dictionaries and exposes a
+  `chunk_records` helper for batching large datasets.
+- `prompt_builder.py` – Provides the `PromptTemplate` dataclass plus helper
+  functions for rendering prompts using string substitution.
+- `workflow.py` – Defines the `PackagingJob` orchestration primitive and a
+  reference post-processor used by integration tests.
+- `cli.py` – Offers a thin CLI around the core modules. It is safe to execute
+  in local environments because the default model runner simply echoes the
+  prompts back. Pass `--dry-run` to inspect prompts without invoking the
+  runner.
+
+## Getting Started
+1. Install Python 3.11+.
+2. Run `python projects/07-aiml-automation/PRJ-AIML-002/src/cli.py \
+   sample.csv sample-template.txt` to exercise the workflow. Provide
+   `--uppercase` to apply the reference post-processor or `--dry-run` to inspect
+   prompts only.
+3. Implementation plan, milestone breakdown, and prompt-engineering notes live
+   under `docs/private/projects/07-aiml-automation/PRJ-AIML-002/`.
+
+## Development Notes
+- Add regression tests under `tests/prj_aiml_002/` when extending the pipeline.
+- Keep sensitive model prompts, evaluation rubrics, and credential references in
+  the private docs directory and environment-specific secret stores.

--- a/projects/07-aiml-automation/PRJ-AIML-002/src/__init__.py
+++ b/projects/07-aiml-automation/PRJ-AIML-002/src/__init__.py
@@ -1,0 +1,10 @@
+"""Core package for the PRJ-AIML-002 automation toolkit."""
+
+from . import adapters, prompt_builder, workflow, cli  # noqa: F401
+
+__all__ = [
+    "adapters",
+    "prompt_builder",
+    "workflow",
+    "cli",
+]

--- a/projects/07-aiml-automation/PRJ-AIML-002/src/adapters.py
+++ b/projects/07-aiml-automation/PRJ-AIML-002/src/adapters.py
@@ -1,0 +1,85 @@
+"""Data adapter utilities for PRJ-AIML-002.
+
+The helpers here intentionally depend only on the Python standard library so
+that the automation toolkit can run in lightweight execution environments (e.g.
+GitHub Actions, ephemeral containers).  They cover the minimum viable feature
+set required by the developer workflow documented in this project.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    """Describe where a dataset lives and how it should be parsed."""
+
+    path: Path
+    kind: str | None = None
+    encoding: str = "utf-8"
+
+    def detect_kind(self) -> str:
+        """Infer the dataset type from the file extension when not provided."""
+
+        if self.kind:
+            return self.kind
+        suffix = self.path.suffix.lower()
+        if suffix in {".csv", ".tsv"}:
+            return "delimited"
+        if suffix in {".json"}:
+            return "json"
+        raise ValueError(f"Unsupported dataset type for {self.path!s}")
+
+
+def load_records(spec: DatasetSpec) -> List[Mapping[str, str]]:
+    """Load tabular records from CSV/TSV/JSON documents.
+
+    Returns a list of dictionaries ready to be consumed by prompt builders or
+    templating engines.  JSON payloads are expected to be arrays of objects.
+    """
+
+    kind = spec.detect_kind()
+    if kind == "delimited":
+        delimiter = ","
+        if spec.path.suffix.lower() == ".tsv":
+            delimiter = "\t"
+        with spec.path.open("r", encoding=spec.encoding, newline="") as handle:
+            reader = csv.DictReader(handle, delimiter=delimiter)
+            return [row for row in reader]
+    if kind == "json":
+        with spec.path.open("r", encoding=spec.encoding) as handle:
+            data = json.load(handle)
+        if not isinstance(data, list):
+            raise ValueError("JSON payload must be an array of objects")
+        return [ensure_string_map(item) for item in data]
+    raise ValueError(f"Unsupported dataset kind: {kind}")
+
+
+def ensure_string_map(item: Mapping[str, object]) -> Mapping[str, str]:
+    """Convert mapping values to strings for downstream templating."""
+
+    return {key: str(value) for key, value in item.items()}
+
+
+def chunk_records(records: Sequence[Mapping[str, str]], *, chunk_size: int) -> Iterable[Sequence[Mapping[str, str]]]:
+    """Yield the input records in fixed-size chunks.
+
+    Used by the prompt orchestration code when large datasets need to be broken
+    into manageable batches before dispatching work to an LLM endpoint.
+    """
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer")
+    batch: List[Mapping[str, str]] = []
+    for record in records:
+        batch.append(record)
+        if len(batch) == chunk_size:
+            yield tuple(batch)
+            batch.clear()
+    if batch:
+        yield tuple(batch)

--- a/projects/07-aiml-automation/PRJ-AIML-002/src/cli.py
+++ b/projects/07-aiml-automation/PRJ-AIML-002/src/cli.py
@@ -1,0 +1,75 @@
+"""Command line entry point for PRJ-AIML-002."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from . import adapters, prompt_builder, workflow
+
+
+def default_runner(prompt: str) -> str:
+    """Default model runner that simply returns the rendered prompt."""
+
+    return prompt
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Document packaging helper")
+    parser.add_argument("dataset", type=Path, help="Path to the dataset file (CSV, TSV, or JSON array)")
+    parser.add_argument("template", type=Path, help="Prompt template file (.json or plain text)")
+    parser.add_argument("output", type=Path, nargs="?", help="Optional output file to write results to")
+    parser.add_argument("--dataset-kind", choices=["delimited", "json"], help="Override dataset type detection")
+    parser.add_argument("--uppercase", action="store_true", help="Apply uppercase post-processing to outputs")
+    parser.add_argument("--dry-run", action="store_true", help="Render prompts without invoking the model runner")
+    return parser
+
+
+def load_template(path: Path) -> prompt_builder.PromptTemplate:
+    if path.suffix.lower() == ".json":
+        return prompt_builder.PromptTemplate.from_json(str(path))
+    body = path.read_text(encoding="utf-8")
+    return prompt_builder.PromptTemplate(name=path.stem, body=body, description=None)
+
+
+def render_prompts(records: Iterable[dict], template: prompt_builder.PromptTemplate) -> List[str]:
+    return [prompt for prompt in prompt_builder.render_batch(template, records)]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    dataset_spec = adapters.DatasetSpec(path=args.dataset, kind=args.dataset_kind)
+    records = adapters.load_records(dataset_spec)
+    template = load_template(args.template)
+
+    if args.dry_run:
+        for prompt in render_prompts(records, template):
+            print("--- Prompt ---")
+            print(prompt)
+        return 0
+
+    postprocessors = []
+    if args.uppercase:
+        postprocessors.append(workflow.uppercase_postprocessor)
+
+    job = workflow.PackagingJob(
+        template=template,
+        records=records,
+        model_runner=default_runner,
+        postprocessors=tuple(postprocessors),
+    )
+
+    if args.output:
+        job.write_outputs(args.output)
+    else:
+        for output in job.run():
+            print("--- Output ---")
+            print(output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/projects/07-aiml-automation/PRJ-AIML-002/src/prompt_builder.py
+++ b/projects/07-aiml-automation/PRJ-AIML-002/src/prompt_builder.py
@@ -1,0 +1,48 @@
+"""Prompt assembly helpers for PRJ-AIML-002."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from string import Template
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class PromptTemplate:
+    """Declarative representation of a prompt template."""
+
+    name: str
+    body: str
+    description: str | None = None
+
+    @classmethod
+    def from_json(cls, path: str) -> "PromptTemplate":
+        """Load a template from a JSON document.
+
+        The JSON file should contain ``{"name": str, "body": str, "description": str?}``.
+        """
+
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return cls(
+            name=payload["name"],
+            body=payload["body"],
+            description=payload.get("description"),
+        )
+
+
+def render_prompt(template: PromptTemplate, data: Mapping[str, object]) -> str:
+    """Render ``template`` with ``data`` using ``string.Template`` substitution."""
+
+    return Template(template.body).safe_substitute({key: str(value) for key, value in data.items()})
+
+
+def render_batch(template: PromptTemplate, rows: Iterable[Mapping[str, object]]) -> Iterable[str]:
+    """Render prompts for each row in ``rows``.
+
+    Returns a generator of strings to minimise memory usage for large jobs.
+    """
+
+    for row in rows:
+        yield render_prompt(template, row)

--- a/projects/07-aiml-automation/PRJ-AIML-002/src/workflow.py
+++ b/projects/07-aiml-automation/PRJ-AIML-002/src/workflow.py
@@ -1,0 +1,52 @@
+"""Lightweight orchestration helpers for PRJ-AIML-002."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, List, Mapping, MutableSequence, Sequence
+
+from . import prompt_builder
+
+ModelRunner = Callable[[str], str]
+PostProcessor = Callable[[str], str]
+
+
+@dataclass
+class PackagingJob:
+    """A minimal orchestration primitive for the document packaging pipeline."""
+
+    template: prompt_builder.PromptTemplate
+    records: Sequence[Mapping[str, object]]
+    model_runner: ModelRunner
+    postprocessors: Sequence[PostProcessor] = field(default_factory=tuple)
+
+    def run(self) -> List[str]:
+        """Execute the job and return processed model outputs."""
+
+        outputs: MutableSequence[str] = []
+        for rendered_prompt in prompt_builder.render_batch(self.template, self.records):
+            raw = self.model_runner(rendered_prompt)
+            outputs.append(self._apply_postprocessors(raw))
+        return list(outputs)
+
+    def write_outputs(self, destination: Path) -> None:
+        """Persist ``run`` outputs to ``destination`` as UTF-8 text."""
+
+        results = self.run()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("w", encoding="utf-8") as handle:
+            for index, entry in enumerate(results, start=1):
+                handle.write(f"# Output {index}\n\n{entry}\n\n")
+
+    def _apply_postprocessors(self, payload: str) -> str:
+        processed = payload
+        for processor in self.postprocessors:
+            processed = processor(processed)
+        return processed
+
+
+def uppercase_postprocessor(payload: str) -> str:
+    """Example post-processor used by documentation and tests."""
+
+    return payload.upper()


### PR DESCRIPTION
## Summary
- relocate the PRJ-AIML-002 implementation plan into docs/private with export-ignore metadata
- replace the project README with a concise developer summary and module guide
- add lightweight Python scaffolding (adapters, prompt builder, workflow, CLI) to match the documented modules

## Testing
- python -m compileall projects/07-aiml-automation/PRJ-AIML-002/src

------
https://chatgpt.com/codex/tasks/task_e_68fa47ffa02483279438654d549d99ca