### PR TITLE
Configure Terraform backend for S3 state

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -24,20 +24,15 @@
 # - DynamoDB table prevents concurrent modifications
 # - Bucket is private with no public access
 
-# Uncomment and configure after running bootstrap script:
-#
-# terraform {
-#   backend "s3" {
-#     bucket         = "twisted-monk-tfstate-XXXXX"  # From bootstrap output
-#     key            = "twisted-monk/terraform.tfstate"
-#     region         = "us-east-1"                    # Your AWS region
-#     dynamodb_table = "twisted-monk-tfstate-lock"   # From bootstrap output
-#     encrypt        = true
-#   }
-# }
-
-# Local backend (default until S3 backend is configured)
 terraform {
+  backend "s3" {
+    bucket         = "twisted-monk-tfstate-xxxxx"  # Override via -backend-config or backend.hcl
+    key            = "twisted-monk/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "twisted-monk-tfstate-lock"
+    encrypt        = true
+  }
+
   required_version = ">= 1.0"
 
   required_providers {


### PR DESCRIPTION
## Summary
- enable the Terraform backend configuration so it points at the S3 bucket/DynamoDB lock table used for remote state while still allowing CLI `-backend-config` overrides

## Testing
- not run (Terraform CLI is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691645a51f0c8327a9c86e219a9b9fbf)