### PR TITLE
Align P01-P20 directories

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -18,6 +18,8 @@ professional/resume/                      ← Resume PDFs
 
 📖 **Detailed breakdown:** See `MISSING_DOCUMENTS_ANALYSIS.md`
 
+> 🆕 **Enterprise templates (P01–P20)** are located in `projects-new/`. See [`projects-new/QUICK_START_GUIDE.md`](./projects-new/QUICK_START_GUIDE.md) for a deep dive, or jump directly with `cd projects-new/P01-aws-infra`.
+
 ---
 
 ## 🚀 Three Methods (Pick One)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 > **Note:** Some project directories referenced below contain planning documentation and structure but are awaiting evidence/asset uploads. Check individual project READMEs for current status.
 
+> **Directory update:** Enterprise project templates P01–P20 now live exclusively under `./projects-new/`. The `./projects/1-*` directories remain for archival reference only.
+
 > 📚 **New:** [Missing Documents Analysis](./MISSING_DOCUMENTS_ANALYSIS.md) | [Quick Start Guide](./QUICK_START_GUIDE.md) | [Completion Checklist](./PROJECT_COMPLETION_CHECKLIST.md)
 
 ---
@@ -35,26 +37,28 @@ System-minded engineer specializing in building, securing, and operating infrast
 
 ## 📦 Portfolio Blueprints
 
