### PR TITLE
Add scaffolding and config samples for P01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ __pycache__/
 *.pfx
 .env
 .env.*
+!.env.example
 *secrets*
 *password*
 *credential*

--- a/projects-new/P01-aws-infra/.env.example
+++ b/projects-new/P01-aws-infra/.env.example
@@ -1,0 +1,6 @@
+# AWS account configuration
+AWS_ACCOUNT_ID=123456789012
+AWS_REGION=us-east-1
+
+# Project metadata used for container images
+PROJECT_SLUG=aws-infra

--- a/projects-new/P01-aws-infra/README.md
+++ b/projects-new/P01-aws-infra/README.md
@@ -24,6 +24,18 @@ make test
 make deploy
 ```
 
+## Configuration
+
+Create a `.env` file (based on `.env.example`) with the variables required by the Makefile targets and deployment scripts:
+
+| Variable | Description |
+| --- | --- |
+| `AWS_ACCOUNT_ID` | AWS account that hosts the container registry. |
+| `AWS_REGION` | AWS region where infrastructure resources are provisioned. |
+| `PROJECT_SLUG` | Identifier used for tagging Docker images in the Makefile. |
+
+These values are consumed by `make build`, the deployment script in `scripts/deploy.sh`, and can also be referenced by local tooling such as `docker run --env-file .env ...`.
+
 ## Documentation
 
 - [📘 HANDBOOK](docs/HANDBOOK.md) - Engineering standards and best practices
@@ -48,7 +60,7 @@ P01-aws-infra/
 ├── tests/                    # Test suite
 ├── infrastructure/           # IaC configurations
 │   ├── terraform/
-│   └── k8s/
+│   └── k8s/                  # Starter Kubernetes manifests
 └── ci/                       # CI/CD workflows
 ```
 

--- a/projects-new/P01-aws-infra/infrastructure/k8s/deployment.yaml
+++ b/projects-new/P01-aws-infra/infrastructure/k8s/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aws-infra-app
+  labels:
+    app: aws-infra
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: aws-infra
+  template:
+    metadata:
+      labels:
+        app: aws-infra
+    spec:
+      containers:
+        - name: aws-infra
+          image: aws-infra:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: APP_ENV
+              value: "production"

--- a/projects-new/P01-aws-infra/infrastructure/k8s/service.yaml
+++ b/projects-new/P01-aws-infra/infrastructure/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aws-infra-service
+  labels:
+    app: aws-infra
+spec:
+  selector:
+    app: aws-infra
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/projects-new/P01-aws-infra/tests/conftest.py
+++ b/projects-new/P01-aws-infra/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Project-wide pytest configuration for path setup."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if SRC_DIR.exists():
+    sys.path.insert(0, str(SRC_DIR))

--- a/projects-new/P01-aws-infra/tests/e2e/test_e2e_placeholder.py
+++ b/projects-new/P01-aws-infra/tests/e2e/test_e2e_placeholder.py
@@ -1,0 +1,5 @@
+"""Placeholder end-to-end tests for project scaffolding."""
+
+def test_e2e_placeholder():
+    """Ensure the end-to-end test suite is discoverable."""
+    assert True

--- a/projects-new/P01-aws-infra/tests/integration/test_integration_placeholder.py
+++ b/projects-new/P01-aws-infra/tests/integration/test_integration_placeholder.py
@@ -1,0 +1,5 @@
+"""Placeholder integration tests for project scaffolding."""
+
+def test_integration_placeholder():
+    """Ensure the integration test suite is discoverable."""
+    assert True

--- a/projects-new/P01-aws-infra/tests/unit/test_main.py
+++ b/projects-new/P01-aws-infra/tests/unit/test_main.py
@@ -1,8 +1,14 @@
-"""
-Unit tests for main module.
-"""
+"""Unit tests for main module."""
 
-from src.main import health_check
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from main import health_check
 
 
 def test_health_check():


### PR DESCRIPTION
## Summary
- add an explicit `.env.example` alongside README guidance so developers know which variables are required for the Makefile and deploy script
- scaffold the missing integration and e2e pytest suites (with a shared `conftest.py`) so the advertised test targets work
- populate `infrastructure/k8s` with starter Deployment and Service manifests to match the documented project structure

## Testing
- `cd projects-new/P01-aws-infra && pytest tests -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ff9491b48327ae2252bd7b0f72f7)