### PR TITLE
Fix cluster-scoped status updates

### DIFF
--- a/projects/19-advanced-kubernetes-operators/advanced-operators.py
+++ b/projects/19-advanced-kubernetes-operators/advanced-operators.py
@@ -1,0 +1,77 @@
+"""Utilities for managing advanced Kubernetes operators."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def update_resource_status(
+    custom_objects_api: Any,
+    *,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    status: Dict[str, Any],
+    namespace: Optional[str] = None,
+    namespaced: bool = True,
+) -> Dict[str, Any]:
+    """Patch the status block for a custom resource.
+
+    Parameters
+    ----------
+    custom_objects_api:
+        Instance of ``kubernetes.client.CustomObjectsApi`` (or a compatible
+        object in tests).
+    group, version, plural, name:
+        Identify the custom resource definition and instance to update.
+    status:
+        The desired ``status`` payload for the resource.
+    namespace:
+        Namespace containing the resource.  Ignored for cluster-scoped
+        resources.
+    namespaced:
+        ``True`` if the resource is namespace-scoped, otherwise cluster-scoped.
+    """
+
+    patch_body = {"status": status}
+
+    if namespaced:
+        logger.debug(
+            "Patching namespaced custom resource status",
+            extra={
+                "k8s_group": group,
+                "k8s_version": version,
+                "k8s_plural": plural,
+                "k8s_name": name,
+                "k8s_namespace": namespace,
+            },
+        )
+        return custom_objects_api.patch_namespaced_custom_object_status(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            name=name,
+            body=patch_body,
+        )
+
+    logger.debug(
+        "Patching cluster-scoped custom resource status",
+        extra={
+            "k8s_group": group,
+            "k8s_version": version,
+            "k8s_plural": plural,
+            "k8s_name": name,
+        },
+    )
+    return custom_objects_api.patch_cluster_custom_object_status(
+        group=group,
+        version=version,
+        plural=plural,
+        name=name,
+        body=patch_body,
+    )

--- a/tests/test_advanced_operators.py
+++ b/tests/test_advanced_operators.py
@@ -1,0 +1,46 @@
+"""Tests for advanced Kubernetes operator utilities."""
+
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "projects"
+    / "19-advanced-kubernetes-operators"
+    / "advanced-operators.py"
+)
+
+
+def load_module() -> ModuleType:
+    spec = util.spec_from_file_location("advanced_operators", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {MODULE_PATH}")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cluster_scoped_status_uses_status_endpoint():
+    module = load_module()
+    api = MagicMock()
+    status_payload = {"phase": "Ready"}
+
+    module.update_resource_status(
+        api,
+        group="example.com",
+        version="v1",
+        plural="widgets",
+        name="demo",
+        status=status_payload,
+        namespaced=False,
+    )
+
+    api.patch_cluster_custom_object_status.assert_called_once_with(
+        group="example.com",
+        version="v1",
+        plural="widgets",
+        name="demo",
+        body={"status": status_payload},
+    )


### PR DESCRIPTION
## Summary
- add advanced operator helper module with logging for status patches
- update cluster-scoped status updates to call patch_cluster_custom_object_status
- add a pytest covering the cluster-scoped status call

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f93b60a1b483278ff35a87efbf4d61