### PR TITLE
Add observability stack assets for PRJ-SDE-002

### DIFF
--- a/projects/01-sde-devops/PRJ-SDE-002/assets/alertmanager/alertmanager.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/alertmanager/alertmanager.yml
@@ -1,0 +1,131 @@
+# Alertmanager configuration for homelab observability stack
+# ----------------------------------------------------------
+# This file defines notification routes, receiver integrations, and inhibition
+# logic tailored for a small team operating a Proxmox-based homelab.
+
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: 'smtp.gmail.com:587'
+  smtp_from: 'prometheus@homelab.local'
+  smtp_require_tls: true
+  slack_api_url: 'https://hooks.slack.com/services/PLACEHOLDER/WEBHOOK/URL'
+
+route:
+  receiver: default-email
+  group_by: ['cluster', 'alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - receiver: critical-all
+      matchers:
+        - severity="critical"
+        - component="infrastructure"
+      group_wait: 10s
+      repeat_interval: 30m
+    - receiver: backup-team
+      matchers:
+        - severity="critical"
+        - component="backup"
+      group_by: ['job_name']
+      repeat_interval: 12h
+    - receiver: slack-only
+      matchers:
+        - severity="warning"
+      repeat_interval: 24h
+    - receiver: app-team
+      matchers:
+        - component="application"
+      group_by: ['service_name', 'alertname']
+
+receivers:
+  - name: default-email
+    email_configs:
+      - to: 'alerts@homelab.local'
+        headers:
+          subject: '[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }} on {{ .GroupLabels.instance }}'
+        html: |
+          <html>
+            <body>
+              <h3>Alert summary ({{ .Status }})</h3>
+              <table border="1" cellpadding="4" cellspacing="0">
+                <tr><th>Alert</th><th>Instance</th><th>Severity</th><th>Description</th></tr>
+                {{ range .Alerts }}
+                <tr>
+                  <td>{{ .Labels.alertname }}</td>
+                  <td>{{ .Labels.instance }}</td>
+                  <td>{{ .Labels.severity }}</td>
+                  <td>{{ .Annotations.description }}</td>
+                </tr>
+                {{ end }}
+              </table>
+              <p>Runbook: {{ (index .Alerts 0).Annotations.runbook }}</p>
+            </body>
+          </html>
+
+  - name: critical-all
+    email_configs:
+      - to: 'alerts@homelab.local'
+        headers:
+          subject: '[CRITICAL] {{ .GroupLabels.alertname }} on {{ .GroupLabels.instance }}'
+    slack_configs:
+      - channel: '#homelab-critical'
+        username: 'Prometheus Alertmanager'
+        title: 'Critical Alert: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}• {{ .Labels.instance }} - {{ .Annotations.description }}\n{{ end }}'
+        color: 'danger'
+    pagerduty_configs:
+      - service_key: 'pg123456'
+        severity: 'critical'
+        description: '{{ .GroupLabels.alertname }} on {{ .GroupLabels.instance }}'
+
+  - name: backup-team
+    email_configs:
+      - to: 'alerts@homelab.local'
+        headers:
+          subject: '[BACKUP] {{ .GroupLabels.alertname }} for {{ .GroupLabels.job_name }}'
+
+  - name: slack-only
+    slack_configs:
+      - channel: '#homelab-alerts'
+        username: 'Prometheus Alertmanager'
+        title: 'Warning Alert: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}• {{ .Labels.instance }} - {{ .Annotations.description }}\n{{ end }}'
+        color: 'warning'
+
+  - name: app-team
+    email_configs:
+      - to: 'alerts@homelab.local'
+        headers:
+          subject: '[APP] {{ .GroupLabels.alertname }} affecting {{ .GroupLabels.service_name }}'
+    slack_configs:
+      - channel: '#homelab-alerts'
+        username: 'Prometheus Alertmanager'
+        title: 'Application Alert: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}• {{ .Labels.service_name }} ({{ .Labels.instance }}) - {{ .Annotations.description }}\n{{ end }}'
+        color: '#ff9800'
+
+inhibit_rules:
+  - source_matchers:
+      - alertname="HostDown"
+    target_matchers:
+      - alertname=~".*"
+    equal: ['instance']
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal: ['alertname', 'instance']
+
+# Example silences (uncomment and adjust when needed):
+# silences:
+#   - matcher: 'instance="192.168.1.20:9100"'
+#     comment: 'Maintenance window for VM1'
+#     createdBy: 'admin'
+#     startsAt: '2024-01-01T02:00:00Z'
+#     endsAt: '2024-01-01T04:00:00Z'
+
+# Testing receivers:
+# - amtool alert add HostDown severity=critical instance=192.168.1.20:9100 --expires=5m
+# - amtool config routes
+# - amtool silence add alertname=DiskSpaceLow instance=192.168.1.22:9100 --duration=2h

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/diagrams/observability-architecture.mermaid
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/diagrams/observability-architecture.mermaid
@@ -1,0 +1,98 @@
+%% Homelab observability stack architecture
+%% Flowchart showing data sources, collectors, storage, alerting, visualization,
+%% and backup integration. Colors represent functional groups.
+flowchart LR
+  subgraph Trusted_Network[Trusted LAN 192.168.1.0/24]
+    direction LR
+    ProxmoxHost["Proxmox Host\n192.168.1.10"]:::source
+    VM1["VM1\nWiki.js\n192.168.1.20"]:::source
+    VM2["VM2\nHome Assistant\n192.168.1.21"]:::source
+    VM3["VM3\nImmich\n192.168.1.22"]:::source
+    VM4["VM4\nDatabase\n192.168.1.23"]:::source
+    VM5["VM5\nUtility\n192.168.1.24"]:::source
+    LXC1["LXC1\n192.168.1.30"]:::source
+    LXC2["LXC2\n192.168.1.31"]:::source
+    LXC3["LXC3\n192.168.1.32"]:::source
+    TrueNAS["TrueNAS\nStorage\n192.168.1.5"]:::source
+  end
+
+  subgraph Collectors[Metrics & Log Collectors]
+    direction TB
+    NodeExporter[Node Exporters]:::collector
+    ProxmoxExporter[Proxmox Exporter\n:9221]:::collector
+    TrueNASExporter[TrueNAS Exporter\n:9273]:::collector
+    BlackboxExporter[Blackbox Exporter]:::collector
+    PromtailAgents[Promtail Agents\n:9080]:::collector
+  end
+
+  subgraph Core[Central Observability]
+    direction TB
+    Prometheus[(Prometheus\n:9090)]:::storage
+    Alertmanager[(Alertmanager\n:9093)]:::alert
+    Loki[(Loki\n:3100/9096)]:::storage
+  end
+
+  subgraph Visualization
+    Grafana[Grafana\n:3000]:::visual
+  end
+
+  subgraph Backup
+    PBS[Proxmox Backup Server\n192.168.1.15\n:8007]:::backup
+  end
+
+  ProxmoxHost -->|Metrics\nHTTP 9100| NodeExporter
+  VM1 -->|Metrics\nHTTP 9100| NodeExporter
+  VM2 -->|Metrics\nHTTP 9100| NodeExporter
+  VM3 -->|Metrics\nHTTP 9100| NodeExporter
+  VM4 -->|Metrics\nHTTP 9100| NodeExporter
+  VM5 -->|Metrics\nHTTP 9100| NodeExporter
+  LXC1 -->|Metrics\nHTTP 9100| NodeExporter
+  LXC2 -->|Metrics\nHTTP 9100| NodeExporter
+  LXC3 -->|Metrics\nHTTP 9100| NodeExporter
+  ProxmoxHost -->|VM Metrics\nHTTP 9221| ProxmoxExporter
+  TrueNAS -->|Storage Metrics\nHTTP 9273| TrueNASExporter
+  ProxmoxHost -->|Logs\nHTTP 9080| PromtailAgents
+  VM1 -->|Logs\nHTTP 9080| PromtailAgents
+  VM2 -->|Logs\nHTTP 9080| PromtailAgents
+  VM3 -->|Logs\nHTTP 9080| PromtailAgents
+  VM4 -->|Logs\nHTTP 9080| PromtailAgents
+  VM5 -->|Logs\nHTTP 9080| PromtailAgents
+  LXC1 -->|Logs\nHTTP 9080| PromtailAgents
+  LXC2 -->|Logs\nHTTP 9080| PromtailAgents
+  LXC3 -->|Logs\nHTTP 9080| PromtailAgents
+  BlackboxExporter -.->|HTTP Probes| VM1
+  BlackboxExporter -.->|HTTP Probes| VM2
+  BlackboxExporter -.->|HTTP Probes| VM3
+
+  NodeExporter -->|Scrape HTTP 9090| Prometheus
+  ProxmoxExporter -->|Scrape HTTP 9090| Prometheus
+  TrueNASExporter -->|Scrape HTTP 9090| Prometheus
+  BlackboxExporter -->|Scrape HTTP 9090| Prometheus
+  PromtailAgents -->|Push Logs HTTP 3100| Loki
+
+  Prometheus -->|Alerts HTTP 9093| Alertmanager
+  Alertmanager -.->|Email| Email[alerts@homelab.local]:::alert
+  Alertmanager -.->|Slack| Slack[#homelab-alerts]:::alert
+  Alertmanager -.->|PagerDuty| PagerDuty[PagerDuty pg123456]:::alert
+
+  Grafana -->|Query Metrics HTTP 9090| Prometheus
+  Grafana -->|Query Logs HTTP 3100| Loki
+  Grafana -.->|Dashboards| Users((Operators))
+
+  ProxmoxHost -.->|Nightly backups| PBS
+  VM1 -.->|Snapshot jobs| PBS
+  VM2 -.->|Snapshot jobs| PBS
+  VM3 -.->|Snapshot jobs| PBS
+  VM4 -.->|Snapshot jobs| PBS
+  VM5 -.->|Snapshot jobs| PBS
+  LXC1 -.->|Snapshot jobs| PBS
+  LXC2 -.->|Snapshot jobs| PBS
+  LXC3 -.->|Snapshot jobs| PBS
+  PBS -.->|Stores to| TrueNAS
+
+  classDef source fill:#1e88e5,color:#fff,stroke:#0d47a1;
+  classDef collector fill:#43a047,color:#fff,stroke:#1b5e20;
+  classDef storage fill:#7e57c2,color:#fff,stroke:#4527a0;
+  classDef alert fill:#e53935,color:#fff,stroke:#b71c1c;
+  classDef visual fill:#fb8c00,color:#fff,stroke:#ef6c00;
+  classDef backup fill:#9e9e9e,color:#fff,stroke:#616161;

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/grafana/dashboards/application-metrics.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/grafana/dashboards/application-metrics.json
@@ -1,0 +1,266 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "id": 1, "panels": [], "title": "Row 1: Application Status", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0}]}, "mappings": []}, "overrides": []},
+      "gridPos": {"h": 3, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "probe_success{job=\"blackbox\", instance=\"https://wiki.homelab.local\"}", "refId": "A"}],
+      "title": "Wiki.js Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0}]}}, "overrides": []},
+      "gridPos": {"h": 3, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "probe_success{job=\"blackbox\", instance=\"https://homeassistant.homelab.local\"}", "refId": "A"}],
+      "title": "Home Assistant Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0}]}}, "overrides": []},
+      "gridPos": {"h": 3, "w": 6, "x": 12, "y": 1},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "probe_success{job=\"blackbox\", instance=\"https://immich.homelab.local\"}", "refId": "A"}],
+      "title": "Immich Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 100}, {"color": "red", "value": 200}]}, "unit": "none"}},
+      "gridPos": {"h": 3, "w": 6, "x": 18, "y": 1},
+      "id": 5,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "center", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "sum(app_active_sessions_total{service=~\"$service\"})", "refId": "A"}],
+      "title": "Total Active Sessions",
+      "type": "stat"
+    },
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4}, "id": 6, "panels": [], "title": "Row 2: HTTP Metrics", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Req/s", "drawStyle": "line", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"}}, "overrides": []},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 5},
+      "id": 7,
+      "options": {"legend": {"calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"expr": "rate(nginx_http_requests_total{vhost=~\"wiki.homelab.local|homeassistant.homelab.local|immich.homelab.local\"}[5m])", "legendFormat": "{{vhost}}"}
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "ms", "drawStyle": "line", "lineWidth": 2, "showPoints": "never"}, "unit": "ms"}},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 5},
+      "id": 8,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"expr": "histogram_quantile($quantile, rate(nginx_http_request_duration_seconds_bucket{vhost=~\"wiki.homelab.local|homeassistant.homelab.local|immich.homelab.local\"}[5m])) * 1000", "legendFormat": "{{vhost}} p$quantile"}
+      ],
+      "title": "HTTP Response Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Errors/s", "drawStyle": "line", "lineWidth": 2, "showPoints": "never"}}},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 5},
+      "id": 9,
+      "options": {"legend": {"calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"expr": "rate(nginx_http_requests_total{status=~\"4..|5..\", vhost=~\"wiki.homelab.local|homeassistant.homelab.local|immich.homelab.local\"}[5m])", "legendFormat": "{{vhost}}"}
+      ],
+      "title": "HTTP Error Rate",
+      "type": "timeseries"
+    },
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 12}, "id": 10, "panels": [], "title": "Row 3: Database Performance", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Connections", "drawStyle": "line", "lineWidth": 2}, "unit": "short"}},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 13},
+      "id": 11,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "pg_stat_activity_count{datname=~\"wikijs|homeassistant|immich\", state=\"active\"}", "legendFormat": "{{datname}} active"},
+        {"expr": "pg_stat_activity_count{datname=~\"wikijs|homeassistant|immich\", state=\"idle\"}", "legendFormat": "{{datname}} idle"}
+      ],
+      "title": "PostgreSQL Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "ms", "drawStyle": "line", "lineWidth": 2}, "unit": "ms"}},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 13},
+      "id": 12,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "avg(rate(pg_stat_statement_mean_time_seconds{datname=~\"wikijs|homeassistant|immich\"}[5m])) * 1000", "legendFormat": "{{datname}} avg"},
+        {"expr": "histogram_quantile(0.95, rate(pg_stat_statement_duration_seconds_bucket{datname=~\"wikijs|homeassistant|immich\"}[5m])) * 1000", "legendFormat": "{{datname}} p95"}
+      ],
+      "title": "Query Execution Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "GB", "drawStyle": "line", "lineWidth": 2}, "unit": "decgbytes"}},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 13},
+      "id": 13,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "pg_database_size_bytes{datname=~\"wikijs|homeassistant|immich\"} / 1024 / 1024 / 1024", "legendFormat": "{{datname}}"}
+      ],
+      "title": "Database Size Growth",
+      "type": "timeseries"
+    },
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 20}, "id": 14, "panels": [], "title": "Row 4: Resource Usage", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "CPU %", "drawStyle": "line", "lineWidth": 2}, "unit": "percent"}},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 21},
+      "id": 15,
+      "options": {"legend": {"calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "100 - (avg by(pod) (irate(container_cpu_usage_seconds_total{namespace=\"apps\", pod=~\"wikijs|homeassistant|immich\"}[5m])) * 100)", "legendFormat": "{{pod}}"},
+        {"expr": "avg by(vm) (proxmox_vm_cpu_usage_percent{vm=~\"Wiki.*|Home.*|Immich.*\"})", "legendFormat": "{{vm}}"}
+      ],
+      "title": "CPU Usage per Application",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "GB", "drawStyle": "line", "lineWidth": 2}, "unit": "decbytes"}},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 21},
+      "id": 16,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "container_memory_usage_bytes{namespace=\"apps\", pod=~\"wikijs|homeassistant|immich\"}", "legendFormat": "{{pod}}"},
+        {"expr": "proxmox_vm_mem_used_bytes{vm=~\"Wiki.*|Home.*|Immich.*\"}", "legendFormat": "{{vm}}"}
+      ],
+      "title": "Memory Usage per Application",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "IOPS", "drawStyle": "line", "lineWidth": 2}, "unit": "iops"}},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 21},
+      "id": 17,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "rate(container_fs_reads_total{namespace=\"apps\", pod=~\"wikijs|homeassistant|immich\"}[5m])", "legendFormat": "{{pod}} read"},
+        {"expr": "rate(container_fs_writes_total{namespace=\"apps\", pod=~\"wikijs|homeassistant|immich\"}[5m])", "legendFormat": "{{pod}} write"}
+      ],
+      "title": "Disk I/O per Application",
+      "type": "timeseries"
+    },
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 28}, "id": 18, "panels": [], "title": "Row 5: User Activity", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Count", "drawStyle": "line", "lineWidth": 2}}},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 29},
+      "id": 19,
+      "options": {"legend": {"calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "rate(wikijs_page_views_total[5m])", "legendFormat": "Views"},
+        {"expr": "rate(wikijs_page_edits_total[5m])", "legendFormat": "Edits"}
+      ],
+      "title": "Wiki.js Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Events", "drawStyle": "line", "lineWidth": 2}}},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 29},
+      "id": 20,
+      "options": {"legend": {"calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "rate(homeassistant_entity_state_changes_total[5m])", "legendFormat": "Entity Changes"},
+        {"expr": "rate(homeassistant_automation_runs_total[5m])", "legendFormat": "Automation Runs"}
+      ],
+      "title": "Home Assistant Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisLabel": "Count", "drawStyle": "line", "lineWidth": 2}}},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 29},
+      "id": 21,
+      "options": {"legend": {"calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "right"}},
+      "targets": [
+        {"expr": "rate(immich_photos_uploaded_total[5m])", "legendFormat": "Uploads"},
+        {"expr": "immich_library_storage_used_bytes / 1024 / 1024 / 1024", "legendFormat": "Storage Used (GB)"}
+      ],
+      "title": "Immich Activity",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["homelab", "applications"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": true, "text": "All", "value": "All"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(nginx_http_requests_total, vhost)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values(nginx_http_requests_total, vhost)",
+        "refresh": 1,
+        "regex": "wiki|homeassistant|immich",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {"selected": true, "text": "0.95", "value": "0.95"},
+        "hide": 0,
+        "label": "Quantile",
+        "name": "quantile",
+        "options": [
+          {"selected": false, "text": "0.5", "value": "0.5"},
+          {"selected": false, "text": "0.9", "value": "0.9"},
+          {"selected": true, "text": "0.95", "value": "0.95"},
+          {"selected": false, "text": "0.99", "value": "0.99"}
+        ],
+        "query": "0.95",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {"refresh_intervals": ["30s", "1m", "5m", "15m", "30m", "1h"], "time_options": ["1h", "6h", "12h", "24h", "7d"]},
+  "timezone": "",
+  "title": "Application Metrics - Homelab Services",
+  "uid": "homelab-apps-overview",
+  "version": 1
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/grafana/dashboards/infrastructure-overview.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,627 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Row 1: Key Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 0}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 3, "w": 4, "x": 0, "y": 1},
+      "id": 101,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "count(up)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Hosts",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 20}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 3, "w": 4, "x": 4, "y": 1},
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum(proxmox_vm_info)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total VMs/Containers",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 95}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 3, "w": 4, "x": 8, "y": 1},
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "avg(100 - (avg by(instance) (irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$host\"}[5m])) * 100))",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage Average",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 95}
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {"h": 3, "w": 4, "x": 12, "y": 1},
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "avg((1 - (node_memory_MemAvailable_bytes{instance=~\"$host\"} / node_memory_MemTotal_bytes{instance=~\"$host\"})) * 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage Average",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "green", "value": 90}
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {"h": 3, "w": 4, "x": 16, "y": 1},
+      "id": 105,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "avg(100 - ((node_filesystem_avail_bytes{fstype!~\"tmpfs|devtmpfs\",instance=~\"$host\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|devtmpfs\",instance=~\"$host\"}) * 100))",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Usage Average",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4},
+      "id": 200,
+      "panels": [],
+      "title": "Row 2: Resource Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "CPU %",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 95}
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "id": 201,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "100 - (avg by(instance) (irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$host\"}[5m])) * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage by Host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "Memory %",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 95}
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "id": 202,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "(1 - (node_memory_MemAvailable_bytes{instance=~\"$host\"} / node_memory_MemTotal_bytes{instance=~\"$host\"})) * 100",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage by Host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "Bytes/s",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 13},
+      "id": 203,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "sum by(instance) (rate(node_network_receive_bytes_total{instance=~\"$host\"}[5m]))",
+          "legendFormat": "{{instance}} RX",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by(instance) (rate(node_network_transmit_bytes_total{instance=~\"$host\"}[5m]))",
+          "legendFormat": "{{instance}} TX",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Traffic",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
+      "id": 300,
+      "panels": [],
+      "title": "Row 3: Disk and Storage",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "IOPS",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "iops"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
+      "id": 301,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "sum by(instance) (rate(node_disk_reads_completed_total{instance=~\"$host\"}[5m]))",
+          "legendFormat": "{{instance}} reads",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by(instance) (rate(node_disk_writes_completed_total{instance=~\"$host\"}[5m]))",
+          "legendFormat": "{{instance}} writes",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk I/O Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "displayMode": "gradient",
+            "min": 0,
+            "max": 100
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 90}
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {"h": 8, "w": 6, "x": 12, "y": 22},
+      "id": 302,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showUnfilled": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "expr": "100 - ((node_filesystem_avail_bytes{fstype!~\"tmpfs|devtmpfs\",instance=~\"$host\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|devtmpfs\",instance=~\"$host\"}) * 100)",
+          "legendFormat": "{{instance}} {{mountpoint}}"
+        }
+      ],
+      "title": "Filesystem Usage",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 70},
+              {"color": "red", "value": 90}
+            ]
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {"h": 8, "w": 6, "x": 18, "y": 22},
+      "id": 303,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "truenas_pool_used_bytes",
+          "refId": "A"
+        },
+        {
+          "expr": "truenas_pool_size_bytes",
+          "hide": true,
+          "refId": "B"
+        }
+      ],
+      "title": "TrueNAS Storage Pool Usage",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 30},
+      "id": 400,
+      "panels": [],
+      "title": "Row 4: System Health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 31},
+      "id": 401,
+      "options": {
+        "showHeader": true,
+        "sortBy": [{"desc": true, "displayName": "Value"}]
+      },
+      "targets": [
+        {
+          "expr": "ALERTS{alertstate=\"firing\"}",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"__name__": true},
+            "indexByName": {},
+            "renameByName": {"value": "Value"}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 31},
+      "id": 402,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "proxmox_backup_job_last_status",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Backup Job Status",
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "Days",
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 31},
+      "id": 403,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "right"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "node_time_seconds{instance=~\"$host\"} - node_boot_time_seconds{instance=~\"$host\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime by Host",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["homelab", "infrastructure"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": [".*"]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(node_exporter_build_info, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": "label_values(node_exporter_build_info, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "auto",
+          "value": "auto"
+        },
+        "hide": 0,
+        "label": "Interval",
+        "name": "interval",
+        "options": [
+          {"selected": true, "text": "auto", "value": "auto"},
+          {"text": "10s", "value": "10s"},
+          {"text": "30s", "value": "30s"},
+          {"text": "1m", "value": "1m"},
+          {"text": "5m", "value": "5m"}
+        ],
+        "query": "1m",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "time_options": ["1h", "6h", "24h", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Homelab Infrastructure Overview",
+  "uid": "homelab-infra-overview",
+  "version": 1
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/loki/loki-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/loki/loki-config.yml
@@ -1,0 +1,109 @@
+# Loki configuration for single-instance homelab deployment
+# ---------------------------------------------------------
+# This configuration is optimized for a single-node Loki deployment handling
+# approximately 10GB of logs per day with 30-day retention on local storage.
+# Sections include detailed comments for maintainability.
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+  log_format: logfmt
+  # enable_runtime_config allows hot-reloading of select parameters if needed.
+  enable_runtime_config: true
+
+common:
+  path_prefix: /var/lib/loki
+  storage:
+    filesystem:
+      chunks_directory: /var/lib/loki/chunks
+      rules_directory: /var/lib/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    shared_store: filesystem
+    active_index_directory: /var/lib/loki/index
+    cache_location: /var/lib/loki/boltdb-cache
+    cache_ttl: 24h
+  filesystem:
+    directory: /var/lib/loki/chunks
+
+chunk_store_config:
+  max_look_back_period: 0s
+  # Cache query results for a day to speed up frequently accessed logs.
+  chunk_cache_config:
+    enable_fifocache: true
+    fifocache:
+      max_size_items: 1024
+      ttl: 24h
+
+compactor:
+  working_directory: /var/lib/loki/compactor
+  shared_store: filesystem
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_cancel_period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+  max_streams_per_user: 10000
+  max_global_streams_per_user: 0
+  max_query_length: 721h
+  max_query_lookback: 0s
+  max_cache_freshness_per_query: 10s
+
+runtime_config:
+  file: /etc/loki/runtime-config.yaml
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 720h
+  poll_interval: 10m
+
+querier:
+  engine:
+    max_queriers_per_tenant: 2
+  query_timeout: 2m
+  tail_max_duration: 5m
+
+query_range:
+  cache_results: true
+  results_cache:
+    cache:
+      enable_fifocache: true
+      fifocache:
+        max_size_items: 1024
+        ttl: 24h
+
+frontend:
+  log_queries_longer_than: 5s
+  max_outstanding_per_tenant: 64
+
+ruler:
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true
+  storage:
+    type: local
+    local:
+      directory: /var/lib/loki/rules

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/loki/promtail-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/loki/promtail-config.yml
@@ -1,0 +1,136 @@
+# Promtail configuration for homelab log shippers
+# -----------------------------------------------
+# This configuration collects logs from system files, the journal, Docker
+# containers, and application specific paths. Extensive comments explain each
+# section for future operators.
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: info
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: http://192.168.1.30:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 1048576
+    timeout: 10s
+    external_labels:
+      cluster: homelab
+      environment: production
+
+scrape_configs:
+  - job_name: syslog
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: syslog
+          host: "${HOSTNAME}"
+          __path__: /var/log/syslog
+    pipeline_stages:
+      - labeldrop:
+          - filename
+
+  - job_name: auth-log
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: auth
+          host: "${HOSTNAME}"
+          __path__: /var/log/auth.log
+    pipeline_stages:
+      - match:
+          selector: '{job="auth"}'
+          stages:
+            - regex:
+                expression: '.*sshd\\[(?P<pid>\\d+)\].*'
+            - labels:
+                pid:
+            - regex:
+                expression: '.*for (?P<user>\\w+) from (?P<source_ip>[\\d\.]+).*'
+            - labels:
+                user:
+                source_ip:
+
+  - job_name: systemd-services
+    journal:
+      json: false
+      max_age: 12h
+      labels:
+        job: systemd
+        host: "${HOSTNAME}"
+      path: /var/log/journal
+      matches:
+        - _SYSTEMD_UNIT=nginx.service
+        - _SYSTEMD_UNIT=postgresql.service
+        - _SYSTEMD_UNIT=docker.service
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: unit
+
+  - job_name: docker-containers
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          host: "${HOSTNAME}"
+          __path__: /var/lib/docker/containers/*/*.log
+    pipeline_stages:
+      - match:
+          selector: '{job="docker"}'
+          stages:
+            - json:
+                expressions:
+                  log: log
+                  stream: stream
+                  time: time
+                  attrs: attrs
+            - labels:
+                stream:
+            - output:
+                source: log
+            - timestamp:
+                source: time
+                format: RFC3339Nano
+            - json:
+                expressions:
+                  container_name: attrs.name
+            - labels:
+                container_name:
+
+  - job_name: nginx-access
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: nginx-access
+          host: "${HOSTNAME}"
+          __path__: /var/log/nginx/access.log
+    pipeline_stages:
+      - regex:
+          expression: '^(?P<client_ip>[^ ]*) [^ ]* [^ ]* \[(?P<timestamp>[^\]]*)\] "(?P<method>[A-Z]+) (?P<path>[^ ]*) [^"]*" (?P<status>\\d{3}) (?P<size>\\d+|-)'
+      - labels:
+          client_ip:
+          method:
+          path:
+          status:
+      - metrics:
+          - counter:
+              name: nginx_requests_total
+              help: Total number of processed requests
+              labels:
+                status:
+                method:
+      - timestamp:
+          source: timestamp
+          format: RFC3339
+
+# Example queries for Grafana dashboards:
+# - {job="syslog"} |~ "error"
+# - rate(nginx_requests_total[5m]) by (status)
+# - count_over_time({job="auth",user="root"}[1h])

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/prometheus/alerts/infrastructure_alerts.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/prometheus/alerts/infrastructure_alerts.yml
@@ -1,0 +1,124 @@
+# Prometheus alert rules for homelab infrastructure monitoring
+# -----------------------------------------------------------
+# This file groups alerting rules by functional category and documents the
+# rationale behind each threshold. Rules follow Prometheus alert rule syntax
+# version 2 and include annotations that link to runbooks.
+
+groups:
+  - name: infrastructure
+    rules:
+      - alert: HostDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+          component: infrastructure
+        annotations:
+          summary: 'Host {{ $labels.instance }} is unreachable'
+          description: 'Prometheus has not scraped {{ $labels.instance }} for over two minutes. Investigate network connectivity or system health.'
+          runbook: 'https://runbooks.homelab.local/{{ $labels.alertname }}'
+
+      - alert: HighCPUUsageWarning
+        expr: (100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
+        for: 15m
+        labels:
+          severity: warning
+          component: infrastructure
+        annotations:
+          summary: 'CPU usage high on {{ $labels.instance }}'
+          description: 'Average CPU utilization exceeded 80% for 15 minutes. Current value: {{ printf "%.2f" $value }}%.'
+          runbook: 'https://runbooks.homelab.local/HighCPUUsage'
+
+      - alert: HighCPUUsageCritical
+        expr: (100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 95
+        for: 15m
+        labels:
+          severity: critical
+          component: infrastructure
+        annotations:
+          summary: 'CPU usage critical on {{ $labels.instance }}'
+          description: 'Average CPU utilization exceeded 95% for 15 minutes. Current value: {{ printf "%.2f" $value }}%. Check top processes immediately.'
+          runbook: 'https://runbooks.homelab.local/HighCPUUsage'
+
+      - alert: HighMemoryUsageWarning
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 85
+        for: 10m
+        labels:
+          severity: warning
+          component: infrastructure
+        annotations:
+          summary: 'Memory usage high on {{ $labels.instance }}'
+          description: 'Available memory below 15% for 10 minutes. Current usage: {{ printf "%.2f" $value }}%.'
+          runbook: 'https://runbooks.homelab.local/HighMemoryUsage'
+
+      - alert: HighMemoryUsageCritical
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 95
+        for: 10m
+        labels:
+          severity: critical
+          component: infrastructure
+        annotations:
+          summary: 'Memory usage critical on {{ $labels.instance }}'
+          description: 'Available memory below 5% for 10 minutes. Current usage: {{ printf "%.2f" $value }}%. Consider restarting services or migrating workloads.'
+          runbook: 'https://runbooks.homelab.local/HighMemoryUsage'
+
+      - alert: DiskSpaceLowWarning
+        expr: (node_filesystem_avail_bytes{fstype!="tmpfs",fstype!="devtmpfs"} / node_filesystem_size_bytes{fstype!="tmpfs",fstype!="devtmpfs"}) * 100 < 15
+        for: 30m
+        labels:
+          severity: warning
+          component: infrastructure
+        annotations:
+          summary: 'Disk space low on {{ $labels.instance }} ({{ $labels.mountpoint }})'
+          description: 'Disk utilization above 85% for 30 minutes. Remaining free space: {{ printf "%.2f" $value }}%.'
+          runbook: 'https://runbooks.homelab.local/DiskSpaceLow'
+
+      - alert: DiskSpaceLowCritical
+        expr: (node_filesystem_avail_bytes{fstype!="tmpfs",fstype!="devtmpfs"} / node_filesystem_size_bytes{fstype!="tmpfs",fstype!="devtmpfs"}) * 100 < 5
+        for: 15m
+        labels:
+          severity: critical
+          component: infrastructure
+        annotations:
+          summary: 'Disk space critical on {{ $labels.instance }} ({{ $labels.mountpoint }})'
+          description: 'Disk utilization above 95% for 15 minutes. Remaining free space: {{ printf "%.2f" $value }}%.'
+          runbook: 'https://runbooks.homelab.local/DiskSpaceLow'
+
+      - alert: BackupJobFailed
+        expr: proxmox_backup_job_last_status != 0
+        for: 1h
+        labels:
+          severity: critical
+          component: backup
+        annotations:
+          summary: 'Proxmox backup job failing ({{ $labels.job_name }})'
+          description: 'Backup job {{ $labels.job_name }} has non-zero status {{ $value }}. Check PBS logs and rerun verification.'
+          runbook: 'https://runbooks.homelab.local/BackupJobFailed'
+
+      - alert: HighNetworkTraffic
+        expr: rate(node_network_receive_bytes_total[5m]) > 100000000
+        for: 30m
+        labels:
+          severity: warning
+          component: infrastructure
+        annotations:
+          summary: 'High inbound traffic on {{ $labels.instance }} ({{ $labels.device }})'
+          description: 'Inbound traffic sustained above 100 MB/s for 30 minutes. Current bandwidth: {{ humanize1024 $value }}/s.'
+          runbook: 'https://runbooks.homelab.local/HighNetworkTraffic'
+
+      - alert: ServiceUnreachable
+        expr: probe_success == 0
+        for: 5m
+        labels:
+          severity: critical
+          component: application
+        annotations:
+          summary: 'Service unreachable: {{ $labels.instance }}'
+          description: 'Blackbox probe failed for {{ $labels.instance }} with HTTP status {{ $labels.status_code }}. Check service availability.'
+          runbook: 'https://runbooks.homelab.local/ServiceUnreachable'
+
+  - name: backup
+    rules: []
+
+  - name: application
+    rules: []

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/prometheus/prometheus.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/prometheus/prometheus.yml
@@ -1,0 +1,154 @@
+# Prometheus configuration for the homelab observability stack
+# -----------------------------------------------------------
+# This file defines global scraping settings, scrape jobs for all monitored
+# components, rule file locations, and alerting endpoints. The extensive
+# comments explain why each option is chosen for the Proxmox-based homelab.
+
+global:
+  # Scrape all targets every 15 seconds to capture fine-grained metrics
+  # while balancing resource usage on the small homelab environment.
+  scrape_interval: 15s
+  # Evaluate alerting and recording rules at the same cadence as scraping so
+  # the latest data is always used for alert calculations.
+  evaluation_interval: 15s
+  # Global labels added to every time series. These make it easy to filter all
+  # data from this homelab cluster when federating or aggregating metrics.
+  external_labels:
+    environment: homelab
+    cluster: main
+
+# Alerting configuration defines how Prometheus sends alerts to Alertmanager.
+alerting:
+  alert_relabel_configs:
+    # Derive severity labels dynamically based on alert names to simplify rule
+    # definitions. Customize the mapping as alert coverage grows.
+    - source_labels: [alertname]
+      regex: ".*(Critical|Severe).*"
+      target_label: severity
+      replacement: critical
+    - source_labels: [alertname]
+      regex: ".*(Warn|High|Warning).*"
+      target_label: severity
+      replacement: warning
+    - source_labels: [alertname]
+      regex: ".*(Info|Informational).*"
+      target_label: severity
+      replacement: info
+  alertmanagers:
+    - static_configs:
+        # Alertmanager runs on the same host as Prometheus, reachable via the
+        # loopback interface. TLS can be added later if exposed remotely.
+        - targets: ['localhost:9093']
+      # Timeout for sending alerts to Alertmanager. A short timeout prevents
+      # metric pipeline interruptions if Alertmanager is unavailable.
+      timeout: 10s
+
+# Rule files containing alerting and recording rules. The glob patterns allow
+# multiple rule files to be dropped into these directories without updating the
+# configuration.
+rule_files:
+  - /etc/prometheus/alerts/*.yml
+  - /etc/prometheus/rules/*.yml
+
+# Scrape configuration section enumerates every target monitored in the homelab.
+scrape_configs:
+  # Monitor Prometheus itself to ensure the service is healthy.
+  - job_name: prometheus
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['localhost:9090']
+        labels:
+          hostname: prom-main
+          job: prometheus
+    metric_relabel_configs:
+      - source_labels: [instance]
+        target_label: instance
+        replacement: localhost:9090
+
+  # Node exporter running on the Proxmox hypervisor.
+  - job_name: proxmox-node
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    scheme: http
+    static_configs:
+      - targets: ['192.168.1.10:9100']
+        labels:
+          hostname: proxmox-host
+          job: node-exporter
+    # Basic auth placeholder for environments exposing exporters with auth.
+    basic_auth:
+      username: proxmox_exporter
+      password: changeme
+
+  # Node exporters running on each VM to capture guest metrics.
+  - job_name: vm-nodes
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets:
+          - '192.168.1.20:9100'
+          - '192.168.1.21:9100'
+          - '192.168.1.22:9100'
+          - '192.168.1.23:9100'
+          - '192.168.1.24:9100'
+        labels:
+          job: node-exporter
+    relabel_configs:
+      # Attach friendly hostnames used across dashboards and alerts.
+      - source_labels: [__address__]
+        regex: '192.168.1.(20):.*'
+        replacement: vm-wiki
+        target_label: hostname
+      - source_labels: [__address__]
+        regex: '192.168.1.(21):.*'
+        replacement: vm-homeassistant
+        target_label: hostname
+      - source_labels: [__address__]
+        regex: '192.168.1.(22):.*'
+        replacement: vm-immich
+        target_label: hostname
+      - source_labels: [__address__]
+        regex: '192.168.1.(23):.*'
+        replacement: vm-db
+        target_label: hostname
+      - source_labels: [__address__]
+        regex: '192.168.1.(24):.*'
+        replacement: vm-utility
+        target_label: hostname
+
+  # Alertmanager metrics endpoint for insight into alert processing.
+  - job_name: alertmanager
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['localhost:9093']
+        labels:
+          job: alertmanager
+          hostname: alertmanager
+
+  # Proxmox exporter exposes metrics for all virtual machines and containers.
+  - job_name: proxmox-exporter
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['192.168.1.10:9221']
+        labels:
+          job: proxmox-exporter
+          hostname: proxmox-host
+    basic_auth:
+      username: proxmox_exporter
+      password: changeme
+
+  # TrueNAS exporter for storage metrics, capacity, and SMART data.
+  - job_name: truenas-exporter
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['192.168.1.5:9273']
+        labels:
+          job: truenas-exporter
+          hostname: truenas-core
+    basic_auth:
+      username: truenas_exporter
+      password: changeme

--- a/projects/01-sde-devops/PRJ-SDE-002/assets/scripts/verify-pbs-backups.sh
+++ b/projects/01-sde-devops/PRJ-SDE-002/assets/scripts/verify-pbs-backups.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# verify-pbs-backups.sh
+# ------------------------------------------------------------------
+# Proxmox Backup Server verification utility for homelab deployments.
+# Performs job health checks, snapshot validation, datastore review,
+# and mails an HTML report. Designed for cron-based daily execution.
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+VERSION="1.0.0"
+LOG_FILE="/var/log/backup-verification.log"
+REPORT_FILE="/tmp/pbs-verification-report.html"
+PBS_ENDPOINT="https://192.168.1.15:8007"
+PBS_DATASTORE="homelab-backups"
+EMAIL_RECIPIENT="admin@homelab.local"
+VERBOSE=false
+DRY_RUN=false
+EXIT_CODE=0
+
+COLOR_GREEN="\033[1;32m"
+COLOR_YELLOW="\033[1;33m"
+COLOR_RED="\033[1;31m"
+COLOR_RESET="\033[0m"
+
+usage() {
+  cat <<USAGE
+${SCRIPT_NAME} v${VERSION}
+Usage: ${SCRIPT_NAME} [-v] [-d] [-h]
+  -v    Verbose output (echo log lines to STDOUT)
+  -d    Dry run (skip email delivery)
+  -h    Show help
+
+Environment:
+  PBS_TOKEN   Proxmox Backup Server API token (required)
+USAGE
+}
+
+while getopts "vdh" opt; do
+  case ${opt} in
+    v) VERBOSE=true ;;
+    d) DRY_RUN=true ;;
+    h) usage; exit 0 ;;
+    *) usage >&2; exit 1 ;;
+  esac
+done
+
+log() {
+  local level=$1 color=$2
+  shift 2
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  local message="${timestamp} [${level}] $*"
+  echo -e "${message}" >> "$LOG_FILE"
+  if [[ $VERBOSE == true ]]; then
+    echo -e "${color}${message}${COLOR_RESET}"
+  fi
+}
+
+require_token() {
+  if [[ -z "${PBS_TOKEN:-}" ]]; then
+    log ERROR "$COLOR_RED" "PBS_TOKEN environment variable is required"
+    exit 2
+  fi
+}
+
+api_call() {
+  local method=$1 path=$2 data=${3:-}
+  local url="${PBS_ENDPOINT}${path}"
+  local opts=(
+    --silent --show-error --fail --insecure
+    --request "$method"
+    -H "Authorization: PBSAPIToken=${PBS_TOKEN}"
+    -H 'Content-Type: application/json'
+    "$url"
+  )
+  if [[ -n $data ]]; then
+    opts+=(--data "$data")
+  fi
+  curl "${opts[@]}"
+}
+
+# Containers for report content
+JOB_ROWS=()
+SNAPSHOT_ROWS=()
+DATASTORE_SUMMARY="Not available"
+DATASTORE_WARNINGS=()
+
+fetch_jobs() {
+  log INFO "$COLOR_GREEN" "Fetching backup jobs"
+  api_call GET "/api2/json/admin/datastore/${PBS_DATASTORE}/backups" | jq -c '.data[]'
+}
+
+process_jobs() {
+  while IFS= read -r job; do
+    [[ -z $job ]] && continue
+    local name last_time status duration size prev_size
+    name=$(jq -r '."backup-id"' <<<"$job")
+    last_time=$(jq -r '."last-run".time // empty' <<<"$job")
+    status=$(jq -r '."last-run".status // "unknown"' <<<"$job")
+    duration=$(jq -r '."last-run".duration // 0' <<<"$job")
+    size=$(jq -r '."last-run".size // 0' <<<"$job")
+    prev_size=$(jq -r '."previous-run".size // 0' <<<"$job")
+
+    local issues=()
+    if [[ -z $last_time ]]; then
+      issues+=('No successful run recorded')
+      EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+    else
+      local last_epoch now_epoch
+      last_epoch=$last_time
+      now_epoch=$(date +%s)
+      if (( now_epoch - last_epoch > 86400 )); then
+        issues+=('Last run >24h ago')
+        EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+      fi
+    fi
+
+    if [[ ${status,,} != ok ]]; then
+      issues+=("Status ${status}")
+      EXIT_CODE=2
+    fi
+
+    if (( duration > 3600 )); then
+      issues+=("Duration ${duration}s > 1h")
+      EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+    fi
+
+    if (( prev_size > 0 )); then
+      local half=$(( prev_size / 2 ))
+      if (( size < half )); then
+        issues+=("Size drop ${size} vs ${prev_size}")
+        EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+      fi
+    fi
+
+    local color_class="pass"
+    local status_text=${status}
+    if [[ ${status,,} != ok ]]; then
+      color_class="fail"
+    elif ((${#issues[@]} > 0)); then
+      color_class="warn"
+    fi
+
+    JOB_ROWS+=("<tr><td>${name}</td><td class=\"${color_class}\">${status_text}</td><td>${issues[*]:-None}</td></tr>")
+  done
+}
+
+fetch_snapshots() {
+  log INFO "$COLOR_GREEN" "Collecting snapshot metadata"
+  api_call GET "/api2/json/admin/datastore/${PBS_DATASTORE}/snapshots" | jq -c '.data[]'
+}
+
+process_snapshots() {
+  declare -A latest_snapshot_seen
+  while IFS= read -r snap; do
+    [[ -z $snap ]] && continue
+    local id type timestamp size
+    id=$(jq -r '.snapshot' <<<"$snap")
+    type=$(jq -r '."backup-type"' <<<"$snap")
+    timestamp=$(jq -r '.timestamp' <<<"$snap")
+    size=$(jq -r '.size // 0' <<<"$snap")
+
+    local epoch now_epoch note="Verified"
+    epoch=$(date --date="${timestamp}" +%s)
+    now_epoch=$(date +%s)
+
+    if (( now_epoch - epoch > 604800 )); then
+      note="Older than 7 days"
+      EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+    fi
+    if (( size <= 0 )); then
+      note="Snapshot size zero"
+      EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+    fi
+
+    local base_id
+    base_id=$(jq -r '."backup-id"' <<<"$snap")
+    if [[ -n ${latest_snapshot_seen[$base_id]:-} ]]; then
+      continue
+    fi
+    latest_snapshot_seen[$base_id]=1
+
+    local payload
+    payload=$(jq -n --arg snap "$id" '{snap: $snap, "output-format": "json"}')
+    if api_call POST "/api2/json/admin/datastore/${PBS_DATASTORE}/verify" "$payload" >/dev/null 2>&1; then
+      note+="; verification queued"
+    else
+      note="Verify request failed"
+      EXIT_CODE=2
+    fi
+
+    local css="pass"
+    if [[ $note == *failed* ]]; then
+      css="fail"
+    elif [[ $note == *Older* || $note == *zero* ]]; then
+      css="warn"
+    fi
+    SNAPSHOT_ROWS+=("<tr><td>${base_id}</td><td>${type}</td><td>${timestamp}</td><td class=\"${css}\">${note}</td></tr>")
+  done
+}
+
+check_datastore() {
+  log INFO "$COLOR_GREEN" "Reviewing datastore status"
+  local summary
+  if ! summary=$(api_call GET "/api2/json/admin/datastore/${PBS_DATASTORE}/status"); then
+    DATASTORE_SUMMARY="Status unavailable"
+    EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+    return
+  fi
+  local total used gc_status gc_time
+  total=$(jq -r '.data.total // 0' <<<"$summary")
+  used=$(jq -r '.data.used // 0' <<<"$summary")
+  gc_status=$(jq -r '.data."last-gc-status" // "unknown"' <<<"$summary")
+  gc_time=$(jq -r '.data."last-gc" // 0' <<<"$summary")
+  local percent=0
+  if (( total > 0 )); then
+    percent=$(( used * 100 / total ))
+  fi
+  if (( percent > 80 )); then
+    DATASTORE_WARNINGS+=("Usage ${percent}% > 80%")
+    EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+  fi
+  local now_epoch=$(date +%s)
+  if (( gc_time > 0 && now_epoch - gc_time > 604800 )); then
+    DATASTORE_WARNINGS+=("Garbage collection older than 7 days")
+    EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+  fi
+  DATASTORE_SUMMARY=$(cat <<SUMMARY
+Total capacity: $(numfmt --to=iec ${total:-0})<br/>
+Used space: $(numfmt --to=iec ${used:-0})<br/>
+Last GC status: ${gc_status}
+SUMMARY
+)
+}
+
+build_report() {
+  log INFO "$COLOR_GREEN" "Generating HTML report"
+  local warning_text="${DATASTORE_WARNINGS[*]:-None}"
+  cat <<HTML > "$REPORT_FILE"
+<html><head><meta charset="utf-8" /><title>PBS Backup Verification Report</title>
+<style>body{font-family:Arial,sans-serif;background:#101418;color:#e0e0e0;}
+h1{color:#ff9800;}
+table{width:100%;border-collapse:collapse;margin-bottom:20px;}
+th,td{border:1px solid #333;padding:8px;text-align:left;}
+th{background:#1e1e1e;}
+.pass{color:#4caf50;}
+.warn{color:#ffeb3b;}
+.fail{color:#f44336;}
+</style></head><body>
+<h1>Proxmox Backup Verification Report</h1><p>Generated: $(date)</p>
+<h2>Datastore Health</h2><p>${DATASTORE_SUMMARY}</p><p class="warn">${warning_text}</p>
+<h2>Backup Jobs</h2><table><tr><th>Job</th><th>Status</th><th>Issues</th></tr>${JOB_ROWS[*]}</table>
+<h2>Snapshot Verification</h2><table><tr><th>Backup ID</th><th>Type</th><th>Timestamp</th><th>Status</th></tr>${SNAPSHOT_ROWS[*]}</table>
+<p>Exit code: ${EXIT_CODE}</p></body></html>
+HTML
+}
+
+send_report() {
+  if [[ $DRY_RUN == true ]]; then
+    log INFO "$COLOR_YELLOW" "Dry run enabled; email suppressed"
+    return
+  fi
+  if command -v mailx >/dev/null 2>&1; then
+    log INFO "$COLOR_GREEN" "Sending report to ${EMAIL_RECIPIENT}"
+    mailx -a "Content-Type: text/html" -s "PBS Backup Verification" "$EMAIL_RECIPIENT" < "$REPORT_FILE"
+  else
+    log WARN "$COLOR_YELLOW" "mailx not available; report saved at ${REPORT_FILE}"
+    EXIT_CODE=$(( EXIT_CODE < 1 ? 1 : EXIT_CODE ))
+  fi
+}
+
+main() {
+  require_token
+  log INFO "$COLOR_GREEN" "Starting PBS backup verification"
+  JOB_ROWS=()
+  SNAPSHOT_ROWS=()
+  fetch_jobs | process_jobs
+  fetch_snapshots | process_snapshots
+  check_datastore
+  build_report
+  send_report
+  log INFO "$COLOR_GREEN" "Verification complete with exit code ${EXIT_CODE}"
+  exit ${EXIT_CODE}
+}
+
+main "$@"
+
+# Cron example (run daily at 03:00):
+# 0 3 * * * root PBS_TOKEN="<user@pbs!token=abc123>" /usr/local/bin/verify-pbs-backups.sh >> /var/log/backup-verification.log 2>&1
+# Token setup: PBS UI → Datacenter → API Tokens → create token with DatastoreBackup privileges, export as PBS_TOKEN before running.


### PR DESCRIPTION
## Summary
- add production-ready Prometheus, Alertmanager, Loki, and Promtail configurations for the homelab stack
- include Grafana infrastructure and application dashboards plus a Mermaid architecture diagram
- enhance the PRJ-SDE-002 README with operational guidance, runbooks, metrics references, and backup procedures
- supply a PBS backup verification script that validates jobs, snapshots, and datastore health while emailing HTML reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a35be53dc8327b4bbc992a8faa91b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with comprehensive setup guides, alert examples, backup procedures, architecture overview, and operational lessons learned

* **New Features**
  * Added two new Grafana dashboards for monitoring application metrics and infrastructure overview
  * Introduced automated backup verification utility

* **Configuration**
  * Added complete observability stack configurations for alerting, logging, and monitoring systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->