-- [Project 1: AWS Infrastructure Automation](./projects/1-aws-infrastructure-automation) — Multi-tool infrastructure-as-code implementation covering Terraform, AWS CDK, and Pulumi with reusable deploy scripts.
-- [Project 2: Database Migration Platform](./projects/2-database-migration) — Change data capture pipelines and automation for zero-downtime migrations.
-- [Project 3: Kubernetes CI/CD Pipeline](./projects/3-kubernetes-cicd) — GitOps, progressive delivery, and environment promotion policies.
-- [Project 4: DevSecOps Pipeline](./projects/4-devsecops) — Security scanning, SBOM publishing, and policy-as-code enforcement.
-- [Project 5: Real-time Data Streaming](./projects/5-real-time-data-streaming) — Kafka, Flink, and schema registry patterns for resilient stream processing.
-- [Project 6: Machine Learning Pipeline](./projects/6-mlops-platform) — End-to-end MLOps workflows with experiment tracking and automated promotion.
-- [Project 7: Serverless Data Processing](./projects/7-serverless-data-processing) — Event-driven analytics built on AWS Lambda, Step Functions, and DynamoDB.
-- [Project 8: Advanced AI Chatbot](./projects/8-advanced-ai-chatbot) — Retrieval-augmented assistant with vector search, tool execution, and streaming responses.
-- [Project 9: Multi-Region Disaster Recovery](./projects/9-multi-region-disaster-recovery) — Automated failover, replication validation, and DR runbooks.
-- [Project 10: Blockchain Smart Contract Platform](./projects/10-blockchain-smart-contract-platform) — Hardhat-based DeFi stack with staking contracts and security tooling.
-- [Project 11: IoT Data Ingestion & Analytics](./projects/11-iot-data-analytics) — Edge telemetry simulation, ingestion, and real-time dashboards.
-- [Project 12: Quantum Computing Integration](./projects/12-quantum-computing) — Hybrid quantum/classical optimization workflows using Qiskit.
-- [Project 13: Advanced Cybersecurity Platform](./projects/13-advanced-cybersecurity) — SOAR engine with enrichment adapters and automated response playbooks.
-- [Project 14: Edge AI Inference Platform](./projects/14-edge-ai-inference) — ONNX Runtime service optimized for Jetson-class devices.
-- [Project 15: Real-time Collaborative Platform](./projects/15-real-time-collaboration) — Operational transform collaboration server with CRDT reconciliation.
-- [Project 16: Advanced Data Lake & Analytics](./projects/16-advanced-data-lake) — Medallion architecture transformations and Delta Lake patterns.
-- [Project 17: Multi-Cloud Service Mesh](./projects/17-multi-cloud-service-mesh) — Istio multi-cluster configuration with mTLS and network overlays.
-- [Project 18: GPU-Accelerated Computing](./projects/18-gpu-accelerated-computing) — CuPy-powered Monte Carlo simulations and GPU workload orchestration.
-- [Project 19: Advanced Kubernetes Operators](./projects/19-advanced-kubernetes-operators) — Kopf-based operator managing portfolio stack lifecycles.
-- [Project 20: Blockchain Oracle Service](./projects/20-blockchain-oracle-service) — Chainlink adapter and consumer contracts for on-chain metrics.
+> **Canonical directory:** Enterprise templates P01–P20 live in `./projects-new/`. The historical `./projects/1-*` hierarchy is now legacy/archival only.
+
+- [Project P01: AWS Infrastructure Automation](./projects-new/P01-aws-infra) — Terraform-first landing zone with automated networking, compute, and IAM baselines.
+- [Project P02: Kubernetes Cluster Management](./projects-new/P02-k8s-cluster) — EKS cluster automation, scaling policies, and RBAC templates.
+- [Project P03: CI/CD Pipeline Implementation](./projects-new/P03-cicd-pipeline) — Multi-stage GitHub Actions workflows with policy gates and automated rollbacks.
+- [Project P04: Operational Monitoring Stack](./projects-new/P04-monitoring-stack) — Prometheus/Grafana stack with alerting-as-code and golden-signal dashboards.
+- [Project P05: Database Performance Optimization](./projects-new/P05-db-optimization) — Query analysis tooling, connection tuning, and reproducible benchmarks.
+- [Project P06: Web Application Testing Framework](./projects-new/P06-web-testing) — Playwright + pytest harness for API/UI regression, visual, and smoke suites.
+- [Project P07: Security Compliance Automation](./projects-new/P07-security-compliance) — CIS + OWASP scanning profiles with automated evidence capture.
+- [Project P08: Cost Optimization Tooling](./projects-new/P08-cost-optimization) — AWS cost explorer integration, idle resource sweeps, and budget alerting.
+- [Project P09: Disaster Recovery Orchestration](./projects-new/P09-dr-orchestration) — Automated DR drills, failover orchestration, and RTO/RPO scoring.
+- [Project P10: Log Aggregation System](./projects-new/P10-log-aggregation) — ELK-based aggregation with retention policies and Kibana dashboards.
+- [Project P11: API Gateway Configuration](./projects-new/P11-api-gateway) — Rate-limited, authenticated API Gateway patterns with Terraform modules.
+- [Project P12: Container Registry Management](./projects-new/P12-container-registry) — ECR lifecycle automation with image scanning and replication.
+- [Project P13: Secrets Management System](./projects-new/P13-secrets-management) — AWS Secrets Manager automation with rotation and audit hooks.
+- [Project P14: Network Configuration Automation](./projects-new/P14-network-automation) — Infrastructure-as-code for routing, ACLs, and VLAN orchestration.
+- [Project P15: Incident Response Automation](./projects-new/P15-incident-response) — Playbook-driven automation for triage, enrichment, and chat-ops notifications.
+- [Project P16: Backup Verification System](./projects-new/P16-backup-verification) — Scheduled restore validations with integrity checks and compliance evidence.
+- [Project P17: Performance Load Testing](./projects-new/P17-load-testing) — k6-based load suite with scenario templates and automated reports.
+- [Project P18: Service Mesh Implementation](./projects-new/P18-service-mesh) — Istio multi-cluster mesh with mTLS policies and traffic shifting recipes.
+- [Project P19: Observability Dashboard](./projects-new/P19-observability-dashboard) — Unified metrics/logs/traces dashboards with OpenTelemetry pipelines.
+- [Project P20: Multi-Cloud Orchestration](./projects-new/P20-multi-cloud) — Cross-cloud workflow automation with Terraform, GitHub Actions, and guardrails.
 - [Project 21: Quantum-Safe Cryptography](./projects/21-quantum-safe-cryptography) — Hybrid Kyber + ECDH key exchange prototype.
 - [Project 22: Autonomous DevOps Platform](./projects/22-autonomous-devops-platform) — Event-driven remediation workflows and runbooks-as-code.
 - [Project 23: Advanced Monitoring & Observability](./projects/23-advanced-monitoring) — Grafana dashboards, alerting rules, and distributed tracing config.

