### PR TITLE
Add multi-location photo storage service

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,13 @@ A modern, production-ready REST API built with FastAPI, featuring JWT authentica
    # Edit .env with your database credentials and secret key
    ```
 
+   Optional storage overrides:
+   ```bash
+   PHOTO_PRIMARY_STORAGE_PATH=/mnt/home-server/photos
+   PHOTO_BACKUP_PATHS=/mnt/aunt-backup/photos,/mnt/tucson-backup/photos
+   ```
+   The defaults already map to the home server, aunt's house, and Tucson backups.
+
 5. **Run database migrations**
    ```bash
    alembic upgrade head
@@ -111,6 +118,8 @@ backend/
 │   ├── schemas.py           # Pydantic schemas
 │   ├── auth.py              # Authentication utilities
 │   ├── dependencies.py      # FastAPI dependencies
+│   ├── services/            # Shared service layer helpers
+│   │   └── storage.py       # Photo storage with multi-site backups
 │   └── routers/
 │       ├── __init__.py
 │       ├── health.py        # Health check endpoints
@@ -169,6 +178,8 @@ alembic history
 | `SECRET_KEY` | JWT secret key (min 32 chars) | Required |
 | `CORS_ORIGINS` | Allowed CORS origins | ["http://localhost:3000"] |
 | `LOG_LEVEL` | Logging level | INFO |
+| `PHOTO_PRIMARY_STORAGE_PATH` | Primary photo storage directory (home server) | /srv/elderphoto/home-server |
+| `PHOTO_BACKUP_PATHS` | Comma-separated backup paths (aunt's house, Tucson AZ) | /srv/elderphoto/aunt-backup,/srv/elderphoto/tucson-backup |
 
 ## Security Considerations
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -55,6 +55,21 @@ class Settings(BaseSettings):
     # Logging Settings
     log_level: str = Field(default="INFO", description="Logging level")
 
+    # Photo Storage Settings
+    photo_primary_storage_path: str = Field(
+        default="/srv/elderphoto/home-server",
+        description="Primary storage path located on the home server",
+    )
+    photo_backup_paths: list[str] = Field(
+        default_factory=lambda: [
+            "/srv/elderphoto/aunt-backup",
+            "/srv/elderphoto/tucson-backup",
+        ],
+        description=(
+            "Backup storage directories, e.g. aunt's house NAS and Tucson remote backup"
+        ),
+    )
+
     @field_validator("database_url")
     @classmethod
     def validate_database_url(cls, v: str) -> str:

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer utilities for the backend application."""
+
+from .storage import PhotoStorageService, StoredPhotoPaths, get_photo_storage_service
+
+__all__ = ["PhotoStorageService", "StoredPhotoPaths", "get_photo_storage_service"]

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,111 @@
+"""Photo storage service with multi-location backups."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+import uuid
+
+from fastapi import UploadFile
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class StoredPhotoPaths:
+    """Result of storing a photo.
+
+    Attributes:
+        primary: Path to the primary copy stored on the home server.
+        backups: Paths to any successfully replicated backup copies.
+    """
+
+    primary: Path
+    backups: list[Path]
+
+
+class PhotoStorageService:
+    """Store uploaded photos to primary and backup locations.
+
+    The service writes a single authoritative copy to the "home server"
+    directory and then replicates the file to any configured backup
+    directories. This supports the user's desired topology:
+
+    * Primary: home server storage
+    * Secondary: local backup at aunt's house (e.g. NAS or external drive)
+    * Remote: off-site backup in Tucson, AZ (e.g. VPN mounted share)
+    """
+
+    def __init__(self, primary_path: Path, backup_paths: Sequence[Path]):
+        self.primary_path = primary_path
+        self.backup_paths = list(backup_paths)
+
+    def _build_relative_path(
+        self,
+        user_id: uuid.UUID,
+        capture_date: datetime | None,
+        original_filename: str,
+    ) -> Path:
+        """Build a deterministic relative path for the photo."""
+
+        date_folder = capture_date.strftime("%Y/%m/%d") if capture_date else "unknown"
+        safe_name = original_filename.replace(os.sep, "_")
+        return Path(str(user_id)) / date_folder / safe_name
+
+    async def save_upload(
+        self,
+        upload: UploadFile,
+        user_id: uuid.UUID,
+        capture_date: datetime | None = None,
+    ) -> StoredPhotoPaths:
+        """Persist an UploadFile to primary and backup locations."""
+
+        data = await upload.read()
+        if not data:
+            raise ValueError("Uploaded file contained no data")
+
+        relative_path = self._build_relative_path(
+            user_id=user_id,
+            capture_date=capture_date,
+            original_filename=upload.filename or "photo.jpg",
+        )
+
+        primary_full_path = self.primary_path / relative_path
+        await self._write_bytes(primary_full_path, data)
+
+        backup_paths: list[Path] = []
+        for backup_root in self.backup_paths:
+            backup_full_path = backup_root / relative_path
+            try:
+                await self._write_bytes(backup_full_path, data)
+            except OSError:
+                logger.exception("Failed to write backup copy to %s", backup_full_path)
+            else:
+                backup_paths.append(backup_full_path)
+
+        return StoredPhotoPaths(primary=primary_full_path, backups=backup_paths)
+
+    async def _write_bytes(self, destination: Path, data: bytes) -> None:
+        """Write bytes to disk using a thread to avoid blocking the event loop."""
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(destination.write_bytes, data)
+        logger.info("Stored photo copy at %s", destination)
+
+
+def get_photo_storage_service() -> PhotoStorageService:
+    """Factory that creates a storage service using application settings."""
+
+    primary = Path(settings.photo_primary_storage_path).expanduser()
+    backups = [Path(path).expanduser() for path in settings.photo_backup_paths]
+    return PhotoStorageService(primary_path=primary, backup_paths=backups)
+
+
+__all__ = ["PhotoStorageService", "StoredPhotoPaths", "get_photo_storage_service"]


### PR DESCRIPTION
## Summary
- add a storage service that saves uploaded photos to the home server and configurable backup locations
- extend application settings with primary and backup photo storage paths that default to the requested home/aunt/tucson layout
- document the new environment variables and storage override instructions in the backend README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913653e65b08327963a30a154535c6d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated configuration documentation with new photo storage settings and environment variable guidance.

* **New Features**
  * Added configurable photo storage with support for primary and multiple backup storage locations via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->