### PR TITLE
Remove unused dependency entries from requirements

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# Environment Setup
+
+This portfolio repository is documentation-first and does not currently ship any
+runtime services. The previous Python dependencies `apscheduler` and `redis`
+were removed because there is no code that uses them.
+
+## Prerequisites
+
+A Python 3.10+ interpreter is sufficient if you would like to work inside a
+virtual environment for future tooling.
+
+## Installing Dependencies
+
+The `requirements.txt` file is intentionally comment-only to reflect that the
+project has no runtime dependencies right now. Running `pip install -r requirements.txt`
+will succeed without installing any packages.
+
+## Next Steps
+
+If you add tooling that needs packages later, document the additions in
+`requirements.txt` and update this guide accordingly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Runtime dependencies for the portfolio project.
+# No Python packages are required at this time; previously listed scheduler/cache
+# dependencies (apscheduler, redis) were removed because they are unused.


### PR DESCRIPTION
## Summary
- document that the project currently has no Python runtime dependencies and removed the unused apscheduler/redis entries
- add a setup guide describing the intentionally empty requirements file

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa4801ce7883279cce16524c892ac2