### PR TITLE
Fix README project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ System-minded engineer specializing in building, securing, and operating infrast
 
 ### Homelab & Secure Network Build
 **Description** Designed and wired a home network from scratch: rack-mounted gear, VLAN segmentation, and secure Wi-Fi for isolated IoT, guest, and trusted networks.
-**Links**: [Repo/Folder](./projects/06-homelab/PRJ-HOME-001/) · [Evidence/Diagrams](./projects/06-homelab/PRJ-HOME-001/assets)
+**Links**: [Repo/Folder](./infrastructure/06-homelab/PRJ-HOME-001/) · [Evidence/Diagrams](./documentation/06-homelab/PRJ-HOME-001/assets)
 
 ### Virtualization & Core Services
 **Description** Proxmox/TrueNAS host running Wiki.js, Home Assistant, and Immich behind a reverse proxy with TLS.
-**Links**: [Repo/Folder](./projects/06-homelab/PRJ-HOME-002/) · [Backup Logs](./projects/06-homelab/PRJ-HOME-002/assets)
+**Links**: [Repo/Folder](./infrastructure/06-homelab/PRJ-HOME-002/) · [Backup Logs](./documentation/06-homelab/PRJ-HOME-002/assets)
 
 ### Observability & Backups Stack
 **Description** Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.
-**Links**: [Repo/Folder](./projects/01-sde-devops/PRJ-SDE-002/) · [Dashboards](./projects/01-sde-devops/PRJ-SDE-002/assets)
+**Links**: [Repo/Folder](./infrastructure/01-sde-devops/PRJ-SDE-002/) · [Dashboards](./documentation/01-sde-devops/PRJ-SDE-002/assets)
 
 ---
 ## 🔄 Past Projects Requiring Recovery
@@ -49,28 +49,28 @@ Older commercial efforts live in cold storage while I recreate code, processes, 
 ### Commercial E-commerce & Booking Systems (Rebuild in Progress)
 **Status** 🔄 Recovering artifacts from backup exports and recreating runbooks.
 **Description** Previously built and managed: resort booking site; high-SKU flooring store; tours site with complex variations. Code and process docs are being rebuilt for publication.
-**Links**: [Repo/Folder](./projects/08-web-data/PRJ-WEB-001/) · [Evidence](./projects/08-web-data/PRJ-WEB-001/assets) *(placeholder while recovery completes)*
+**Links**: [Repo/Folder](./infrastructure/08-web-data/PRJ-WEB-001/) · [Evidence](./documentation/08-web-data/PRJ-WEB-001/assets) *(placeholder while recovery completes)*
 
 > **Recovery plan & timeline:** Catalog and restore SQL workflows and automation scripts (Week 1), re-document content management processes and deployment steps (Week 2), publish refreshed artifacts and narratives (Week 3).
 
 ---
 ## 🟠 In-Progress Projects (Milestones)
-- **GitOps Platform with IaC (Terraform + ArgoCD)** · [Repo/Folder](./projects/01-sde-devops/PRJ-SDE-001/)
-- **AWS Landing Zone (Organizations + SSO)** · [Repo/Folder](./projects/02-cloud-architecture/PRJ-CLOUD-001/)
-- **Active Directory Design & Automation (DSC/Ansible)** · [Repo/Folder](./projects/05-networking-datacenter/PRJ-NET-DC-001/)
+- **GitOps Platform with IaC (Terraform + ArgoCD)** · [Repo/Folder](./infrastructure/01-sde-devops/PRJ-SDE-001/)
+- **AWS Landing Zone (Organizations + SSO)** · [Repo/Folder](./infrastructure/02-cloud-architecture/PRJ-CLOUD-001/)
+- **Active Directory Design & Automation (DSC/Ansible)** · [Repo/Folder](./infrastructure/05-networking-datacenter/PRJ-NET-DC-001/)
 - **Resume Set (SDE/Cloud/QA/Net/Cyber)** · [Folder](./professional/resume/)
 
 ---
 ## 🔵 Planned Projects (Roadmaps)
