### PR TITLE
Ensure CI surfaces lint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
     
     - name: Validate Markdown
       run: |
-        markdownlint '**/*.md' --ignore node_modules || true
-        
+        markdownlint '**/*.md' --ignore node_modules
+
     - name: Check Python formatting
-      run: black --check . || true
-      
+      run: black --check .
+
     - name: Lint Python code
-      run: ruff check . || true
-      
+      run: ruff check .
+
     - name: Run tests
-      run: pytest || true
+      run: pytest


### PR DESCRIPTION
## Summary
- remove the `|| true` suffixes in the markdownlint, Black, Ruff, and pytest steps so the workflow fails when the tools fail

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161430b448832780111be5f079c4f9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to improve pipeline reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->