### PR TITLE
Add Pod Security Admission labels to namespace manifest

### DIFF
--- a/infrastructure/kubernetes/base/namespace.yaml
+++ b/infrastructure/kubernetes/base/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portfolio
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: "latest"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: "latest"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: "latest"


### PR DESCRIPTION
## Summary
- add a namespace manifest that enforces the restricted Pod Security Admission profile via labels

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fa4e6b81188327ace4693137884cc8