### PR TITLE
Allow optional access to public content endpoints

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -55,11 +55,11 @@ backend/
 - `GET /auth/me` - Get current user (protected)
 
 #### Content Management
-- `GET /content` - List all content (paginated)
-- `GET /content/{id}` - Get single content item
-- `POST /content` - Create content (protected)
-- `PUT /content/{id}` - Update content (owner only)
-- `DELETE /content/{id}` - Delete content (owner only)
+- `GET /content` - List published content (public; auth includes owner's drafts)
+- `GET /content/{id}` - Get single content item (public if published, owner-only for drafts)
+- `POST /content` - Create content (**protected**)
+- `PUT /content/{id}` - Update content (**owner only**)
+- `DELETE /content/{id}` - Delete content (**owner only**)
 
 #### Health
 - `GET /health` - Overall health status

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,11 +92,11 @@ A modern, production-ready REST API built with FastAPI, featuring JWT authentica
 - `GET /auth/me` - Get current user info (requires auth)
 
 ### Content Management
-- `GET /content` - List all content (with pagination)
-- `GET /content/{id}` - Get single content item
-- `POST /content` - Create new content (requires auth)
-- `PUT /content/{id}` - Update content (owner only)
-- `DELETE /content/{id}` - Delete content (owner only)
+- `GET /content` - List published content (public). Authenticated users also see their drafts.
+- `GET /content/{id}` - Get single content item (public if published, owner-only for drafts)
+- `POST /content` - Create new content (**requires auth**)
+- `PUT /content/{id}` - Update content (**owner only**)
+- `DELETE /content/{id}` - Delete content (**owner only**)
 
 ## Project Structure
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -47,6 +47,13 @@ def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
 
+# Backwards-compatible alias --------------------------------------------------
+def get_password_hash(password: str) -> str:
+    """Compatibility wrapper around :func:`hash_password`."""
+
+    return hash_password(password)
+
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
     Verify a plain text password against a hashed password.

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -23,7 +23,7 @@ from app.schemas import (
     ContentResponse,
     ContentListResponse
 )
-from app.dependencies import get_current_user
+from app.dependencies import get_current_user, get_optional_user
 
 
 router = APIRouter(
@@ -40,7 +40,7 @@ router = APIRouter(
 )
 async def list_content(
     db: AsyncSession = Depends(get_db),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_optional_user),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(10, ge=1, le=100, description="Items per page"),
     published_only: bool = Query(True, description="Show only published content"),
@@ -73,9 +73,9 @@ async def list_content(
             )
         )
     else:
-        # Not authenticated: only published content
-        if published_only:
-            query = query.where(Content.is_published == True)
+        # Not authenticated: only published content regardless of flag
+        published_only = True
+        query = query.where(Content.is_published == True)
 
     # Apply search filter
     if search:
@@ -124,7 +124,7 @@ async def list_content(
 async def get_content(
     content_id: UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: Optional[User] = Depends(get_current_user)
+    current_user: Optional[User] = Depends(get_optional_user)
 ) -> Content:
     """
     Get a single content item by ID.


### PR DESCRIPTION
## Summary
- add an optional user dependency that wraps the HTTP bearer scheme without raising when no token is supplied and reuse it from the read-only content endpoints
- keep the stricter dependency for mutations while expanding regression coverage for public/private content access and aligning pagination tests with the API schema
- document which content endpoints require authorization (and when it is optional) so the API surface is clearer to consumers

## Testing
- `cd backend && pytest tests/test_content.py` *(fails: test database expects PostgreSQL on localhost:5432)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161438bb548327b23d44ada0dd4313)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional authentication support for content browsing, enabling public access to published content.

* **Documentation**
  * Updated API endpoint descriptions to clarify content visibility rules (published vs. draft) and access control requirements.

* **Tests**
  * Expanded test coverage for content access scenarios with and without user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->