### PR TITLE
Add 21-day execution schedule for PRJ-AIML-002

### DIFF
--- a/projects/07-aiml-automation/PRJ-AIML-002/README.md
+++ b/projects/07-aiml-automation/PRJ-AIML-002/README.md
@@ -1,0 +1,66 @@
+# PRJ-AIML-002 · AI/ML Marketing Automation Rollout
+
+## Project Overview
+PRJ-AIML-002 advances the automation foundation for always-on marketing workflows. The intent is to pair search-intent discovery with AI-assisted content operations and outreach automation so that marketing teams can deliver refreshed assets on a predictable cadence without increasing manual toil. The effort operates as a three-week sprint with discrete discovery, build, and launch phases.
+
+## Objectives & Success Criteria
+- Baseline technical SEO and analytics posture to surface the most pressing crawl, indexing, and performance gaps.
+- Stand up repeatable AI/ML content workflows that can be executed by marketing operators with low friction and high transparency.
+- Automate distribution and reporting so performance feedback loops remain under one week.
+- Deliver a documented, supportable process stack with clear handoff to operations.
+
+## Tooling & Automation Stack
+### Tooling – Data & Analytics Foundation
+- **Sources**: Google Analytics 4, Search Console, CRM/lead pipeline exports.
+- **Processing**: dbt/SQL transformations maintained in the shared analytics repo.
+- **Visualization**: Looker Studio dashboards with shared filters and drill-down views.
+
+### Tooling – SEO Audit Stack
+- **Crawling & Technical Checks**: Screaming Frog, Sitebulb, PageSpeed Insights.
+- **Backlog Tracking**: Jira SEO board with pre-templated epics and quick filters.
+- **Monitoring**: LittleWarden for change alerts tied to Slack #seo-ops.
+
+### Tooling – Content Automation Workbench
+- **Generation**: Custom GPT workflows orchestrated through PromptLayer with guardrails.
+- **CMS Operations**: WordPress CLI scripts, Airtable content calendar, and bulk upload helpers.
+- **Quality Gates**: Grammarly Business, Originality.ai, and internal QA checklist library.
+
+### Tooling – Outreach & Reporting Ops
+- **Outreach**: Pitchbox sequences synchronized with HubSpot CRM.
+- **Automation**: Zapier recipes for data sync, Asana task creation, and status alerts.
+- **Reporting**: Power BI marketing attribution model refreshed nightly via Data Factory.
+
+## Implementation Phasing Strategy
+| Phase | Days | Focus | Primary Deliverables | Tooling References |
+| --- | --- | --- | --- | --- |
+| **Phase 1 – Baseline Discovery** | 1–7 | Establish a defensible technical and analytics baseline. | Crawl and analytics diagnostics, prioritized remediation backlog, automation prerequisites validated. | [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation), [Tooling – SEO Audit Stack](#tooling--seo-audit-stack) |
+| **Phase 2 – Build & Automate** | 8–14 | Configure AI/ML workflows and supporting automation. | Content generation playbooks, automation pipelines, QA workflows, and rollout communications. | [Tooling – Content Automation Workbench](#tooling--content-automation-workbench), [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops) |
+| **Phase 3 – Launch & Optimize** | 15–21 | Deploy automations, validate performance, and transition to operations. | Pilot launch report, optimization backlog, support model, and operational handoff. | All stacks; emphasis on [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops) and [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation) |
+
+## 21-Day Execution Schedule
+| Day | Functional Focus | Primary Deliverable | Dependencies | Owner |
+| --- | --- | --- | --- | --- |
+| **Day 1** | Phase 1 – Kickoff & Analytics Alignment | Program kickoff workshop, confirm KPIs, and provision analytics access following [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation). | None | Program Manager |
+| **Day 2** | Phase 1 – SEO Audit | Run Screaming Frog crawl, triage critical blockers, and capture Jira tickets per [Tooling – SEO Audit Stack](#tooling--seo-audit-stack). | Day 1 access handshakes | SEO Lead |
+| **Day 3** | Phase 1 – Analytics Health Check | Validate GA4/Search Console data parity, build baseline Looker Studio views via [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation). | Days 1–2 diagnostics | Data Analyst |
+| **Day 4** | Phase 1 – Content Inventory & AI Readiness | Map high-impact pages, prep PromptLayer templates, and document guardrails per [Tooling – Content Automation Workbench](#tooling--content-automation-workbench). | Days 2–3 outputs | Content Operations Lead |
+| **Day 5** | Phase 1 – Backlog Prioritization | Finalize remediation backlog, assign owners, and align on SLAs referencing [Tooling – SEO Audit Stack](#tooling--seo-audit-stack). | Days 2–4 artifacts | Program Manager & SEO Lead |
+| **Day 6** | Phase 1 – Weekend Buffer | Weekend buffer for backlog catch-up; run asynchronous QA spot checks using [Tooling – SEO Audit Stack](#tooling--seo-audit-stack). Escalate to Program Manager if >1 day slip persists. | Outstanding items Days 1–5 | On-call Leads |
+| **Day 7** | Phase 1 – Weekend Buffer & Prep | Buffer/catch-up window; prepare automation requirements doc aligned with [Tooling – Content Automation Workbench](#tooling--content-automation-workbench). | Outstanding items Days 1–6 | Automation Engineer |
+| **Day 8** | Phase 2 – Workflow Design | Finalize AI content templates, prompt libraries, and QA steps leveraging [Tooling – Content Automation Workbench](#tooling--content-automation-workbench). | Phase 1 completion | Content Operations Lead |
+| **Day 9** | Phase 2 – Automation Build | Configure Zapier/Asana automation flows and data sync per [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Day 8 templates | Automation Engineer |
+| **Day 10** | Phase 2 – QA Engineering | Run test submissions, validate data pipelines, and document rollback in accordance with [Tooling – Content Automation Workbench](#tooling--content-automation-workbench). | Day 9 builds | QA Specialist |
+| **Day 11** | Phase 2 – Dashboard & Alerting | Build Looker Studio dashboards and Slack alerting as outlined in [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation) and [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Day 10 QA sign-off | Data Analyst |
+| **Day 12** | Phase 2 – Outreach Integration | Connect Pitchbox sequences and CRM sync workflows using [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Day 9 automations & Day 11 dashboards | Outreach Lead |
+| **Day 13** | Phase 2 – Weekend Buffer | Weekend buffer for QA regressions; if blockers remain, escalate to Program Manager and adjust Day 14 scope. Follow [Tooling – Content Automation Workbench](#tooling--content-automation-workbench) for retests. | Outstanding items Days 8–12 | QA Specialist |
+| **Day 14** | Phase 2 – Weekend Buffer & Enablement Prep | Catch-up window; draft enablement materials referencing [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Outstanding items Days 8–13 | Program Manager |
+| **Day 15** | Phase 3 – Pilot Launch | Deploy automation to pilot cohort, confirm monitoring hooks per [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Phase 2 complete | Automation Engineer |
+| **Day 16** | Phase 3 – Performance Monitoring | Analyze first-run metrics, tune prompts and automations using [Tooling – Data & Analytics Foundation](#tooling--data--analytics-foundation). | Day 15 launch data | Data Analyst & Content Lead |
+| **Day 17** | Phase 3 – Training & Support | Deliver runbook walkthrough and support rota referencing all tooling sections for continuity. | Days 15–16 insights | Program Manager |
+| **Day 18** | Phase 3 – Outreach Cycle 1 | Execute first full outreach wave and record outcomes per [Tooling – Outreach & Reporting Ops](#tooling--outreach--reporting-ops). | Day 17 training sign-off | Outreach Lead |
+| **Day 19** | Phase 3 – Optimization Backlog | Compile optimization backlog, tag Jira tickets, and prioritize next sprint referencing [Tooling – SEO Audit Stack](#tooling--seo-audit-stack). | Day 18 results | SEO Lead |
+| **Day 20** | Phase 3 – Weekend Buffer | Weekend buffer for backlog cleanup and blocker removal; follow swap rules and escalate unresolved issues to Program Manager. | Outstanding items Days 15–19 | On-call Leads |
+| **Day 21** | Phase 3 – Final Catch-up & Executive Review | Finalize executive summary, confirm handoff readiness, and close open items referencing all tooling stacks. | Day 20 buffer outputs | Program Manager |
+
+### Re-plan & Escalation Guidance
+If a dependency slips, first assess whether the impacted task can swap with a later activity in the same phase that does **not** rely on the blocked deliverable. Weekend buffer days (6–7, 13–14, 20–21) are the preferred swap targets; document the change in the project plan and ensure owners stay within phase boundaries. When swaps cannot resolve the risk within 24 hours, escalate to the Program Manager (escalations via Slack #aiml-automation-ops) for resource assist or scope trade-off. Always update the Jira board to reflect the new sequencing and tag affected owners so downstream teams can adjust their prep work accordingly.


### PR DESCRIPTION
## Summary
- add a project overview and tooling context for PRJ-AIML-002
- document the implementation phasing strategy with tooling references
- introduce a 21-day execution schedule and re-plan guidance that call out buffer rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f943d1e680832792fdd3054d313f6d