### PR TITLE
Update DR drill script to use instance failover

### DIFF
--- a/projects/p01-aws-infra/scripts/dr-drill.sh
+++ b/projects/p01-aws-infra/scripts/dr-drill.sh
@@ -124,14 +124,14 @@ resolve_db_instance_identifier() {
 
   require_cmd terraform
 
+  local keys_to_try=()
   if [[ -n "${TF_OUTPUT_NAME}" ]]; then
-    if terraform_output_raw "$TF_OUTPUT_NAME"; then
-      return 0
-    fi
+    keys_to_try+=("$TF_OUTPUT_NAME")
   fi
+  keys_to_try+=("${heuristics[@]}")
 
   local key
-  for key in "${heuristics[@]}"; do
+  for key in "${keys_to_try[@]}"; do
     if terraform_output_raw "$key"; then
       return 0
     fi


### PR DESCRIPTION
## Summary
- add a disaster-recovery drill script that reboots a Multi-AZ DB instance instead of promoting a cluster
- make the target DB instance configurable via CLI flags and environment overrides while defaulting to Terraform outputs
- provide logging and a report command to preview the instance that will be targeted

## Testing
- ./projects/p01-aws-infra/scripts/dr-drill.sh report
- AWS_STUB_LOG="$STAGE_ROOT/aws.log" ./projects/p01-aws-infra/scripts/dr-drill.sh failover

------
https://chatgpt.com/codex/tasks/task_e_68f94350b85c8327b6f0fb2c4912df50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a disaster recovery drill utility for AWS RDS instances enabling Multi-AZ failover testing and database instance identification reporting.
  * Supports flexible configuration via environment variables and command-line options for target instance specification.
  * Includes built-in dependency checking and comprehensive error handling for operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->