### PR TITLE
Add navigation links for new documentation

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -87,8 +87,8 @@ This index guides you through the comprehensive analysis of the 25-project portf
 ---
 
 ### 4. TECHNOLOGY_MATRIX.md
-**Purpose**: Quick reference and setup guide  
-**Length**: ~9,500 words  
+**Purpose**: Quick reference and setup guide
+**Length**: ~9,500 words
 **Best For**:
 - Setting up projects locally
 - Understanding dependencies
@@ -115,6 +115,59 @@ This index guides you through the comprehensive analysis of the 25-project portf
 - Setup Templates
 
 **Start Here**: If you need to run a project locally
+
+---
+
+### 5. MISSING_DOCUMENTS_ANALYSIS.md
+**Purpose**: Repository-wide gap analysis and upload checklist
+**Length**: 500+ lines
+**Best For**:
+- Understanding what's missing per project
+- Prioritizing uploads and documentation work
+- Reviewing security considerations before publishing assets
+
+**Contains**:
+- Status overview tables for all 25 projects
+- Detailed "What's Needed" section per project
+- File format and sanitization guidance
+- Priority recommendations and sequencing
+
+**Start Here**: When you need a definitive list of missing artifacts
+
+---
+
+### 6. QUICK_START_GUIDE.md
+**Purpose**: Hands-on instructions for getting files into this repository
+**Length**: Fast reference (multi-section)
+**Best For**:
+- Uploading existing assets via GitHub Web, Desktop, or CLI
+- Mapping local folders to the repo structure
+- Resolving common Git issues during uploads
+
+**Contains**:
+- Step-by-step workflows for three upload methods
+- Required Git commands and troubleshooting tips
+- Directory placement guidance for every asset type
+- Mini checklist to confirm each upload
+
+**Start Here**: When you're ready to import files and need procedural help
+
+---
+
+### 7. PROJECT_COMPLETION_CHECKLIST.md
+**Purpose**: Progress tracker for finishing each portfolio project
+**Length**: Checklist-style reference
+**Best For**:
+- Tracking completion across all documentation tasks
+- Sequencing work week-by-week
+- Sharing status updates with collaborators
+
+**Contains**:
+- Checklist per project with priority labels
+- Timeline suggestions (Week 1–3) and dependencies
+- Space to record evidence links and notes
+
+**Start Here**: When you want to monitor progress and stay organized
 
 ---
 

--- a/HOW_TO_USE_THIS_ANALYSIS.md
+++ b/HOW_TO_USE_THIS_ANALYSIS.md
@@ -2,6 +2,12 @@
 
 Welcome! This portfolio repository now includes comprehensive documentation to help you complete all missing materials.
 
+## 📑 Document Quick Links
+
+- [MISSING_DOCUMENTS_ANALYSIS.md](./MISSING_DOCUMENTS_ANALYSIS.md) — Portfolio-wide gap tracker with prioritized to-dos per project.
+- [QUICK_START_GUIDE.md](./QUICK_START_GUIDE.md) — Step-by-step upload instructions for GitHub Web, Desktop, and CLI workflows.
+- [PROJECT_COMPLETION_CHECKLIST.md](./PROJECT_COMPLETION_CHECKLIST.md) — Progress checklist with week-by-week sequencing and notes space.
+
 ---
 
 ## 📚 Start Here

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ System-minded engineer specializing in building, securing, and operating infrast
 ---
 ## 📘 Guides
 
+- [Documentation Index & Navigation Guide](./DOCUMENTATION_INDEX.md#navigation-guide) — Understand how the portfolio documents connect and where to start.
 - [Wiki.js Setup Guide](./docs/wiki-js-setup-guide.md) — Complete walkthrough to deploy, harden, and populate a Wiki.js instance for portfolio documentation.
 
 ## 💻 UI Components


### PR DESCRIPTION
## Summary
- expand the documentation index with dedicated entries for the Missing Documents Analysis, Quick Start Guide, and Project Completion Checklist so readers can understand how and when to use each new file
- add quick links for the same documents inside HOW_TO_USE_THIS_ANALYSIS.md for faster navigation
- update the README guides section to point directly to the navigation guide inside DOCUMENTATION_INDEX.md

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691622b17d3c8327a5d0c655643d3deb)