--- a/projects-new/QUICK_START_GUIDE.md
+++ b/projects-new/QUICK_START_GUIDE.md
@@ -197,7 +197,7 @@ make deploy ENV=prod
 ### Infrastructure & Platform (P01-P03)
 
 #### P01: AWS Infrastructure Automation
-**Directory:** `P01-aws-infra`
+**Directory:** `projects-new/P01-aws-infra`
 
 Automates AWS infrastructure provisioning with Terraform.
 
@@ -209,7 +209,7 @@ Automates AWS infrastructure provisioning with Terraform.
 
 **Quick Start:**
 ```bash
-cd P01-aws-infra
+cd projects-new/P01-aws-infra
 make install
 cp .env.example .env
 cd infrastructure/terraform
@@ -222,7 +222,7 @@ terraform plan
 ---
 
 #### P02: Kubernetes Cluster Management
-**Directory:** `P02-k8s-cluster`
+**Directory:** `projects-new/P02-k8s-cluster`
 
 Manages Kubernetes clusters with automated deployment and scaling.
 
@@ -234,7 +234,7 @@ Manages Kubernetes clusters with automated deployment and scaling.
 
 **Quick Start:**
 ```bash
-cd P02-k8s-cluster
+cd projects-new/P02-k8s-cluster
 make install
 kubectl cluster-info
 kubectl get nodes
@@ -245,7 +245,7 @@ kubectl get nodes
 ---
 
 #### P03: CI/CD Pipeline Implementation
-**Directory:** `P03-cicd-pipeline`
+**Directory:** `projects-new/P03-cicd-pipeline`
 
 Complete CI/CD pipeline with automated testing and deployment.
 
@@ -257,7 +257,7 @@ Complete CI/CD pipeline with automated testing and deployment.
 
 **Quick Start:**
 ```bash
-cd P03-cicd-pipeline
+cd projects-new/P03-cicd-pipeline
 cat ci/ci-cd.yml
 # Push to trigger pipeline
 git push origin main
@@ -270,7 +270,7 @@ git push origin main
 ### Monitoring & Observability (P04, P10, P19)
 
 #### P04: Operational Monitoring Stack
-**Directory:** `P04-monitoring-stack`
+**Directory:** `projects-new/P04-monitoring-stack`
 
 Prometheus and Grafana monitoring stack.
 
@@ -282,7 +282,7 @@ Prometheus and Grafana monitoring stack.
 
 **Quick Start:**
 ```bash
-cd P04-monitoring-stack
+cd projects-new/P04-monitoring-stack
 docker-compose up -d
 # Access Grafana at http://localhost:3000
 ```
@@ -292,7 +292,7 @@ docker-compose up -d
 ---
 
 #### P10: Log Aggregation System
-**Directory:** `P10-log-aggregation`
+**Directory:** `projects-new/P10-log-aggregation`
 
 Centralized log aggregation with ELK stack.
 
@@ -304,7 +304,7 @@ Centralized log aggregation with ELK stack.
 
 **Quick Start:**
 ```bash
-cd P10-log-aggregation
+cd projects-new/P10-log-aggregation
 docker-compose up -d elasticsearch kibana
 # Access Kibana at http://localhost:5601
 ```
@@ -312,7 +312,7 @@ docker-compose up -d elasticsearch kibana
 ---
 
 #### P19: Observability Dashboard
-**Directory:** `P19-observability-dashboard`
+**Directory:** `projects-new/P19-observability-dashboard`
 
 Unified observability dashboard combining metrics, logs, and traces.
 
@@ -324,7 +324,7 @@ Unified observability dashboard combining metrics, logs, and traces.
 
 **Quick Start:**
 ```bash
-cd P19-observability-dashboard
+cd projects-new/P19-observability-dashboard
 make install
 make deploy ENV=dev
 ```
@@ -334,7 +334,7 @@ make deploy ENV=dev
 ### Database & Performance (P05, P17)
 
 #### P05: Database Performance Optimization
-**Directory:** `P05-db-optimization`
+**Directory:** `projects-new/P05-db-optimization`
 
 Tools for database performance analysis and optimization.
 
@@ -346,7 +346,7 @@ Tools for database performance analysis and optimization.
 
 **Quick Start:**
 ```bash
