### PR TITLE
Add remediation blueprint and clarify project status

### DIFF
--- a/GAP_REMEDIATION_BLUEPRINT.md
+++ b/GAP_REMEDIATION_BLUEPRINT.md
@@ -1,0 +1,49 @@
+# Portfolio Gap Remediation Blueprint
+
+## Executive Summary
+- **Portfolio verification status:** critical. No public GitHub account currently exists for Samuel Jackson, so none of the planned work can be independently validated.
+- **Existing assets:** 11 production-quality code files (3 Python, 8 Terraform) and extensive planning documents stored privately in Google Drive.
+- **Primary risk:** Documentation claims (including a “complete” homelab) do not have accessible code or configuration evidence.
+
+## Immediate Priorities (Weeks 1-4)
+1. **Create public GitHub presence**
+   - Register an available username (recommendation: `samsjackson`).
+   - Publish the 11 existing code artifacts with professional repository structures, READMEs, and licenses.
+   - Update résumé and LinkedIn with the accurate GitHub URL once live.
+2. **Validate homelab claims**
+   - Confirm whether the documented Proxmox/pfSense/TrueNAS stack exists.
+   - If it exists, export and sanitize configs, monitoring dashboards, and runbooks into a new `proxmox-homelab-iac` repository.
+   - If not, reclassify the project as “planned” until implementation is complete.
+3. **Launch public portfolio website**
+   - Implement the planned React frontend and integrate it with the FastAPI backend.
+   - Deploy both front and back end (e.g., Vercel/Render + managed PostgreSQL) and link from professional profiles.
+
+## Secondary Priorities (Weeks 5-12)
+- **SIEM pipeline (OpenSearch on AWS):** deliver infrastructure-as-code, data ingestion, dashboards, and alerting.
+- **Containerized CI/CD platform:** showcase GitHub Actions, Docker, and AWS ECS/EKS deployment workflows.
+- **AWS landing zone expansion:** complete governance, security services, and documentation.
+- **Reportify Pro full-stack delivery:** pair the existing backend code with a modern React interface and deployment guide.
+
+## Documentation Standards
+- Every repository must include:
+  - Comprehensive README with architecture diagrams and quick-start instructions.
+  - `docs/` folder covering architecture, development, deployment, and operations.
+  - OpenAPI specs or equivalent API documentation when relevant.
+  - Runbooks for operational procedures (especially infrastructure and security projects).
+- Validation checklist:
+  - Automated tests passing locally and in CI.
+  - `terraform validate`/`plan` clean for IaC projects.
+  - No hard-coded secrets; `.env.example` supplied for configuration.
+
+## Risk & Mitigation Highlights
+- **Credibility risk:** Publicly claiming completed projects without evidence erodes trust. Mitigation: publish artifacts or reclassify status immediately.
+- **Scope overload:** 22+ planned initiatives can stall progress. Mitigation: adhere to the phased roadmap and ship verifiable increments.
+- **Time estimation:** underestimate at own peril. Re-evaluate capacity after Phase 1 deliveries.
+
+## Success Metrics
+- **Week 4:** GitHub profile live with ≥3 repositories, portfolio site deployed, homelab status clarified.
+- **Week 12:** ≥8 repositories with working demos/tests, SIEM and CI/CD platforms operational, documentation aligned with code.
+- **Week 28:** ≥18 repositories, comprehensive documentation, demonstrable multi-domain expertise.
+
+---
+*This blueprint captures the actionable remediation plan derived from the comprehensive gap analysis performed on Samuel Jackson’s portfolio materials (November 2025).* 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Hi, I'm Sam Jackson!
-**[System Development Engineer](https://github.com/samueljackson-collab)** · **[DevOps & QA Enthusiast](https://www.linkedin.com/in/sams-jackson)** · **Freelance Full-Stack Web Developer**
+**System Development Engineer** · **[DevOps & QA Enthusiast](https://www.linkedin.com/in/sams-jackson)** · **Freelance Full-Stack Web Developer**
+
+> 📢 **Transparency update (Nov 2025):** I am currently establishing my public GitHub presence. Until the profile is live, all project links below refer to planning documentation within this repository rather than external code repositories.
 
 [![CI](https://github.com/samueljackson-collab/Portfolio-Project/workflows/CI/badge.svg?branch=main)](https://github.com/samueljackson-collab/Portfolio-Project/actions/workflows/ci.yml)
 
 ***Building reliable systems, documenting clearly, and sharing what I learn. I turn ambiguous requirements into runbooks, dashboards, and repeatable processes.***
 
-**Status key:** 🟢 Done · 🟠 In Progress · 🔵 Planned · 🔄 Recovery/Rebuild · 📝 Documentation Pending
+**Status key:** 🟢 Done (code + evidence published) · 🟠 In Progress · 🔵 Planned · 🔄 Recovery/Rebuild · 📝 Documentation in progress · ⚠️ Evidence pending publication
 
 > **Portfolio Note:** This repository is actively being built. Projects marked 🟢 are technically complete but documentation/evidence is being prepared (📝). Projects marked 🔵 are planned roadmap items, and 🔄 indicates recovery/rebuild efforts are underway.
 
 > **Note:** Some project directories referenced below contain planning documentation and structure but are awaiting evidence/asset uploads. Check individual project READMEs for current status.
 
-> 📚 **New:** [Missing Documents Analysis](./MISSING_DOCUMENTS_ANALYSIS.md) | [Quick Start Guide](./QUICK_START_GUIDE.md) | [Completion Checklist](./PROJECT_COMPLETION_CHECKLIST.md)
+> 📚 **New:** [Missing Documents Analysis](./MISSING_DOCUMENTS_ANALYSIS.md) | [Quick Start Guide](./QUICK_START_GUIDE.md) | [Completion Checklist](./PROJECT_COMPLETION_CHECKLIST.md) | [Gap Remediation Blueprint](./GAP_REMEDIATION_BLUEPRINT.md)
 
 ---
 ## 🎯 Summary
@@ -72,22 +74,24 @@ System-minded engineer specializing in building, securing, and operating infrast
 - **Quality & Process:** runbooks, acceptance criteria, regression checklists, change control
 
 ---
-## 🟢 Completed Projects (📝 Documentation in Progress)
+## ⚠️ Documented-Only Projects (Evidence Pending)
+
+The initiatives below have detailed planning artifacts, but their automation, code, and configuration exports are not yet published. They remain documentation-first until the GitHub remediation work in [Gap Remediation Blueprint](./GAP_REMEDIATION_BLUEPRINT.md) is delivered.
 
 ### Homelab & Secure Network Build
-**Status:** 🟢 Complete · 📝 Docs pending
+**Status:** ⚠️ Evidence pending
 **Description** Designed and wired a home network from scratch: rack-mounted gear, VLAN segmentation, and secure Wi-Fi for isolated IoT, guest, and trusted networks.
-**Links**: [Project README](./projects/06-homelab/PRJ-HOME-001/) · [Evidence/Diagrams](./projects/06-homelab/PRJ-HOME-001/assets) *(being prepared)*
+**Links**: [Project README](./projects/06-homelab/PRJ-HOME-001/) · [Evidence/Diagrams](./projects/06-homelab/PRJ-HOME-001/assets) *(to be published alongside sanitized configs)*
 
 ### Virtualization & Core Services
-**Status:** 🟢 Complete · 📝 Docs pending
+**Status:** ⚠️ Evidence pending
 **Description** Proxmox/TrueNAS host running Wiki.js, Home Assistant, and Immich behind a reverse proxy with TLS.
-**Links**: [Project README](./projects/06-homelab/PRJ-HOME-002/) · [Backup Logs](./projects/06-homelab/PRJ-HOME-002/assets) *(being prepared)*
+**Links**: [Project README](./projects/06-homelab/PRJ-HOME-002/) · [Backup Logs](./projects/06-homelab/PRJ-HOME-002/assets) *(publication scheduled post-GitHub migration)*
 
 ### Observability & Backups Stack
-**Status:** 🟢 Complete · 📝 Docs pending
+**Status:** ⚠️ Evidence pending
 **Description** Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.
-**Links**: [Project README](./projects/01-sde-devops/PRJ-SDE-002/) · [Dashboards](./projects/01-sde-devops/PRJ-SDE-002/assets)
+**Links**: [Project README](./projects/01-sde-devops/PRJ-SDE-002/) · [Dashboards](./projects/01-sde-devops/PRJ-SDE-002/assets) *(to be exported from Grafana)*
 
 ---
 ## 🔄 Past Projects Requiring Recovery
@@ -145,5 +149,5 @@ Older commercial efforts live in cold storage while I recreate code, processes, 
 
 ---
 ## 🤳 Connect
-[GitHub](https://github.com/samueljackson-collab) · [LinkedIn](https://www.linkedin.com/in/sams-jackson) 
-[![GitHub Profile](https://img.shields.io/badge/GitHub-Portfolio-181717?style=flat&logo=github)](https://github.com/samueljackson-collab)
+- GitHub profile: *going live with migrated repositories — link will be published here by Week 4 (see roadmap).* 
+- [LinkedIn](https://www.linkedin.com/in/sams-jackson)


### PR DESCRIPTION
## Summary
- add a remediation blueprint that captures the immediate GitHub migration plan and follow-on project priorities
- update the README with a transparency notice, revised status key, and link to the new blueprint
- restate “completed” initiatives as documentation-only until supporting evidence is published

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691366a2e3d483278ea1e42cc0a9e06e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Gap Remediation Blueprint outlining phased timelines and concrete action items with success metrics.
  * Updated README with transparency notes regarding November 2025 public GitHub availability.
  * Clarified project status indicators to reflect documentation progress and evidence publication status.
  * Improved portfolio guidance sections for clearer roadmap interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->