### PR TITLE
Fix compliance scan to use explicit policy directory

### DIFF
--- a/scripts/compliance-scan.sh
+++ b/scripts/compliance-scan.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/compliance-scan.sh [OPTIONS] [TARGET ...]
+
+Options:
+  --policy-dir DIR   Path to the directory containing Rego policies (default: security/policies)
+  --target PATH      Explicit manifest or directory to evaluate (repeatable)
+  -h, --help         Show this help message
+
+Any additional positional arguments are treated as extra targets.
+USAGE
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY_DIR="security/policies"
+TARGETS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --policy-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --policy-dir requires a value" >&2
+        usage
+        exit 2
+      fi
+      POLICY_DIR="$2"
+      shift 2
+      ;;
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target requires a path" >&2
+        usage
+        exit 2
+      fi
+      TARGETS+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      TARGETS+=("$@")
+      break
+      ;;
+    -* )
+      echo "error: unknown option $1" >&2
+      usage
+      exit 2
+      ;;
+    * )
+      TARGETS+=("$1")
+      shift
+      ;;
+  esac
+
+done
+
+cd "$REPO_ROOT"
+
+if [[ ! -d "$POLICY_DIR" ]]; then
+  echo "error: policy directory '$POLICY_DIR' does not exist" >&2
+  exit 3
+fi
+
+if ! command -v conftest >/dev/null 2>&1; then
+  echo "error: conftest binary not found in PATH" >&2
+  exit 4
+fi
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  if [[ -d "kubernetes" ]]; then
+    mapfile -t TARGETS < <(find kubernetes -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.json' \) -print)
+  fi
+fi
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(".")
+fi
+
+conftest test --policy "$POLICY_DIR" "${TARGETS[@]}"

--- a/security/policies/portfolio.rego
+++ b/security/policies/portfolio.rego
@@ -1,0 +1,33 @@
+package portfolio.networkpolicy
+
+default allow = true
+
+deny[msg] {
+  input.kind == "NetworkPolicy"
+  ns := input.metadata.namespace
+  name := input.metadata.name
+  not has_ingress_rules(input)
+  msg := sprintf("%s/%s must define at least one ingress rule", [ns, name])
+}
+
+deny[msg] {
+  input.kind == "NetworkPolicy"
+  ns := input.metadata.namespace
+  name := input.metadata.name
+  declares_egress(input)
+  not has_egress_rules(input)
+  msg := sprintf("%s/%s declares egress policyTypes but has no egress rules", [ns, name])
+}
+
+has_ingress_rules(obj) {
+  count(obj.spec.ingress) > 0
+}
+
+has_egress_rules(obj) {
+  count(obj.spec.egress) > 0
+}
+
+declares_egress(obj) {
+  some i
+  obj.spec.policyTypes[i] == "Egress"
+}


### PR DESCRIPTION
## Summary
- add a compliance scan script that allows specifying the policy directory and targets
- add a Rego policy that flags network policies missing ingress or egress rules

## Testing
- ./scripts/compliance-scan.sh --policy-dir security/policies *(fails: `conftest` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4e6f7cb4832794a5585ca754bbee