### PR TITLE
Add AWS infra FastAPI service with IaC and tests

### DIFF
--- a/projects-new/P01-aws-infra/README.md
+++ b/projects-new/P01-aws-infra/README.md
@@ -52,14 +52,21 @@ P01-aws-infra/
 └── ci/                       # CI/CD workflows
 ```
 
+## Application Components
+
+- **FastAPI control plane** exposing `/health`, `/metrics`, `/aws/*`, and `/security/posture` endpoints.
+- **Security middleware** enforcing API keys plus modern security headers (CSP, HSTS, referrer policy).
+- **AWS SDK integrations** for S3 inventory, Secrets Manager metadata, and CloudWatch metric publishing.
+- **Observability hooks** via Prometheus metrics counters/histograms and structured JSON logging with `structlog`.
+
 ## Features
 
 - ✅ Enterprise-grade implementation
 - ✅ Comprehensive test coverage (≥80%)
 - ✅ Infrastructure as Code
 - ✅ CI/CD automation
-- ✅ Production-ready monitoring
-- ✅ Security best practices
+- ✅ Production-ready monitoring (Prometheus rules, Grafana dashboards, OpenTelemetry collector config)
+- ✅ Security best practices (API key enforcement, secrets management, Terraform guardrails)
 
 ## Requirements
 
@@ -95,17 +102,17 @@ make deploy ENV=prod
 
 ## Monitoring
 
-- **Metrics:** Prometheus metrics exposed on `:9090/metrics`
-- **Logs:** Structured JSON logging to stdout
-- **Traces:** OpenTelemetry integration
-- **Dashboards:** Grafana dashboards in `infrastructure/monitoring/`
+- **Metrics:** Prometheus scrape endpoint exposed at `/metrics` plus alert rules in `infrastructure/monitoring/prometheus-rules.yaml`
+- **Logs:** Structured JSON logging to stdout for ingestion into CloudWatch Logs or Loki
+- **Traces:** OpenTelemetry Collector configuration supplied (`infrastructure/monitoring/otel-collector-config.yaml`); application auto-instrumentation is a roadmap task
+- **Dashboards:** Ready-to-import Grafana dashboard JSON in `infrastructure/monitoring/grafana-dashboard.json`
 
 ## Security
 
-- 🔒 OWASP Top 10 compliance
-- 🔒 CIS benchmark compliance
-- 🔒 Automated security scanning
-- 🔒 Secrets management via AWS Secrets Manager
+- 🔒 API key enforcement + hardened headers for every protected endpoint
+- 🔒 Automated AWS guardrails through Terraform (encryption, public access blocks, log retention)
+- 🔒 Secrets management via AWS Secrets Manager metadata surfaced through `/secrets/{name}`
+- 🔵 OWASP Top 10 + CIS Level 2 audit evidence is tracked as a roadmap item while automated checks are implemented in CI
 
 ## Contributing
 

--- a/projects-new/P01-aws-infra/infrastructure/monitoring/grafana-dashboard.json
+++ b/projects-new/P01-aws-infra/infrastructure/monitoring/grafana-dashboard.json
@@ -1,0 +1,28 @@
+{
+  "title": "AWS Infra Automation",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Request Rate",
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(aws_infra_requests_total[1m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "AWS SDK Calls",
+      "targets": [
+        {
+          "expr": "sum by (service,operation) (rate(aws_infra_aws_calls_total[5m]))",
+          "legendFormat": "{{service}}/{{operation}}"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": []
+  }
+}

--- a/projects-new/P01-aws-infra/infrastructure/monitoring/otel-collector-config.yaml
+++ b/projects-new/P01-aws-infra/infrastructure/monitoring/otel-collector-config.yaml
@@ -1,0 +1,15 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+exporters:
+  logging:
+    loglevel: info
+  awsxray:
+    region: ${AWS_REGION}
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, awsxray]

--- a/projects-new/P01-aws-infra/infrastructure/monitoring/prometheus-rules.yaml
+++ b/projects-new/P01-aws-infra/infrastructure/monitoring/prometheus-rules.yaml
@@ -1,0 +1,25 @@
+# Prometheus alerting rules for the AWS infra application.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: aws-infra-rules
+spec:
+  groups:
+    - name: aws-infra-availability
+      rules:
+        - alert: AWSInfraHighErrorRate
+          expr: rate(aws_infra_requests_total{status!~"2.."}[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "AWS Infra API has elevated error rate"
+            description: "Investigate recent deployment or upstream AWS failures."
+        - alert: AWSInfraMissingMetrics
+          expr: absent(aws_infra_requests_total)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Prometheus lost visibility into AWS Infra API"
+            description: "Ensure scraping, networking, and service availability."

--- a/projects-new/P01-aws-infra/infrastructure/terraform/main.tf
+++ b/projects-new/P01-aws-infra/infrastructure/terraform/main.tf
@@ -20,3 +20,151 @@ provider "aws" {
     }
   }
 }
+
+locals {
+  project_slug = lower(replace(var.project_name, " ", "-"))
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "logs" {
+  description = "KMS key protecting application logs and secrets"
+  deletion_window_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/aws/aws-infra/${var.environment}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = aws_kms_key.logs.arn
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = "${local.project_slug}-${var.environment}-artifacts"
+  force_destroy = false
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.logs.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket                  = aws_s3_bucket.artifacts.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_role" "app" {
+  name = "${local.project_slug}-${var.environment}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = ["lambda.amazonaws.com", "ecs-tasks.amazonaws.com"]
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_policy" "app" {
+  name        = "${local.project_slug}-${var.environment}-policy"
+  description = "Least-privilege policy for AWS infra automation"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = ["secretsmanager:DescribeSecret"],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = ["cloudwatch:PutMetricData"],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "app" {
+  role       = aws_iam_role.app.name
+  policy_arn = aws_iam_policy.app.arn
+}
+
+resource "aws_ssm_parameter" "api_key" {
+  name   = "/aws-infra/${var.environment}/api-key"
+  type   = "SecureString"
+  value  = var.api_key_value
+  key_id = aws_kms_key.logs.arn
+}
+
+resource "aws_cloudwatch_dashboard" "golden_signals" {
+  dashboard_name = "aws-infra-${var.environment}"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        x    = 0
+        y    = 0
+        width = 12
+        height = 6
+        properties = {
+          metrics = [
+            ["AWSInfra/Custom", "RequestLatency", "Environment", var.environment]
+          ]
+          period = 60
+          stat   = "p99"
+          title  = "API Latency"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "custom_metric_high" {
+  alarm_name          = "aws-infra-${var.environment}-custom-metric-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "CustomErrors"
+  namespace           = "AWSInfra/Custom"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_description   = "Alert when custom error metric breaches threshold"
+  treat_missing_data  = "breaching"
+}
+
+output "artifacts_bucket" {
+  description = "S3 bucket used for build artifacts"
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
+output "app_role_arn" {
+  description = "IAM role that workloads assume for AWS access"
+  value       = aws_iam_role.app.arn
+}

--- a/projects-new/P01-aws-infra/infrastructure/terraform/variables.tf
+++ b/projects-new/P01-aws-infra/infrastructure/terraform/variables.tf
@@ -15,3 +15,16 @@ variable "project_name" {
   type        = string
   default     = "AWS Infrastructure Automation"
 }
+
+variable "log_retention_days" {
+  description = "Number of days to retain application logs"
+  type        = number
+  default     = 30
+}
+
+variable "api_key_value" {
+  description = "API key stored in SSM for the FastAPI service"
+  type        = string
+  default     = "local-dev-key"
+  sensitive   = true
+}

--- a/projects-new/P01-aws-infra/requirements.txt
+++ b/projects-new/P01-aws-infra/requirements.txt
@@ -5,3 +5,4 @@ boto3==1.28.85
 psycopg2-binary==2.9.9
 redis==5.0.1
 structlog==23.2.0
+prometheus-client==0.19.0

--- a/projects-new/P01-aws-infra/src/__init__.py
+++ b/projects-new/P01-aws-infra/src/__init__.py
@@ -1,0 +1,1 @@
+"""AWS Infrastructure Automation application package."""

--- a/projects-new/P01-aws-infra/src/config.py
+++ b/projects-new/P01-aws-infra/src/config.py
@@ -15,7 +15,7 @@ class Settings(BaseModel):
     app_name: str = Field(default="AWS Infrastructure Automation")
     environment: str = Field(default="development")
     aws_region: str = Field(default="us-east-1")
-    api_keys: List[str] = Field(default_factory=lambda: ["local-dev-key"])
+    api_keys: Set[str] = Field(default_factory=lambda: {"local-dev-key"})
     metrics_namespace: str = Field(default="aws_infra")
     feature_flags: Dict[str, bool] = Field(
         default_factory=lambda: {

--- a/projects-new/P01-aws-infra/src/config.py
+++ b/projects-new/P01-aws-infra/src/config.py
@@ -1,0 +1,59 @@
+"""Application configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class Settings(BaseModel):
+    """Runtime configuration loaded from the environment."""
+
+    app_name: str = Field(default="AWS Infrastructure Automation")
+    environment: str = Field(default="development")
+    aws_region: str = Field(default="us-east-1")
+    api_keys: List[str] = Field(default_factory=lambda: ["local-dev-key"])
+    metrics_namespace: str = Field(default="aws_infra")
+    feature_flags: Dict[str, bool] = Field(
+        default_factory=lambda: {
+            "enable_telemetry": False,
+            "enforce_rate_limiting": False,
+        }
+    )
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Create settings using environment variables with sane defaults."""
+
+        api_keys_env = os.getenv("API_KEYS")
+        api_keys = [key.strip() for key in api_keys_env.split(",") if key.strip()] if api_keys_env else ["local-dev-key"]
+
+        feature_flags = {
+            "enable_telemetry": os.getenv("FEATURE_ENABLE_TELEMETRY", "false").lower() == "true",
+            "enforce_rate_limiting": os.getenv("FEATURE_ENFORCE_RATE_LIMITING", "false").lower() == "true",
+        }
+
+        return cls(
+            app_name=os.getenv("APP_NAME", "AWS Infrastructure Automation"),
+            environment=os.getenv("ENVIRONMENT", "development"),
+            aws_region=os.getenv("AWS_REGION", "us-east-1"),
+            api_keys=api_keys,
+            metrics_namespace=os.getenv("METRICS_NAMESPACE", "aws_infra"),
+            feature_flags=feature_flags,
+        )
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+
+    return Settings.from_env()
+
+
+def reset_settings_cache() -> None:
+    """Clear cached settings for tests."""
+
+    get_settings.cache_clear()

--- a/projects-new/P01-aws-infra/src/main.py
+++ b/projects-new/P01-aws-infra/src/main.py
@@ -50,7 +50,7 @@ def get_aws_service() -> AWSResourceService:
 
 
 @app.middleware("http")
-async def secure_headers_middleware(request, call_next):  # type: ignore[override]
+async def secure_headers_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     response = await call_next(request)
     for key, value in apply_security_headers({}).items():
         response.headers.setdefault(key, value)

--- a/projects-new/P01-aws-infra/src/main.py
+++ b/projects-new/P01-aws-infra/src/main.py
@@ -1,27 +1,125 @@
-"""
-Main application module.
-"""
+"""FastAPI application exposing AWS automation helpers."""
 
-from typing import Dict, Any
-import logging
+from __future__ import annotations
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+import time
+from typing import Annotated, Dict, List
+
+import structlog
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.responses import JSONResponse, PlainTextResponse
+from pydantic import BaseModel, Field
+
+from src.config import Settings, get_settings
+from src.metrics import metrics_endpoint, metrics_middleware
+from src.security import apply_security_headers, verify_api_key
+from src.services import AWSResourceService, AWSServiceError
+
+structlog.configure(processors=[structlog.processors.JSONRenderer()])
+logger = structlog.get_logger(__name__)
+
+app = FastAPI(title="AWS Infrastructure Automation API", version="1.1.0")
+app.middleware("http")(metrics_middleware)
 
 
-def health_check() -> Dict[str, Any]:
-    """
-    Health check endpoint.
-
-    Returns:
-        Dictionary with health status
-    """
-    return {
-        "status": "healthy",
-        "version": "1.0.0"
-    }
+class PublishMetricPayload(BaseModel):
+    metric_name: str = Field(..., description="Custom metric name")
+    value: float = Field(..., description="Metric value")
+    unit: str = Field(default="Count", description="Metric unit")
 
 
-if __name__ == "__main__":
-    logger.info("Application started")
-    print(health_check())
+class SecurityPosture(BaseModel):
+    owasp_top_10_controls: str
+    cis_benchmark_status: str
+    dependency_scanning: str
+    secrets_management: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    environment: str
+    timestamp: float
+
+
+ApiKeyDep = Annotated[str, Depends(verify_api_key)]
+
+
+def get_aws_service() -> AWSResourceService:
+    settings = get_settings()
+    return AWSResourceService(region=settings.aws_region)
+
+
+@app.middleware("http")
+async def secure_headers_middleware(request, call_next):  # type: ignore[override]
+    response = await call_next(request)
+    for key, value in apply_security_headers({}).items():
+        response.headers.setdefault(key, value)
+    return response
+
+
+@app.get("/health", response_model=HealthResponse)
+def health(settings: Settings = Depends(get_settings)) -> HealthResponse:
+    """Basic health endpoint used by load balancers and uptime checks."""
+
+    logger.info("health_check", environment=settings.environment)
+    return HealthResponse(status="healthy", environment=settings.environment, timestamp=time.time())
+
+
+@app.get("/aws/s3/buckets")
+def s3_buckets(
+    _: ApiKeyDep,
+    service: AWSResourceService = Depends(get_aws_service),
+) -> Dict[str, List[Dict[str, str]]]:
+    """Return S3 buckets to demonstrate AWS SDK usage."""
+
+    buckets = service.list_s3_buckets()
+    return {"buckets": buckets}
+
+
+@app.get("/security/posture", response_model=SecurityPosture)
+def security_posture(_: ApiKeyDep) -> SecurityPosture:
+    """Summarize currently implemented and roadmap security controls."""
+
+    return SecurityPosture(
+        owasp_top_10_controls="Implemented for authn/authz + input validation; remaining controls tracked in backlog.",
+        cis_benchmark_status="Guardrails automated for IAM/logging; full CIS Level 2 audit scheduled in roadmap.",
+        dependency_scanning="Automated via CI safety checks and SBOM export.",
+        secrets_management="AWS Secrets Manager metadata surfaced via /aws endpoints.",
+    )
+
+
+@app.post("/aws/metrics/publish")
+def publish_metric(
+    payload: PublishMetricPayload,
+    _: ApiKeyDep,
+    service: AWSResourceService = Depends(get_aws_service),
+):
+    """Publish a custom CloudWatch metric to validate telemetry integration."""
+
+    try:
+        return service.publish_custom_metric(payload.metric_name, payload.value, payload.unit)
+    except AWSServiceError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+
+@app.get("/metrics")
+def prometheus_metrics():
+    """Expose application metrics for Prometheus scraping."""
+
+    payload, content_type = metrics_endpoint()
+    return PlainTextResponse(content=payload.decode("utf-8"), media_type=content_type)
+
+
+@app.get("/secrets/{secret_name}")
+def secret_metadata(
+    secret_name: str,
+    _: ApiKeyDep,
+    service: AWSResourceService = Depends(get_aws_service),
+):
+    """Surface Secrets Manager metadata without revealing the secret value."""
+
+    try:
+        result = service.describe_secret(secret_name)
+        return JSONResponse(content=result)
+    except AWSServiceError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/projects-new/P01-aws-infra/src/metrics.py
+++ b/projects-new/P01-aws-infra/src/metrics.py
@@ -54,5 +54,6 @@ async def metrics_middleware(request: Request, call_next: Callable[[Request], Aw
     start_time = time.perf_counter()
     response = await call_next(request)
     elapsed = time.perf_counter() - start_time
-    record_request_metrics(request.method, request.url.path, response.status_code, elapsed)
+    route = getattr(request.scope.get("route"), "path", request.url.path)
+    record_request_metrics(request.method, route, response.status_code, elapsed)
     return response

--- a/projects-new/P01-aws-infra/src/metrics.py
+++ b/projects-new/P01-aws-infra/src/metrics.py
@@ -1,0 +1,58 @@
+"""Prometheus metrics helpers."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Awaitable
+
+from fastapi import Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+REQUEST_COUNTER = Counter(
+    "aws_infra_requests_total",
+    "Total HTTP requests processed by the AWS infra service",
+    labelnames=["method", "endpoint", "status"],
+)
+
+REQUEST_LATENCY = Histogram(
+    "aws_infra_request_latency_seconds",
+    "Latency of HTTP requests in seconds",
+    labelnames=["endpoint"],
+)
+
+AWS_CALL_COUNTER = Counter(
+    "aws_infra_aws_calls_total",
+    "Number of AWS SDK calls made by the service",
+    labelnames=["service", "operation", "status"],
+)
+
+
+def record_request_metrics(method: str, endpoint: str, status_code: int, latency_seconds: float) -> None:
+    """Increment counters for request metrics."""
+
+    REQUEST_COUNTER.labels(method=method, endpoint=endpoint, status=str(status_code)).inc()
+    REQUEST_LATENCY.labels(endpoint=endpoint).observe(latency_seconds)
+
+
+def record_aws_call(service: str, operation: str, success: bool) -> None:
+    """Track AWS SDK invocation results."""
+
+    status = "success" if success else "error"
+    AWS_CALL_COUNTER.labels(service=service, operation=operation, status=status).inc()
+
+
+def metrics_endpoint() -> tuple[bytes, str]:
+    """Return serialized metrics and content type."""
+
+    payload = generate_latest()
+    return payload, CONTENT_TYPE_LATEST
+
+
+async def metrics_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    """Collect latency metrics for every HTTP request."""
+
+    start_time = time.perf_counter()
+    response = await call_next(request)
+    elapsed = time.perf_counter() - start_time
+    record_request_metrics(request.method, request.url.path, response.status_code, elapsed)
+    return response

--- a/projects-new/P01-aws-infra/src/security.py
+++ b/projects-new/P01-aws-infra/src/security.py
@@ -1,0 +1,39 @@
+"""Security helpers and dependencies."""
+
+from fastapi import Header, HTTPException, status
+
+from src.config import get_settings
+
+
+def verify_api_key(x_api_key: str | None = Header(default=None, alias="x-api-key")) -> str:
+    """Validate API keys provided with each request."""
+
+    settings = get_settings()
+    if x_api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key.",
+            headers={"WWW-Authenticate": "API-Key"},
+        )
+    if x_api_key not in settings.api_keys:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key provided.",
+            headers={"WWW-Authenticate": "API-Key"},
+        )
+    return x_api_key
+
+
+def apply_security_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Return hardened HTTP response headers."""
+
+    hardened = {
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "no-referrer",
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+        "Content-Security-Policy": "default-src 'none'",
+    }
+    hardened.update(headers)
+    return hardened

--- a/projects-new/P01-aws-infra/src/services.py
+++ b/projects-new/P01-aws-infra/src/services.py
@@ -31,7 +31,7 @@ class AWSResourceService:
         self.secrets_client = secrets_client or boto3.client("secretsmanager", region_name=region)
         self.cloudwatch_client = cloudwatch_client or boto3.client("cloudwatch", region_name=region)
 
-    def list_s3_buckets(self) -> List[Dict[str, str]]:
+    def list_s3_buckets(self) -> List[Dict[str, Optional[str]]]:
         """Return metadata for all accessible S3 buckets."""
 
         try:

--- a/projects-new/P01-aws-infra/src/services.py
+++ b/projects-new/P01-aws-infra/src/services.py
@@ -1,0 +1,93 @@
+"""AWS service integrations."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from src.metrics import record_aws_call
+
+
+class AWSServiceError(RuntimeError):
+    """Raised when AWS SDK requests fail."""
+
+
+class AWSResourceService:
+    """Wrapper around boto3 clients to keep business logic testable."""
+
+    def __init__(
+        self,
+        *,
+        region: str,
+        s3_client: Optional[Any] = None,
+        secrets_client: Optional[Any] = None,
+        cloudwatch_client: Optional[Any] = None,
+    ) -> None:
+        self.region = region
+        self.s3_client = s3_client or boto3.client("s3", region_name=region)
+        self.secrets_client = secrets_client or boto3.client("secretsmanager", region_name=region)
+        self.cloudwatch_client = cloudwatch_client or boto3.client("cloudwatch", region_name=region)
+
+    def list_s3_buckets(self) -> List[Dict[str, str]]:
+        """Return metadata for all accessible S3 buckets."""
+
+        try:
+            response = self.s3_client.list_buckets()
+            record_aws_call("s3", "list_buckets", True)
+        except (ClientError, BotoCoreError) as exc:  # pragma: no cover - defensive
+            record_aws_call("s3", "list_buckets", False)
+            raise AWSServiceError("Unable to list S3 buckets") from exc
+
+        buckets = []
+        for bucket in response.get("Buckets", []):
+            creation = bucket.get("CreationDate")
+            creation_iso = creation.isoformat() if isinstance(creation, dt.datetime) else None
+            buckets.append({
+                "name": bucket.get("Name", "unknown"),
+                "creation_date": creation_iso,
+            })
+        return buckets
+
+    def describe_secret(self, secret_id: str) -> Dict[str, Any]:
+        """Return metadata for a secret without exposing the value."""
+
+        try:
+            response = self.secrets_client.describe_secret(SecretId=secret_id)
+            record_aws_call("secretsmanager", "describe_secret", True)
+        except (ClientError, BotoCoreError) as exc:  # pragma: no cover - defensive
+            record_aws_call("secretsmanager", "describe_secret", False)
+            raise AWSServiceError("Unable to describe secret") from exc
+
+        return {
+            "name": response.get("Name"),
+            "rotation_enabled": response.get("RotationEnabled", False),
+            "tags": response.get("Tags", []),
+            "last_rotated": response.get("LastRotatedDate").isoformat()
+            if isinstance(response.get("LastRotatedDate"), dt.datetime)
+            else None,
+        }
+
+    def publish_custom_metric(self, metric_name: str, value: float, unit: str = "Count") -> Dict[str, Any]:
+        """Send a single metric data point to CloudWatch."""
+
+        try:
+            response = self.cloudwatch_client.put_metric_data(
+                Namespace="AWSInfra/Custom",
+                MetricData=[
+                    {
+                        "MetricName": metric_name,
+                        "Timestamp": dt.datetime.utcnow(),
+                        "Value": value,
+                        "Unit": unit,
+                    }
+                ],
+            )
+            record_aws_call("cloudwatch", "put_metric_data", True)
+        except (ClientError, BotoCoreError) as exc:  # pragma: no cover - defensive
+            record_aws_call("cloudwatch", "put_metric_data", False)
+            raise AWSServiceError("Unable to publish CloudWatch metric") from exc
+
+        return {"metric_name": metric_name, "value": value, "unit": unit, "response_metadata": response.get("ResponseMetadata", {})}

--- a/projects-new/P01-aws-infra/tests/conftest.py
+++ b/projects-new/P01-aws-infra/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Shared pytest fixtures for the AWS infra project."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.config import reset_settings_cache
+
+
+class FakeAWSService:
+    """Test double that mimics the AWSResourceService behavior."""
+
+    def list_s3_buckets(self):
+        return [{"name": "demo", "creation_date": "2024-01-01T00:00:00"}]
+
+    def publish_custom_metric(self, metric_name: str, value: float, unit: str):
+        return {"metric_name": metric_name, "value": value, "unit": unit}
+
+    def describe_secret(self, secret_id: str):
+        return {"name": secret_id, "rotation_enabled": True, "tags": [], "last_rotated": None}
+
+
+@pytest.fixture(autouse=True)
+def configure_env(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "test-key")
+    reset_settings_cache()
+    yield
+    reset_settings_cache()
+
+
+@pytest.fixture()
+def fake_service():
+    return FakeAWSService()

--- a/projects-new/P01-aws-infra/tests/integration/test_api.py
+++ b/projects-new/P01-aws-infra/tests/integration/test_api.py
@@ -1,0 +1,43 @@
+"""Integration-style tests that exercise route handlers with fake services."""
+
+from src.config import get_settings, reset_settings_cache
+from src.main import (
+    PublishMetricPayload,
+    health,
+    prometheus_metrics,
+    publish_metric,
+    s3_buckets,
+    secret_metadata,
+)
+
+
+def test_health_endpoint(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "qa")
+    reset_settings_cache()
+    settings = get_settings()
+    response = health(settings=settings)
+    assert response.status == "healthy"
+    assert response.environment == "qa"
+
+
+def test_s3_buckets_handler(fake_service):
+    payload = s3_buckets("test-key", fake_service)
+    assert payload["buckets"][0]["name"] == "demo"
+
+
+def test_metrics_endpoint(fake_service):  # fake_service unused but keeps fixture order
+    response = prometheus_metrics()
+    assert response.status_code == 200
+    assert "aws_infra_requests_total" in response.body.decode()
+
+
+def test_secret_metadata_endpoint(fake_service):
+    result = secret_metadata("my-secret", "test-key", fake_service)
+    assert result.body
+    assert "my-secret" in result.body.decode()
+
+
+def test_publish_metric(fake_service):
+    payload = PublishMetricPayload(metric_name="Latency", value=123.0, unit="Milliseconds")
+    result = publish_metric(payload, "test-key", fake_service)
+    assert result["metric_name"] == "Latency"

--- a/projects-new/P01-aws-infra/tests/integration/test_api.py
+++ b/projects-new/P01-aws-infra/tests/integration/test_api.py
@@ -33,8 +33,9 @@ def test_metrics_endpoint(fake_service):  # fake_service unused but keeps fixtur
 
 def test_secret_metadata_endpoint(fake_service):
     result = secret_metadata("my-secret", "test-key", fake_service)
-    assert result.body
-    assert "my-secret" in result.body.decode()
+    assert result.status_code == 200
+    payload = json.loads(result.body)
+    assert payload["name"] == "my-secret"
 
 
 def test_publish_metric(fake_service):

--- a/projects-new/P01-aws-infra/tests/unit/test_config.py
+++ b/projects-new/P01-aws-infra/tests/unit/test_config.py
@@ -1,0 +1,19 @@
+"""Unit tests for configuration helpers."""
+
+from src.config import get_settings, reset_settings_cache
+
+
+def test_settings_loaded_from_env(monkeypatch):
+    monkeypatch.setenv("APP_NAME", "Test App")
+    monkeypatch.setenv("ENVIRONMENT", "stage")
+    monkeypatch.setenv("API_KEYS", "one,two")
+    reset_settings_cache()
+
+    settings = get_settings()
+
+    assert settings.app_name == "Test App"
+    assert settings.environment == "stage"
+    assert settings.api_keys == ["one", "two"]
+
+    # Cleanup for other tests
+    reset_settings_cache()

--- a/projects-new/P01-aws-infra/tests/unit/test_main.py
+++ b/projects-new/P01-aws-infra/tests/unit/test_main.py
@@ -1,14 +1,15 @@
-"""
-Unit tests for main module.
-"""
+"""Unit-level tests for FastAPI application utilities."""
 
-from src.main import health_check
+from src.config import get_settings, reset_settings_cache
+from src.main import HealthResponse, health
 
 
-def test_health_check():
-    """Test health check returns expected structure."""
-    result = health_check()
+def test_health_handler_uses_environment(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    reset_settings_cache()
+    settings = get_settings()
 
-    assert "status" in result
-    assert "version" in result
-    assert result["status"] == "healthy"
+    result: HealthResponse = health(settings=settings)
+
+    assert result.status == "healthy"
+    assert result.environment == "staging"

--- a/projects-new/P01-aws-infra/tests/unit/test_security.py
+++ b/projects-new/P01-aws-infra/tests/unit/test_security.py
@@ -1,0 +1,35 @@
+"""Tests for security helpers."""
+
+import pytest
+from fastapi import HTTPException
+
+from src.config import reset_settings_cache
+from src.security import apply_security_headers, verify_api_key
+
+
+@pytest.fixture(autouse=True)
+def setup_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "expected")
+    reset_settings_cache()
+    yield
+    reset_settings_cache()
+
+
+def test_verify_api_key_success():
+    assert verify_api_key(x_api_key="expected") == "expected"
+
+
+def test_verify_api_key_failure():
+    with pytest.raises(HTTPException):
+        verify_api_key(x_api_key="bad")
+
+
+def test_verify_api_key_missing_header():
+    with pytest.raises(HTTPException):
+        verify_api_key(x_api_key=None)
+
+
+def test_apply_security_headers_sets_defaults():
+    headers = apply_security_headers({})
+    assert headers["X-Frame-Options"] == "DENY"
+    assert "Strict-Transport-Security" in headers

--- a/projects-new/P01-aws-infra/tests/unit/test_services.py
+++ b/projects-new/P01-aws-infra/tests/unit/test_services.py
@@ -1,0 +1,44 @@
+"""Tests for AWSResourceService."""
+
+import datetime as dt
+
+import boto3
+from botocore.stub import Stubber
+
+from src.services import AWSResourceService
+
+
+def test_list_s3_buckets_returns_normalized():
+    client = boto3.client("s3", region_name="us-east-1")
+    stubber = Stubber(client)
+    stubber.add_response(
+        "list_buckets",
+        {
+            "Buckets": [
+                {"Name": "demo", "CreationDate": dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)}
+            ]
+        },
+    )
+
+    with stubber:
+        service = AWSResourceService(region="us-east-1", s3_client=client)
+        buckets = service.list_s3_buckets()
+
+    assert buckets == [{"name": "demo", "creation_date": "2024-01-01T00:00:00+00:00"}]
+
+
+def test_publish_metric_returns_shape():
+    client = boto3.client("cloudwatch", region_name="us-east-1")
+    stubber = Stubber(client)
+    stubber.add_response(
+        "put_metric_data",
+        {"ResponseMetadata": {"HTTPStatusCode": 200}},
+    )
+
+    with stubber:
+        service = AWSResourceService(region="us-east-1", cloudwatch_client=client)
+        response = service.publish_custom_metric("Latency", 1.0, "Milliseconds")
+
+    assert response["metric_name"] == "Latency"
+    assert response["value"] == 1.0
+    assert response["unit"] == "Milliseconds"


### PR DESCRIPTION
## Summary
- implement the FastAPI control plane with API key enforcement, Prometheus metrics, and AWS SDK integrations
- extend the Terraform stack plus monitoring configs to provision encrypted buckets, IAM roles, dashboards, and alerting assets
- refresh the project README and add unit/integration tests that cover config loading, security helpers, AWS services, and route handlers

## Testing
- pytest projects-new/P01-aws-infra/tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ff9667488327a6abf2554a418563)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production monitoring with Prometheus metrics, Grafana dashboards, and OpenTelemetry tracing
  * Added API key authentication and security headers for protected endpoints
  * Added endpoints for health checks, S3 bucket listing, security posture, metrics publishing, and secrets metadata access
  * Added infrastructure templates with encryption, access controls, and log retention policies
  * Updated documentation with monitoring and security implementation details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->