### PR TITLE
Update WireGuard network configuration in runbook

### DIFF
--- a/projects/06-homelab/PRJ-HOME-001/assets/runbooks/network-deployment-runbook.md
+++ b/projects/06-homelab/PRJ-HOME-001/assets/runbooks/network-deployment-runbook.md
@@ -277,7 +277,8 @@ nslookup google.com 192.168.10.2
 ### Step 9.1: Enable WireGuard
 - Settings → VPN → WireGuard → Enable
 - Listen Port: 51820
-- Network: 192.168.10.0/24
+- Network: 10.10.10.0/24 (dedicated VPN subnet)
+- Routes: Add 192.168.10.0/24 so VPN clients can reach the trusted VLAN
 
 ### Step 9.2: Create VPN User
 1. Add user account
@@ -287,7 +288,7 @@ nslookup google.com 192.168.10.2
 ### Step 9.3: Test VPN
 ```bash
 # From external network with VPN connected
-ping 192.168.10.1    # Should work
+ping 192.168.10.1    # Should work (routed via WireGuard 10.10.10.0/24 tunnel)
 ```
 
 ## 10. Verification and Testing (Day 5)


### PR DESCRIPTION
## Summary
- switch the WireGuard VPN network to a dedicated 10.10.10.0/24 subnet in the deployment runbook
- document routing the trusted VLAN (192.168.10.0/24) through the VPN tunnel and clarify connectivity testing expectations

## Testing
- not run (documentation change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138447585c832789b6ce3d543805f9)