### PR TITLE
Add Postgres-backed CI pipeline enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,31 +11,95 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/migration-orchestrator
+      IMAGE_TAG: ${{ github.sha }}
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: 'pip'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         npm install -g markdownlint-cli
-    
+
     - name: Validate Markdown
-      run: |
-        markdownlint '**/*.md' --ignore node_modules || true
-        
+      run: markdownlint '**/*.md' --ignore node_modules
+
     - name: Check Python formatting
-      run: black --check . || true
-      
+      run: black --check .
+
     - name: Lint Python code
-      run: ruff check . || true
-      
-    - name: Run tests
-      run: pytest || true
+      run: ruff check .
+
+    - name: Run unit tests with coverage
+      run: |
+        pytest \
+          --cov=projects/2-database-migration/src \
+          --cov-report=xml \
+          --cov-report=term \
+          -m "not integration" \
+          --maxfail=1 \
+          --durations=10
+
+    - name: Run PostgreSQL integration tests
+      env:
+        POSTGRES_HOST: localhost
+        POSTGRES_PORT: 5432
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
+        POSTGRES_SOURCE_DB: migration_source
+        POSTGRES_TARGET_DB: migration_target
+      run: |
+        pytest tests/integration -m integration --maxfail=1 --durations=10
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage.xml
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push migration orchestrator image
+      uses: docker/build-push-action@v5
+      with:
+        context: projects/2-database-migration
+        file: projects/2-database-migration/Dockerfile
+        push: ${{ github.event_name == 'push' }}
+        tags: |
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,11 @@ python-docx>=0.8.11
 kubernetes>=26.0.0
 requests>=2.28.0
 jinja2>=3.1.0
+boto3>=1.34.0
+psycopg2-binary==2.9.9
 
 # Dev tools (optional, used by CI if present):
 black==23.9.1
 ruff==0.12.1
 pytest>=7.2.0
+pytest-cov>=4.1.0

--- a/tests/integration/test_migration_connectivity.py
+++ b/tests/integration/test_migration_connectivity.py
@@ -1,0 +1,124 @@
+"""Integration tests for the migration orchestrator using a live Postgres service."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import psycopg2
+except ModuleNotFoundError:  # pragma: no cover - handled by pytest skip
+    psycopg2 = None
+
+PROJECT_SRC = Path(__file__).resolve().parents[2] / "projects" / "2-database-migration" / "src"
+if str(PROJECT_SRC) not in sys.path:
+    sys.path.insert(0, str(PROJECT_SRC))
+
+pytest.importorskip("psycopg2")
+
+from migration_orchestrator import DatabaseConfig, DatabaseMigrationOrchestrator  # noqa: E402
+
+
+def _require_env(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if not value:
+        pytest.skip(f"Environment variable {var_name} is not set")
+    return value
+
+
+@pytest.fixture(scope="module")
+def postgres_env() -> Dict[str, str]:
+    """Return connection information for the CI-managed Postgres container."""
+    host = _require_env("POSTGRES_HOST")
+    port = _require_env("POSTGRES_PORT")
+    user = _require_env("POSTGRES_USER")
+    password = _require_env("POSTGRES_PASSWORD")
+    source_db = os.getenv("POSTGRES_SOURCE_DB", "migration_source")
+    target_db = os.getenv("POSTGRES_TARGET_DB", "migration_target")
+    return {
+        "host": host,
+        "port": port,
+        "user": user,
+        "password": password,
+        "source_db": source_db,
+        "target_db": target_db,
+    }
+
+
+def _wait_for_postgres(conn_info: Dict[str, str]) -> None:
+    deadline = time.time() + 60
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            conn = psycopg2.connect(
+                host=conn_info["host"],
+                port=conn_info["port"],
+                dbname="postgres",
+                user=conn_info["user"],
+                password=conn_info["password"],
+            )
+            conn.close()
+            return
+        except psycopg2.OperationalError as exc:  # pragma: no cover - best effort polling
+            last_error = exc
+            time.sleep(2)
+    if last_error:
+        raise last_error
+
+
+def _ensure_database(conn_info: Dict[str, str], db_name: str) -> None:
+    conn = psycopg2.connect(
+        host=conn_info["host"],
+        port=conn_info["port"],
+        dbname="postgres",
+        user=conn_info["user"],
+        password=conn_info["password"],
+    )
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_database WHERE datname=%s", (db_name,))
+        if not cur.fetchone():
+            cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+
+@pytest.mark.integration
+@patch("migration_orchestrator.boto3")
+def test_validate_connectivity_against_live_postgres(mock_boto3: MagicMock, postgres_env: Dict[str, str]):
+    """Validate that the orchestrator can connect to the provisioned Postgres databases."""
+    _wait_for_postgres(postgres_env)
+    _ensure_database(postgres_env, postgres_env["source_db"])
+    _ensure_database(postgres_env, postgres_env["target_db"])
+
+    mock_boto3.client.return_value = MagicMock()
+
+    source_config = DatabaseConfig(
+        host=postgres_env["host"],
+        port=int(postgres_env["port"]),
+        database=postgres_env["source_db"],
+        username=postgres_env["user"],
+        password=postgres_env["password"],
+        ssl_mode="disable",
+    )
+    target_config = DatabaseConfig(
+        host=postgres_env["host"],
+        port=int(postgres_env["port"]),
+        database=postgres_env["target_db"],
+        username=postgres_env["user"],
+        password=postgres_env["password"],
+        ssl_mode="disable",
+    )
+
+    orchestrator = DatabaseMigrationOrchestrator(
+        source_config=source_config,
+        target_config=target_config,
+        max_replication_lag_seconds=5,
+    )
+
+    assert orchestrator.validate_connectivity() is True


### PR DESCRIPTION
## Summary
- add the missing runtime and tooling dependencies along with a Postgres-backed integration test that exercises the migration orchestrator against a live database
- extend the CI workflow with Markdown/format/lint enforcement, coverage collection and upload, dedicated integration test execution, and a docker build/push sequence targeting GHCR

## Testing
- Not run (package installation from PyPI is blocked in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164587970483279b26b27d19e4b5a9)