### PR TITLE
Fix login request payload

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -47,6 +47,11 @@ def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
 
+def get_password_hash(password: str) -> str:
+    """Backward compatible alias for hash_password."""
+    return hash_password(password)
+
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
     Verify a plain text password against a hashed password.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -138,7 +138,7 @@ The frontend communicates with the backend API through:
 import { authService, contentService } from './api'
 
 // Authentication
-await authService.login({ username, password })
+await authService.login({ email, password })
 await authService.register({ email, password })
 const user = await authService.getCurrentUser()
 

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -31,15 +31,7 @@ export const authService = {
    * Login user and get access token
    */
   async login(data: LoginRequest): Promise<LoginResponse> {
-    const formData = new FormData()
-    formData.append('username', data.username)
-    formData.append('password', data.password)
-
-    const response = await apiClient.post<LoginResponse>('/auth/login', formData, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-    })
+    const response = await apiClient.post<LoginResponse>('/auth/login', data)
     return response.data
   },
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -23,7 +23,7 @@ export interface Content {
 }
 
 export interface LoginRequest {
-  username: string
+  email: string
   password: string
 }
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -99,7 +99,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       // Automatically login after registration
       await login({
-        username: data.email,
+        email: data.email,
         password: data.password,
       })
     } catch (error) {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -23,7 +23,7 @@ export const Login: React.FC = () => {
     setIsLoading(true)
 
     try {
-      await login({ username: email, password })
+      await login({ email, password })
       navigate('/dashboard')
     } catch (err) {
       setError('Invalid email or password')


### PR DESCRIPTION
## Summary
- update the frontend login flow to send `{ email, password }` JSON payloads and propagate the email property through the AuthContext, login form, and README example
- expose a `get_password_hash` helper so existing backend tests that import it continue to work

## Testing
- `pytest tests/test_auth.py -k login` *(fails: the async test database fixture attempts to connect to PostgreSQL on localhost:5432, which is not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161437e1bc8327b23044cd32c84697)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login authentication to use email instead of username for user credentials.
  * Login requests now use standardized JSON payload format for authentication.

* **Documentation**
  * Updated documentation examples to reflect the new email-based login authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->