-- **SIEM Pipeline**: Sysmon → Ingest → Detections → Dashboards · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-BLUE-001/))
-- **Adversary Emulation**: Validate detections via safe ATT&CK TTP emulation · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-RED-001/))
-- **Incident Response Playbook**: Clear IR guidance for ransomware · ([Repo/Folder](./projects/03-cybersecurity/PRJ-CYB-OPS-002/))
-- **Web App Login Test Plan**: Functional, security, and performance test design · ([Repo/Folder](./projects/04-qa-testing/PRJ-QA-001/))
-- **Selenium + PyTest CI**: Automate UI sanity runs in GitHub Actions · ([Repo/Folder](./projects/04-qa-testing/PRJ-QA-002/))
-- **Multi-OS Lab**: Kali, SlackoPuppy, Ubuntu lab for comparative analysis · ([Repo/Folder](./projects/06-homelab/PRJ-HOME-003/))
-- **Document Packaging Pipeline**: One-click generation of Docs/PDFs/XLSX from prompts · ([Repo/Folder](./projects/07-aiml-automation/PRJ-AIML-001/))
-- **IT Playbook (E2E Lifecycle)**: Unifying playbook from intake to operations · ([Folder](./docs/PRJ-MASTER-PLAYBOOK/))
-- **Engineer’s Handbook (Standards/QA Gates)**: Practical standards and quality bars · ([Folder](./docs/PRJ-MASTER-HANDBOOK/))
+- **SIEM Pipeline**: Sysmon → Ingest → Detections → Dashboards · ([Repo/Folder](./infrastructure/03-cybersecurity/PRJ-CYB-BLUE-001/))
+- **Adversary Emulation**: Validate detections via safe ATT&CK TTP emulation · ([Repo/Folder](./infrastructure/03-cybersecurity/PRJ-CYB-RED-001/))
+- **Incident Response Playbook**: Clear IR guidance for ransomware · ([Repo/Folder](./infrastructure/03-cybersecurity/PRJ-CYB-OPS-002/))
+- **Web App Login Test Plan**: Functional, security, and performance test design · ([Repo/Folder](./infrastructure/04-qa-testing/PRJ-QA-001/))
+- **Selenium + PyTest CI**: Automate UI sanity runs in GitHub Actions · ([Repo/Folder](./infrastructure/04-qa-testing/PRJ-QA-002/))
+- **Multi-OS Lab**: Kali, SlackoPuppy, Ubuntu lab for comparative analysis · ([Repo/Folder](./infrastructure/06-homelab/PRJ-HOME-003/))
+- **Document Packaging Pipeline**: One-click generation of Docs/PDFs/XLSX from prompts · ([Repo/Folder](./infrastructure/07-aiml-automation/PRJ-AIML-001/))
+- **IT Playbook (E2E Lifecycle)**: Unifying playbook from intake to operations · ([Folder](./documentation/master/PRJ-MASTER-PLAYBOOK/))
+- **Engineer’s Handbook (Standards/QA Gates)**: Practical standards and quality bars · ([Folder](./documentation/master/PRJ-MASTER-HANDBOOK/))
 
 ---
 ## 💼 Experience

--- a/documentation/01-sde-devops/PRJ-SDE-002/assets/README.md
+++ b/documentation/01-sde-devops/PRJ-SDE-002/assets/README.md
@@ -1,0 +1,3 @@
+# PRJ-SDE-002 Assets
+
+Placeholder for Observability & Backups Stack dashboards and runbook exports. Artifacts will be migrated from the legacy portfolio repository.

--- a/documentation/06-homelab/PRJ-HOME-001/assets/README.md
+++ b/documentation/06-homelab/PRJ-HOME-001/assets/README.md
@@ -1,0 +1,3 @@
+# PRJ-HOME-001 Assets
+
+Placeholder for Homelab & Secure Network Build diagrams and evidence. Artifacts will be migrated from the legacy portfolio repository.

--- a/documentation/06-homelab/PRJ-HOME-002/assets/README.md
+++ b/documentation/06-homelab/PRJ-HOME-002/assets/README.md
@@ -1,0 +1,3 @@
+# PRJ-HOME-002 Assets
+
+Placeholder for Virtualization & Core Services backup logs and visual evidence. Artifacts will be migrated from the legacy portfolio repository.

--- a/documentation/08-web-data/PRJ-WEB-001/assets/README.md
+++ b/documentation/08-web-data/PRJ-WEB-001/assets/README.md
@@ -1,0 +1,3 @@
+# PRJ-WEB-001 Assets
+
+Placeholder for Commercial E-commerce & Booking Systems evidence. Artifacts will be migrated from the legacy portfolio repository.

--- a/documentation/master/PRJ-MASTER-HANDBOOK/README.md
+++ b/documentation/master/PRJ-MASTER-HANDBOOK/README.md
@@ -1,0 +1,3 @@
+# PRJ-MASTER-HANDBOOK
+
+Placeholder for Engineer’s Handbook standards documentation. Content will be migrated from the original docs directory.

--- a/documentation/master/PRJ-MASTER-PLAYBOOK/README.md
+++ b/documentation/master/PRJ-MASTER-PLAYBOOK/README.md
@@ -1,0 +1,3 @@
+# PRJ-MASTER-PLAYBOOK
+
+Placeholder for IT Playbook lifecycle documentation. Content will be migrated from the original docs directory.

--- a/infrastructure/01-sde-devops/PRJ-SDE-001/README.md
+++ b/infrastructure/01-sde-devops/PRJ-SDE-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-SDE-001
+
+Placeholder for GitOps Platform with IaC (Terraform + ArgoCD) infrastructure assets. Content will be restored from legacy project structure.

