### PR TITLE
Add 21-day execution schedule for AIML automation rollout

### DIFF
--- a/projects/07-aiml-automation/PRJ-AIML-002/README.md
+++ b/projects/07-aiml-automation/PRJ-AIML-002/README.md
@@ -1,0 +1,70 @@
+# PRJ-AIML-002 · AI/ML Marketing Automation Accelerator
+
+## Project Overview
+This runbook packages the processes, tooling, and phased milestones required to deliver an AI-assisted marketing automation foundation for a mid-sized digital organization. It assumes an existing marketing stack with fragmented data, light automation, and no unified performance telemetry.
+
+## Objectives & Success Metrics
+- Stand up an integrated CRM, analytics, and automation backbone that surfaces unified lead intelligence.
+- Deploy AI-assisted workflows that shorten hand-offs between SEO research, content production, and nurture campaigns.
+- Deliver dashboards and runbooks that allow marketing and sales stakeholders to operate autonomously after go-live.
+
+## Tooling Reference
+### CRM & Data Backbone
+- HubSpot Professional (CRM, workflows, lifecycle stages)
+- Airbyte/Hevo pipelines for scheduled data syncs from CMS/e-commerce
+- Google Sheets + AppScript for lightweight data transformations
+
+### SEO & Content Intelligence
+- Screaming Frog (technical crawl + backlog export)
+- Semrush keyword gap + intent clustering
+- Notion AI for summary briefs and internal knowledge capture
+
+### Automation & Campaign Orchestration
+- HubSpot Sequences + Workflows for lead nurture and routing
+- Zapier for bridging edge connectors (webinars, chat, scheduling)
+- Make.com scenarios for long-tail enrichment and webhook fan-out
+
+### Analytics & Reporting
+- GA4 property with BigQuery export
+- Looker Studio dashboards for marketing/sales alignment
+- Mixpanel for product-led funnel tracking where applicable
+
+### Knowledge Management & Collaboration
+- Confluence for runbooks, SOPs, and decision logs
+- Slack (channel-based comms with workflow notifications)
+- Loom for asynchronous walkthroughs and approvals
+
+## Implementation Phasing Strategy
+| Phase | Duration | Focus | Key Activities | Exit Criteria |
+| --- | --- | --- | --- | --- |
+| Phase 0 – Alignment & Baseline | Days 1–3 | Confirm objectives, data availability, and measurement plan | Kickoff workshop, tooling access validation, analytics baseline capture | Stakeholder alignment brief and measurement plan signed off |
+| Phase 1 – Foundation Build | Days 4–9 | Stand up data connectors, CRM hygiene, and segmentation | CRM ingestion, data quality remediation, audience blueprinting, technical SEO triage | Clean CRM dataset, approved segmentation schema, prioritized SEO backlog |
+| Phase 2 – Automation Construction | Days 10–15 | Configure AI-assisted workflows and multi-channel automations | Lead scoring model, nurture sequences, chatbot flows, analytics instrumentation | Automation suite passes UAT with documented playbooks |
+| Phase 3 – Launch & Optimization | Days 16–21 | Activate programs, train teams, and establish continuous improvement rhythms | Go-live execution, enablement sessions, performance monitoring, optimization backlog creation | Marketing/sales self-sufficiency with live dashboards and iterative roadmap |
+
+## 21-Day Execution Schedule
+| Day | Functional Focus | Primary Deliverable | Dependencies | Owner |
+| --- | --- | --- | --- | --- |
+| Day 1 | Program Kickoff | Alignment workshop and decision log published to Confluence (see Tooling §Knowledge Management & Collaboration) | Executive sponsor availability | Program Manager |
+| Day 2 | SEO | Screaming Frog crawl completed with critical issues triaged in backlog (see Tooling §SEO & Content Intelligence) | Day 1 decision log, Screaming Frog license | SEO Lead |
+| Day 3 | Analytics | GA4 baseline dashboard with conversion events documented (see Tooling §Analytics & Reporting) | Tool access verification from Day 1 | Analytics Lead |
+| Day 4 | Data Integration | HubSpot data pipeline activated via Airbyte with sync monitor alerts (see Tooling §CRM & Data Backbone) | GA4 baseline metrics (Day 3) | Data Engineer |
+| Day 5 | Data Quality | Data hygiene report with remediation checklist in Confluence (see Tooling §CRM & Data Backbone) | Successful Day 4 ingestion | Data Engineer |
+| Day 6 | Segmentation | Audience blueprint with lifecycle definitions approved (see Tooling §CRM & Data Backbone) | Cleansed dataset from Day 5 | Marketing Operations Lead |
+| Day 7 | Automation Design | Workflow architecture diagram and RACI stored in Confluence (see Tooling §Automation & Campaign Orchestration) | Segmentation blueprint (Day 6) | Program Manager |
+| Day 8 | Content Enablement | AI-assisted content prompt library drafted in Notion (see Tooling §SEO & Content Intelligence) | Workflow architecture (Day 7) | Content Lead |
+| Day 9 | QA Readiness | Integration QA checklist and smoke scripts recorded in Loom (see Tooling §Knowledge Management & Collaboration) | Content prompts (Day 8) and workflow diagram | QA Lead |
+| Day 10 | Lead Scoring | Predictive lead scoring model configured in HubSpot with documentation (see Tooling §Automation & Campaign Orchestration) | QA checklist from Day 9, cleansed CRM | Marketing Operations Lead |
+| Day 11 | Nurture Automation | Multi-touch email sequence deployed to staging environment (see Tooling §Automation & Campaign Orchestration) | Lead scoring weights (Day 10) | Automation Engineer |
+| Day 12 | Conversational Flows | Chatbot and meeting router automations published to QA channel (see Tooling §Automation & Campaign Orchestration) | Staging nurture sequence (Day 11) | Automation Engineer |
+| Day 13 | Analytics Instrumentation | Looker Studio dashboard wired to GA4 and HubSpot sources (see Tooling §Analytics & Reporting) | Data pipelines (Day 4) and scoring outputs (Day 10) | Analytics Lead |
+| Day 14 | SEO Intelligence Loop | Semrush insights integrated into nurture triggers with auto-tag rules (see Tooling §SEO & Content Intelligence) | Dashboard telemetry (Day 13) | SEO Lead |
+| Day 15 | UAT & Regression | Cross-functional UAT sign-off recorded with Loom walkthrough (see Tooling §Knowledge Management & Collaboration) | Automations from Days 10–14 | QA Lead |
+| Day 16 | Launch Preparation | Production cutover checklist finalized and approvals captured (see Tooling §Knowledge Management & Collaboration) | UAT sign-off (Day 15) | Program Manager |
+| Day 17 | Enablement | Training sessions delivered with playbooks stored in Confluence (see Tooling §Knowledge Management & Collaboration) | Cutover checklist (Day 16) | Program Manager |
+| Day 18 | Go-Live Execution | Automations activated in production with monitoring toggled on (see Tooling §Automation & Campaign Orchestration) | Training completion (Day 17) | Automation Engineer |
+| Day 19 | Performance Monitoring | Live telemetry review and first-week optimization backlog logged (see Tooling §Analytics & Reporting) | Go-live status (Day 18) | Analytics Lead |
+| Day 20 | Executive Reporting | Executive scorecard circulated with commentary and next-step proposals (see Tooling §Knowledge Management & Collaboration) | Monitoring insights (Day 19) | Program Manager |
+| Day 21 | Retrospective & Roadmap | Retro workshop notes with prioritized backlog captured (see Tooling §Knowledge Management & Collaboration) | Scorecard (Day 20) | Program Manager |
+
+**Blocker Adaptation Guidance:** Reserve light-capacity windows on Days 6, 13, and 20 for weekend or evening catch-up if milestones slip. When blockers arise, swap tasks only within the same phase to preserve dependency chains, escalate access constraints within 24 hours via the program Slack channel, and log any scope adjustments in Confluence so downstream owners can re-sequence deliverables without re-planning the entire engagement.


### PR DESCRIPTION
## Summary
- add a dedicated README for PRJ-AIML-002 with project overview and tooling references
- document phased implementation strategy for the AI/ML marketing automation initiative
- provide a 21-day execution schedule aligned to the phases and tooling dependencies

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f93a76d5708327bbab023272fa3acf