-cd P05-db-optimization
+cd projects-new/P05-db-optimization
 source venv/bin/activate
 python src/main.py --analyze --database mydb
 ```
@@ -354,7 +354,7 @@ python src/main.py --analyze --database mydb
 ---
 
 #### P17: Performance Load Testing
-**Directory:** `P17-load-testing`
+**Directory:** `projects-new/P17-load-testing`
 
 Load testing framework with k6 and custom scripts.
 
@@ -366,7 +366,7 @@ Load testing framework with k6 and custom scripts.
 
 **Quick Start:**
 ```bash
-cd P17-load-testing
+cd projects-new/P17-load-testing
 k6 run tests/performance/load_test.js
 ```
 
@@ -375,7 +375,7 @@ k6 run tests/performance/load_test.js
 ### Testing & Quality (P06)
 
 #### P06: Web Application Testing Framework
-**Directory:** `P06-web-testing`
+**Directory:** `projects-new/P06-web-testing`
 
 Comprehensive web testing with Playwright and pytest.
 
@@ -387,7 +387,7 @@ Comprehensive web testing with Playwright and pytest.
 
 **Quick Start:**
 ```bash
-cd P06-web-testing
+cd projects-new/P06-web-testing
 make install
 playwright install
 pytest tests/e2e -v
@@ -398,7 +398,7 @@ pytest tests/e2e -v
 ### Security & Compliance (P07, P13)
 
 #### P07: Security Compliance Automation
-**Directory:** `P07-security-compliance`
+**Directory:** `projects-new/P07-security-compliance`
 
 Automated security compliance checks.
 
@@ -410,14 +410,14 @@ Automated security compliance checks.
 
 **Quick Start:**
 ```bash
-cd P07-security-compliance
+cd projects-new/P07-security-compliance
 python src/main.py --scan --profile cis-aws
 ```
 
 ---
 
 #### P13: Secrets Management System
-**Directory:** `P13-secrets-management`
+**Directory:** `projects-new/P13-secrets-management`
 
 Secure secrets management with AWS Secrets Manager.
 
@@ -429,7 +429,7 @@ Secure secrets management with AWS Secrets Manager.
 
 **Quick Start:**
 ```bash
-cd P13-secrets-management
+cd projects-new/P13-secrets-management
 make install
 python src/main.py --list-secrets
 ```
@@ -439,7 +439,7 @@ python src/main.py --list-secrets
 ### Cost & Resource Optimization (P08)
 
 #### P08: Cost Optimization Tooling
-**Directory:** `P08-cost-optimization`
+**Directory:** `projects-new/P08-cost-optimization`
 
 AWS cost analysis and optimization recommendations.
 
@@ -451,7 +451,7 @@ AWS cost analysis and optimization recommendations.
 
 **Quick Start:**
 ```bash
-cd P08-cost-optimization
+cd projects-new/P08-cost-optimization
 python src/main.py --analyze --days 30
 ```
 
@@ -460,7 +460,7 @@ python src/main.py --analyze --days 30
 ### Disaster Recovery (P09, P16)
 
 #### P09: Disaster Recovery Orchestration
-**Directory:** `P09-dr-orchestration`
+**Directory:** `projects-new/P09-dr-orchestration`
 
 Automated disaster recovery workflows.
 
@@ -472,14 +472,14 @@ Automated disaster recovery workflows.
 
 **Quick Start:**
 ```bash
-cd P09-dr-orchestration
+cd projects-new/P09-dr-orchestration
 python src/main.py --run-drill
 ```
 
 ---
 
 #### P16: Backup Verification System
-**Directory:** `P16-backup-verification`
+**Directory:** `projects-new/P16-backup-verification`
 
 Automated backup testing and verification.
 
@@ -491,7 +491,7 @@ Automated backup testing and verification.
 
 **Quick Start:**
 ```bash
-cd P16-backup-verification
+cd projects-new/P16-backup-verification
 ./scripts/verify_backups.sh
 ```
 
@@ -500,13 +500,13 @@ cd P16-backup-verification
 ### Networking & Infrastructure (P11, P12, P14, P18)
 
 #### P11: API Gateway Configuration
