### PR TITLE
Update Argo CD application path to production overlay

### DIFF
--- a/enterprise-portfolio/kubernetes/manifests/argocd/application.yaml
+++ b/enterprise-portfolio/kubernetes/manifests/argocd/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: enterprise-portfolio
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: enterprise-portfolio
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: git@github.com:example/enterprise-portfolio.git
+    targetRevision: main
+    path: kubernetes/overlays/production
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- add the Argo CD application manifest for the enterprise portfolio
- configure the source path to use the production overlay instead of prod

## Testing
- not run (Argo CD sync not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ff920971b883279786c3673a712ccb