### PR TITLE
Set projects-new as canonical home for P01–P20

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -18,6 +18,13 @@ professional/resume/                      ← Resume PDFs
 
 📖 **Detailed breakdown:** See `MISSING_DOCUMENTS_ANALYSIS.md`
 
+### Enterprise Blueprints (P01–P20)
+
+- Canonical directory: `projects-new/`
+- Example path: `projects-new/P01-aws-infra/`
+- Navigation command: `cd projects-new/P01-aws-infra`
+- Reference playbook: [Enterprise Project Quick Start](./projects-new/QUICK_START_GUIDE.md)
+
 ---
 
 ## 🚀 Three Methods (Pick One)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > **Note:** Some project directories referenced below contain planning documentation and structure but are awaiting evidence/asset uploads. Check individual project READMEs for current status.
 
-> 📚 **New:** [Missing Documents Analysis](./MISSING_DOCUMENTS_ANALYSIS.md) | [Quick Start Guide](./QUICK_START_GUIDE.md) | [Completion Checklist](./PROJECT_COMPLETION_CHECKLIST.md)
+> 📚 **New:** [Missing Documents Analysis](./MISSING_DOCUMENTS_ANALYSIS.md) | [Quick Start Guide](./QUICK_START_GUIDE.md) | [Completion Checklist](./PROJECT_COMPLETION_CHECKLIST.md) | [Enterprise Project Quick Start](./projects-new/QUICK_START_GUIDE.md)
 
 ---
 ## 🎯 Summary
@@ -35,26 +35,28 @@ System-minded engineer specializing in building, securing, and operating infrast
 
 ## 📦 Portfolio Blueprints
 
