### PR TITLE
Address gnupg prerequisite for Docker install

### DIFF
--- a/docs/HOMELAB_ENTERPRISE_INFRASTRUCTURE_VOLUME_2.md
+++ b/docs/HOMELAB_ENTERPRISE_INFRASTRUCTURE_VOLUME_2.md
@@ -770,7 +770,7 @@ pct start 110
 pct enter 110
 
 # Install Docker
-apt update && apt install -y ca-certificates curl
+apt update && apt install -y ca-certificates curl gnupg
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
## Summary
- ensure the Docker install instructions install `gnupg` so the gpg key import works on a clean Ubuntu container

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916070ae3c0832787877003a74b496e)