--- a/infrastructure/01-sde-devops/PRJ-SDE-002/README.md
+++ b/infrastructure/01-sde-devops/PRJ-SDE-002/README.md
@@ -1,0 +1,3 @@
+# PRJ-SDE-002
+
+Placeholder for Observability & Backups Stack infrastructure assets. Content will be restored from the original projects tree.

--- a/infrastructure/02-cloud-architecture/PRJ-CLOUD-001/README.md
+++ b/infrastructure/02-cloud-architecture/PRJ-CLOUD-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-CLOUD-001
+
+Placeholder for AWS Landing Zone (Organizations + SSO) infrastructure assets. Content will be restored from the former projects directory.

--- a/infrastructure/03-cybersecurity/PRJ-CYB-BLUE-001/README.md
+++ b/infrastructure/03-cybersecurity/PRJ-CYB-BLUE-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-CYB-BLUE-001
+
+Placeholder for SIEM Pipeline infrastructure assets. Content will be restored from the legacy projects listing.

--- a/infrastructure/03-cybersecurity/PRJ-CYB-OPS-002/README.md
+++ b/infrastructure/03-cybersecurity/PRJ-CYB-OPS-002/README.md
@@ -1,0 +1,3 @@
+# PRJ-CYB-OPS-002
+
+Placeholder for Incident Response Playbook infrastructure assets. Content will be restored from the original portfolio projects listing.

--- a/infrastructure/03-cybersecurity/PRJ-CYB-RED-001/README.md
+++ b/infrastructure/03-cybersecurity/PRJ-CYB-RED-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-CYB-RED-001
+
+Placeholder for Adversary Emulation infrastructure assets. Content will be restored from the previous projects layout.

--- a/infrastructure/04-qa-testing/PRJ-QA-001/README.md
+++ b/infrastructure/04-qa-testing/PRJ-QA-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-QA-001
+
+Placeholder for Web App Login Test Plan infrastructure assets. Content will be restored from the prior projects hierarchy.

--- a/infrastructure/04-qa-testing/PRJ-QA-002/README.md
+++ b/infrastructure/04-qa-testing/PRJ-QA-002/README.md
@@ -1,0 +1,3 @@
+# PRJ-QA-002
+
+Placeholder for Selenium + PyTest CI infrastructure assets. Content will be restored from the legacy projects hierarchy.

--- a/infrastructure/05-networking-datacenter/PRJ-NET-DC-001/README.md
+++ b/infrastructure/05-networking-datacenter/PRJ-NET-DC-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-NET-DC-001
+
+Placeholder for Active Directory Design & Automation infrastructure assets. Content will be restored from the prior projects tree.

--- a/infrastructure/06-homelab/PRJ-HOME-001/README.md
+++ b/infrastructure/06-homelab/PRJ-HOME-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-HOME-001
+
+Placeholder for Homelab & Secure Network Build infrastructure assets. Content will be restored from the earlier projects folder.

--- a/infrastructure/06-homelab/PRJ-HOME-002/README.md
+++ b/infrastructure/06-homelab/PRJ-HOME-002/README.md
@@ -1,0 +1,3 @@
+# PRJ-HOME-002
+
+Placeholder for Virtualization & Core Services infrastructure assets. Content will be restored from the original projects folder.

--- a/infrastructure/06-homelab/PRJ-HOME-003/README.md
+++ b/infrastructure/06-homelab/PRJ-HOME-003/README.md
@@ -1,0 +1,3 @@
+# PRJ-HOME-003
+
+Placeholder for Multi-OS Lab infrastructure assets. Content will be restored from the historical projects directory.

--- a/infrastructure/07-aiml-automation/PRJ-AIML-001/README.md
+++ b/infrastructure/07-aiml-automation/PRJ-AIML-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-AIML-001
+
+Placeholder for Document Packaging Pipeline infrastructure assets. Content will be restored from the earlier projects structure.

--- a/infrastructure/08-web-data/PRJ-WEB-001/README.md
+++ b/infrastructure/08-web-data/PRJ-WEB-001/README.md
@@ -1,0 +1,3 @@
+# PRJ-WEB-001
+
+Placeholder for Commercial E-commerce & Booking Systems infrastructure assets. Content will be restored from the legacy projects directory.

--- a/professional/resume/README.md
+++ b/professional/resume/README.md
@@ -1,0 +1,3 @@
+# Resume Set
+
+Placeholder for SDE/Cloud/QA/Net/Cyber resume set. Content will be migrated from the legacy professional folder.


### PR DESCRIPTION
## Summary
- update portfolio README to point project references at the new infrastructure and documentation directories
- add placeholder README files in each referenced infrastructure/documentation path so the links resolve inside the repository
- provide a placeholder professional resume folder referenced by the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f94c7a951c8327bf202198c3b1fe5d