-- [Project 1: AWS Infrastructure Automation](./projects/1-aws-infrastructure-automation) — Multi-tool infrastructure-as-code implementation covering Terraform, AWS CDK, and Pulumi with reusable deploy scripts.
-- [Project 2: Database Migration Platform](./projects/2-database-migration) — Change data capture pipelines and automation for zero-downtime migrations.
-- [Project 3: Kubernetes CI/CD Pipeline](./projects/3-kubernetes-cicd) — GitOps, progressive delivery, and environment promotion policies.
-- [Project 4: DevSecOps Pipeline](./projects/4-devsecops) — Security scanning, SBOM publishing, and policy-as-code enforcement.
-- [Project 5: Real-time Data Streaming](./projects/5-real-time-data-streaming) — Kafka, Flink, and schema registry patterns for resilient stream processing.
-- [Project 6: Machine Learning Pipeline](./projects/6-mlops-platform) — End-to-end MLOps workflows with experiment tracking and automated promotion.
-- [Project 7: Serverless Data Processing](./projects/7-serverless-data-processing) — Event-driven analytics built on AWS Lambda, Step Functions, and DynamoDB.
-- [Project 8: Advanced AI Chatbot](./projects/8-advanced-ai-chatbot) — Retrieval-augmented assistant with vector search, tool execution, and streaming responses.
-- [Project 9: Multi-Region Disaster Recovery](./projects/9-multi-region-disaster-recovery) — Automated failover, replication validation, and DR runbooks.
-- [Project 10: Blockchain Smart Contract Platform](./projects/10-blockchain-smart-contract-platform) — Hardhat-based DeFi stack with staking contracts and security tooling.
-- [Project 11: IoT Data Ingestion & Analytics](./projects/11-iot-data-analytics) — Edge telemetry simulation, ingestion, and real-time dashboards.
-- [Project 12: Quantum Computing Integration](./projects/12-quantum-computing) — Hybrid quantum/classical optimization workflows using Qiskit.
-- [Project 13: Advanced Cybersecurity Platform](./projects/13-advanced-cybersecurity) — SOAR engine with enrichment adapters and automated response playbooks.
-- [Project 14: Edge AI Inference Platform](./projects/14-edge-ai-inference) — ONNX Runtime service optimized for Jetson-class devices.
-- [Project 15: Real-time Collaborative Platform](./projects/15-real-time-collaboration) — Operational transform collaboration server with CRDT reconciliation.
-- [Project 16: Advanced Data Lake & Analytics](./projects/16-advanced-data-lake) — Medallion architecture transformations and Delta Lake patterns.
-- [Project 17: Multi-Cloud Service Mesh](./projects/17-multi-cloud-service-mesh) — Istio multi-cluster configuration with mTLS and network overlays.
-- [Project 18: GPU-Accelerated Computing](./projects/18-gpu-accelerated-computing) — CuPy-powered Monte Carlo simulations and GPU workload orchestration.
-- [Project 19: Advanced Kubernetes Operators](./projects/19-advanced-kubernetes-operators) — Kopf-based operator managing portfolio stack lifecycles.
-- [Project 20: Blockchain Oracle Service](./projects/20-blockchain-oracle-service) — Chainlink adapter and consumer contracts for on-chain metrics.
+> **Canonical directories:** Standardized enterprise projects (P01–P20) now live in `./projects-new/`. The historical `./projects/` tree continues to host homelab and commercial recovery work.
+
+- [P01: AWS Infrastructure Automation](./projects-new/P01-aws-infra) — Automates AWS networking, ECS, load balancers, and RDS provisioning with Terraform-first workflows.
+- [P02: Kubernetes Cluster Management](./projects-new/P02-k8s-cluster) — Operates EKS clusters end-to-end, including node groups, RBAC, and Helm-based workloads.
+- [P03: CI/CD Pipeline Implementation](./projects-new/P03-cicd-pipeline) — Multi-stage GitHub Actions with automated testing, deployment gates, and security scanning.
+- [P04: Operational Monitoring Stack](./projects-new/P04-monitoring-stack) — Prometheus, Grafana, and Alertmanager bundle with curated golden-signal dashboards.
+- [P05: Database Performance Optimization](./projects-new/P05-db-optimization) — Python toolkit for slow-query analysis, index tuning, and benchmarking workflows.
+- [P06: Web Application Testing Framework](./projects-new/P06-web-testing) — Playwright + pytest suite covering E2E, API, and visual regression testing.
+- [P07: Security Compliance Automation](./projects-new/P07-security-compliance) — CIS/OWASP profiling with automated evidence capture and compliance reporting.
+- [P08: Cost Optimization Tooling](./projects-new/P08-cost-optimization) — AWS Cost Explorer automation for idle-resource detection and savings recommendations.
+- [P09: Disaster Recovery Orchestration](./projects-new/P09-dr-orchestration) — DR drill automation, failover orchestration, and backup verification pipelines.
+- [P10: Log Aggregation System](./projects-new/P10-log-aggregation) — ELK stack deployment with ingestion pipelines, retention policies, and Kibana dashboards.
+- [P11: API Gateway Configuration](./projects-new/P11-api-gateway) — Terraform-driven API Gateway provisioning with authentication, rate limiting, and observability hooks.
+- [P12: Container Registry Management](./projects-new/P12-container-registry) — ECR lifecycle automation with vulnerability scanning and publish workflows.
+- [P13: Secrets Management System](./projects-new/P13-secrets-management) — Secrets rotation, RBAC, and audit logging using AWS Secrets Manager.
+- [P14: Network Configuration Automation](./projects-new/P14-network-automation) — Network baselines, routing policies, and guardrails codified in Terraform modules.
+- [P15: Incident Response Automation](./projects-new/P15-incident-response) — Automated incident detection, aggregation, remediation, and post-mortem templates.
+- [P16: Backup Verification System](./projects-new/P16-backup-verification) — Scheduled restore tests, integrity validation, and compliance-ready reporting.
+- [P17: Performance Load Testing](./projects-new/P17-load-testing) — k6-powered HTTP/WebSocket load harness with performance analytics.
+- [P18: Service Mesh Implementation](./projects-new/P18-service-mesh) — Istio deployment patterns for secure service-to-service traffic management.
+- [P19: Observability Dashboard](./projects-new/P19-observability-dashboard) — Unified metrics/logs/traces dashboards via OpenTelemetry.
+- [P20: Multi-Cloud Orchestration](./projects-new/P20-multi-cloud) — Cloud-agnostic orchestration, inventory, and cost comparisons across AWS, Azure, and GCP.
 - [Project 21: Quantum-Safe Cryptography](./projects/21-quantum-safe-cryptography) — Hybrid Kyber + ECDH key exchange prototype.
 - [Project 22: Autonomous DevOps Platform](./projects/22-autonomous-devops-platform) — Event-driven remediation workflows and runbooks-as-code.
 - [Project 23: Advanced Monitoring & Observability](./projects/23-advanced-monitoring) — Grafana dashboards, alerting rules, and distributed tracing config.