-**Directory:** `P11-api-gateway`
+**Directory:** `projects-new/P11-api-gateway`
 
 API Gateway setup with rate limiting and authentication.
 
 **Quick Start:**
 ```bash
-cd P11-api-gateway
+cd projects-new/P11-api-gateway
 terraform -chdir=infrastructure/terraform init
 terraform -chdir=infrastructure/terraform apply
 ```
@@ -514,13 +514,13 @@ terraform -chdir=infrastructure/terraform apply
 ---
 
 #### P12: Container Registry Management
-**Directory:** `P12-container-registry`
+**Directory:** `projects-new/P12-container-registry`
 
 ECR registry management with image scanning.
 
 **Quick Start:**
 ```bash
-cd P12-container-registry
+cd projects-new/P12-container-registry
 make build
 make push
 ```
@@ -528,26 +528,26 @@ make push
 ---
 
 #### P14: Network Configuration Automation
-**Directory:** `P14-network-automation`
+**Directory:** `projects-new/P14-network-automation`
 
 Network infrastructure automation.
 
 **Quick Start:**
 ```bash
-cd P14-network-automation
+cd projects-new/P14-network-automation
 terraform -chdir=infrastructure/terraform plan
 ```
 
 ---
 
 #### P18: Service Mesh Implementation
-**Directory:** `P18-service-mesh`
+**Directory:** `projects-new/P18-service-mesh`
 
 Istio service mesh deployment and configuration.
 
 **Quick Start:**
 ```bash
-cd P18-service-mesh
+cd projects-new/P18-service-mesh
 kubectl apply -f infrastructure/k8s/
 ```
 
@@ -556,7 +556,7 @@ kubectl apply -f infrastructure/k8s/
 ### Incident Response (P15)
 
 #### P15: Incident Response Automation
-**Directory:** `P15-incident-response`
+**Directory:** `projects-new/P15-incident-response`
 
 Automated incident detection and response.
 
@@ -568,7 +568,7 @@ Automated incident detection and response.
 
 **Quick Start:**
 ```bash
-cd P15-incident-response
+cd projects-new/P15-incident-response
 python src/main.py --monitor
 ```
 
@@ -577,7 +577,7 @@ python src/main.py --monitor
 ### Multi-Cloud (P20)
 
 #### P20: Multi-Cloud Orchestration
-**Directory:** `P20-multi-cloud`
+**Directory:** `projects-new/P20-multi-cloud`
 
 Multi-cloud resource orchestration across AWS, Azure, GCP.
 
@@ -589,7 +589,7 @@ Multi-cloud resource orchestration across AWS, Azure, GCP.
 
 **Quick Start:**
 ```bash
-cd P20-multi-cloud
+cd projects-new/P20-multi-cloud
 make install
 python src/main.py --list-resources
 ```

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,8 @@
+# Legacy Projects Directory
+
+This directory now primarily houses historical workstreams (homelab rebuilds, commercial recoveries, etc.) that pre-date the standardized enterprise portfolio.
+
+- **Active enterprise templates (P01–P20)** now live in `../projects-new/`. Use the quick start guide at `../projects-new/QUICK_START_GUIDE.md` for navigation and automation scripts.
+- **Legacy assets** under `01-*`, `06-*`, etc. remain for reference while missing evidence is backfilled. Follow the root `QUICK_START_GUIDE.md` for instructions on populating those paths.
+
+> ⚠️ The former `./projects/1-*` directories are deprecated. Do not add new material there—redirect contributions to the matching `./projects-new/PXX-*` folder instead.


### PR DESCRIPTION
## Summary
- declare `projects-new/` as the canonical home for P01–P20 and refresh the README + legacy notice accordingly
- update both quick start guides so all navigation examples and hyperlinks point at the same `projects-new/PXX-*` paths
- add a README inside `projects/` to formally deprecate the former `projects/1-*` hierarchy

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ff97a3348327b94fe359e9dd2e6c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Relocated Enterprise templates (P01–P20) to a new directory with updated quick-start guides and navigation paths.
  * Reorganized project catalog to distinguish current canonical templates from legacy references.
  * Updated all documentation paths and sample commands to reflect the new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->