--- a/projects-new/QUICK_START_GUIDE.md
+++ b/projects-new/QUICK_START_GUIDE.md
@@ -6,6 +6,8 @@
 
 This guide will help you quickly get started with the 20 standardized enterprise projects in this portfolio. Each project follows the same structure and conventions defined in the [Enterprise Engineer's Handbook](../docs/PRJ-MASTER-HANDBOOK/README.md).
 
+> **Canonical location:** Every P01–P20 directory lives under `./projects-new/` at the repository root. Use `cd projects-new/PXX-*` when following the navigation examples below.
+
 ---
 
 ## Table of Contents
@@ -197,7 +199,7 @@ make deploy ENV=prod
 ### Infrastructure & Platform (P01-P03)
 
 #### P01: AWS Infrastructure Automation
-**Directory:** `P01-aws-infra`
+**Directory:** `projects-new/P01-aws-infra`
 
 Automates AWS infrastructure provisioning with Terraform.
 
@@ -209,7 +211,7 @@ Automates AWS infrastructure provisioning with Terraform.
 
 **Quick Start:**
 ```bash
-cd P01-aws-infra
+cd projects-new/P01-aws-infra
 make install
 cp .env.example .env
 cd infrastructure/terraform
@@ -222,7 +224,7 @@ terraform plan
 ---
 
 #### P02: Kubernetes Cluster Management
-**Directory:** `P02-k8s-cluster`
+**Directory:** `projects-new/P02-k8s-cluster`
 
 Manages Kubernetes clusters with automated deployment and scaling.
 
@@ -234,7 +236,7 @@ Manages Kubernetes clusters with automated deployment and scaling.
 
 **Quick Start:**
 ```bash
-cd P02-k8s-cluster
+cd projects-new/P02-k8s-cluster
 make install
 kubectl cluster-info
 kubectl get nodes
@@ -245,7 +247,7 @@ kubectl get nodes
 ---
 
 #### P03: CI/CD Pipeline Implementation
-**Directory:** `P03-cicd-pipeline`
+**Directory:** `projects-new/P03-cicd-pipeline`
 
 Complete CI/CD pipeline with automated testing and deployment.
 
@@ -257,7 +259,7 @@ Complete CI/CD pipeline with automated testing and deployment.
 
 **Quick Start:**
 ```bash
-cd P03-cicd-pipeline
+cd projects-new/P03-cicd-pipeline
 cat ci/ci-cd.yml
 # Push to trigger pipeline
 git push origin main
@@ -270,7 +272,7 @@ git push origin main
 ### Monitoring & Observability (P04, P10, P19)
 
 #### P04: Operational Monitoring Stack
-**Directory:** `P04-monitoring-stack`
+**Directory:** `projects-new/P04-monitoring-stack`
 
 Prometheus and Grafana monitoring stack.
 
@@ -282,7 +284,7 @@ Prometheus and Grafana monitoring stack.
 
 **Quick Start:**
 ```bash
-cd P04-monitoring-stack
+cd projects-new/P04-monitoring-stack
 docker-compose up -d
 # Access Grafana at http://localhost:3000
 ```
@@ -292,7 +294,7 @@ docker-compose up -d
 ---
 
 #### P10: Log Aggregation System
-**Directory:** `P10-log-aggregation`
+**Directory:** `projects-new/P10-log-aggregation`
 
 Centralized log aggregation with ELK stack.
 
@@ -304,7 +306,7 @@ Centralized log aggregation with ELK stack.
 
 **Quick Start:**
 ```bash
-cd P10-log-aggregation
+cd projects-new/P10-log-aggregation
 docker-compose up -d elasticsearch kibana
 # Access Kibana at http://localhost:5601
 ```
@@ -312,7 +314,7 @@ docker-compose up -d elasticsearch kibana
 ---
 
 #### P19: Observability Dashboard
-**Directory:** `P19-observability-dashboard`
+**Directory:** `projects-new/P19-observability-dashboard`
 
 Unified observability dashboard combining metrics, logs, and traces.
 
@@ -324,7 +326,7 @@ Unified observability dashboard combining metrics, logs, and traces.
 
 **Quick Start:**
 ```bash
-cd P19-observability-dashboard
+cd projects-new/P19-observability-dashboard
 make install
 make deploy ENV=dev
 ```
@@ -334,7 +336,7 @@ make deploy ENV=dev
 ### Database & Performance (P05, P17)
 
 #### P05: Database Performance Optimization
-**Directory:** `P05-db-optimization`
+**Directory:** `projects-new/P05-db-optimization`
 
 Tools for database performance analysis and optimization.
 
@@ -346,7 +348,7 @@ Tools for database performance analysis and optimization.
 
 **Quick Start:**
 ```bash
-cd P05-db-optimization
+cd projects-new/P05-db-optimization
 source venv/bin/activate
 python src/main.py --analyze --database mydb
 ```
@@ -354,7 +356,7 @@ python src/main.py --analyze --database mydb
 ---
 
 #### P17: Performance Load Testing
-**Directory:** `P17-load-testing`
+**Directory:** `projects-new/P17-load-testing`
 
 Load testing framework with k6 and custom scripts.
 
@@ -366,7 +368,7 @@ Load testing framework with k6 and custom scripts.
 
 **Quick Start:**
 ```bash
-cd P17-load-testing
+cd projects-new/P17-load-testing
 k6 run tests/performance/load_test.js
 ```
 
@@ -375,7 +377,7 @@ k6 run tests/performance/load_test.js
 ### Testing & Quality (P06)
 
 #### P06: Web Application Testing Framework
-**Directory:** `P06-web-testing`
+**Directory:** `projects-new/P06-web-testing`
 
 Comprehensive web testing with Playwright and pytest.
 
@@ -387,7 +389,7 @@ Comprehensive web testing with Playwright and pytest.
 
 **Quick Start:**
 ```bash
-cd P06-web-testing
+cd projects-new/P06-web-testing
 make install
 playwright install
 pytest tests/e2e -v
@@ -398,7 +400,7 @@ pytest tests/e2e -v
 ### Security & Compliance (P07, P13)
 
 #### P07: Security Compliance Automation
-**Directory:** `P07-security-compliance`
+**Directory:** `projects-new/P07-security-compliance`
 
 Automated security compliance checks.
 
@@ -410,14 +412,14 @@ Automated security compliance checks.
 
 **Quick Start:**
 ```bash
-cd P07-security-compliance
+cd projects-new/P07-security-compliance
 python src/main.py --scan --profile cis-aws
 ```
 
 ---
 
 #### P13: Secrets Management System
-**Directory:** `P13-secrets-management`
+**Directory:** `projects-new/P13-secrets-management`
 
 Secure secrets management with AWS Secrets Manager.
 
@@ -429,7 +431,7 @@ Secure secrets management with AWS Secrets Manager.
 
 **Quick Start:**
 ```bash
-cd P13-secrets-management
+cd projects-new/P13-secrets-management
 make install
 python src/main.py --list-secrets
 ```
@@ -439,7 +441,7 @@ python src/main.py --list-secrets
 ### Cost & Resource Optimization (P08)
 
 #### P08: Cost Optimization Tooling
-**Directory:** `P08-cost-optimization`
+**Directory:** `projects-new/P08-cost-optimization`
 
 AWS cost analysis and optimization recommendations.
 
@@ -451,7 +453,7 @@ AWS cost analysis and optimization recommendations.
 
 **Quick Start:**
 ```bash
-cd P08-cost-optimization
+cd projects-new/P08-cost-optimization
 python src/main.py --analyze --days 30
 ```
 
@@ -460,7 +462,7 @@ python src/main.py --analyze --days 30
 ### Disaster Recovery (P09, P16)
 
 #### P09: Disaster Recovery Orchestration
-**Directory:** `P09-dr-orchestration`
+**Directory:** `projects-new/P09-dr-orchestration`
 
 Automated disaster recovery workflows.
 
@@ -472,14 +474,14 @@ Automated disaster recovery workflows.
 
 **Quick Start:**
 ```bash
-cd P09-dr-orchestration
+cd projects-new/P09-dr-orchestration
 python src/main.py --run-drill
 ```
 
 ---
 
 #### P16: Backup Verification System
-**Directory:** `P16-backup-verification`
+**Directory:** `projects-new/P16-backup-verification`
 
 Automated backup testing and verification.
 
@@ -491,7 +493,7 @@ Automated backup testing and verification.
 
 **Quick Start:**
 ```bash
-cd P16-backup-verification
+cd projects-new/P16-backup-verification
 ./scripts/verify_backups.sh
 ```
 
@@ -500,13 +502,13 @@ cd P16-backup-verification
 ### Networking & Infrastructure (P11, P12, P14, P18)
 
 #### P11: API Gateway Configuration
-**Directory:** `P11-api-gateway`
+**Directory:** `projects-new/P11-api-gateway`
 
 API Gateway setup with rate limiting and authentication.
 
 **Quick Start:**
 ```bash
-cd P11-api-gateway
+cd projects-new/P11-api-gateway
 terraform -chdir=infrastructure/terraform init
 terraform -chdir=infrastructure/terraform apply
 ```
@@ -514,13 +516,13 @@ terraform -chdir=infrastructure/terraform apply
 ---
 
 #### P12: Container Registry Management
-**Directory:** `P12-container-registry`
+**Directory:** `projects-new/P12-container-registry`
 
 ECR registry management with image scanning.
 
 **Quick Start:**
 ```bash
-cd P12-container-registry
+cd projects-new/P12-container-registry
 make build
 make push
 ```
@@ -528,26 +530,26 @@ make push
 ---
 
 #### P14: Network Configuration Automation
-**Directory:** `P14-network-automation`
+**Directory:** `projects-new/P14-network-automation`
 
 Network infrastructure automation.
 
 **Quick Start:**
 ```bash
-cd P14-network-automation
+cd projects-new/P14-network-automation
 terraform -chdir=infrastructure/terraform plan
 ```
 
 ---
 
 #### P18: Service Mesh Implementation
-**Directory:** `P18-service-mesh`
+**Directory:** `projects-new/P18-service-mesh`
 
 Istio service mesh deployment and configuration.
 
 **Quick Start:**
 ```bash
-cd P18-service-mesh
+cd projects-new/P18-service-mesh
 kubectl apply -f infrastructure/k8s/
 ```
 
@@ -556,7 +558,7 @@ kubectl apply -f infrastructure/k8s/
 ### Incident Response (P15)
 
 #### P15: Incident Response Automation
-**Directory:** `P15-incident-response`
+**Directory:** `projects-new/P15-incident-response`
 
 Automated incident detection and response.
 
@@ -568,7 +570,7 @@ Automated incident detection and response.
 
 **Quick Start:**
 ```bash
-cd P15-incident-response
+cd projects-new/P15-incident-response
 python src/main.py --monitor
 ```
 
@@ -577,7 +579,7 @@ python src/main.py --monitor
 ### Multi-Cloud (P20)
 
 #### P20: Multi-Cloud Orchestration
-**Directory:** `P20-multi-cloud`
+**Directory:** `projects-new/P20-multi-cloud`
 
 Multi-cloud resource orchestration across AWS, Azure, GCP.
 
@@ -589,7 +591,7 @@ Multi-cloud resource orchestration across AWS, Azure, GCP.
 
 **Quick Start:**
 ```bash
-cd P20-multi-cloud
+cd projects-new/P20-multi-cloud
 make install
 python src/main.py --list-resources
 ```

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,11 @@
+# Projects Directory
+
+This tree houses homelab builds, commercial recovery work, and other bespoke deliverables that pre-date the standardized enterprise blueprints.
+
+## Canonical Enterprise Projects
+
+- P01–P20 now live in `../projects-new/`
+- Reference playbook: [`projects-new/QUICK_START_GUIDE.md`](../projects-new/QUICK_START_GUIDE.md)
+- Use commands such as `cd projects-new/P01-aws-infra` when working with the standardized templates
+
+The numbered directories (for example `1-aws-infrastructure-automation/`, `10-blockchain-smart-contract-platform/`, etc.) remain as legacy references while documentation and evidence are rebuilt. They are intentionally labeled as historical so that the canonical navigation stays focused on `projects-new/`.

--- a/scripts/create-projects.sh
+++ b/scripts/create-projects.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 # Creates standardized project structure for 20 projects
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECTS_DIR="${SCRIPT_DIR}/../projects-new"
+CANONICAL_PROJECTS_DIR="${SCRIPT_DIR}/../projects-new"
+PROJECTS_DIR="${CANONICAL_PROJECTS_DIR}"
+
+mkdir -p "${PROJECTS_DIR}"
+echo -e "Creating projects inside canonical directory: ${PROJECTS_DIR}"
 
 # Color output
 GREEN='\033[0;32m'

--- a/scripts/validate-projects.sh
+++ b/scripts/validate-projects.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Validates all 20 projects for completeness and standards compliance
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECTS_DIR="${SCRIPT_DIR}/../projects-new"
+CANONICAL_PROJECTS_DIR="${SCRIPT_DIR}/../projects-new"
+PROJECTS_DIR="${CANONICAL_PROJECTS_DIR}"
 
 # Color output
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- document that the enterprise blueprint projects live under `projects-new/` and update all quick start guides accordingly
- refresh the portfolio blueprint list in the root README to point to the canonical directories and link to the enterprise quick start
- add a README under `projects/` to mark the numbered directories as legacy work, and ensure the project creation/validation scripts explicitly target the canonical path

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ff4ff164832791bbd32ba0b0f9e4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced 20 standardized Enterprise Blueprints (P01–P20) with templates for Terraform workflows, cloud infrastructure, CI/CD, monitoring, database optimization, security automation, and multi-cloud orchestration.

* **Documentation**
  * Updated quick start guides and README with new canonical directory structure for enterprise projects.
  * Added reference documentation for navigating and initializing enterprise project templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->