### PR TITLE
Add portfolio master index documentation

### DIFF
--- a/Portfolio_Master_Index_COMPLETE.md
+++ b/Portfolio_Master_Index_COMPLETE.md
@@ -1,0 +1,80 @@
+# Portfolio Master Index — Complete Edition
+
+This index consolidates every high-signal document that ships with the enterprise portfolio. Use it as the canonical starting point when you need to understand what already exists, where it lives in the repository, and how to cross-reference related research.
+
+> **Tip:** The root-level documentation follows a "survey → gap analysis → remediation" flow. Navigate in that order if you're onboarding new teammates.
+
+---
+
+## 1. Core Reference Table
+
+| Priority | Document | Location | Purpose |
+| --- | --- | --- | --- |
+| ⭐ | `SURVEY_EXECUTIVE_SUMMARY.md` | `/` | Portfolio-wide snapshot, stakeholder talking points, and KPI callouts. |
+| ⭐ | `PORTFOLIO_SURVEY.md` | `/` | 25-project README archive with files/dirs, technologies, and completion status. |
+| ⭐ | `IMPLEMENTATION_ANALYSIS.md` | `/` | Gap analysis, missing components, and prioritized remediation steps. |
+| ⭐ | `TECHNOLOGY_MATRIX.md` | `/` | Technology dependencies, install guides, and quick start commands. |
+| ⭐ | `DOCUMENTATION_INDEX.md` | `/` | Short-form navigation helper with metrics and file listings. |
+| ✅ | `PORTFOLIO_GAP_ANALYSIS.md` | `/` | Supplemental risk notes for partially complete tracks. |
+| ✅ | `PORTFOLIO_VALIDATION.md` | `/` | Verification checklist for each delivery stage. |
+| ✅ | `PORTFOLIO_INFRASTRUCTURE_GUIDE.md` | `/` | Hands-on provisioning guide for shared services. |
+| 🔁 | `PR_DESCRIPTION_DOCS_HUB.md` | `/` | PR template that enumerates required documents and testing expectations. |
+| 🔁 | `DOCUMENTATION_INDEX.md` → `## Navigation Guide` | `/` | Lightweight instructions for locating survey, matrix, and analysis artifacts. |
+
+---
+
+## 2. How to Consume the Docs
+
+1. **Start with the Executive Stack**  
+   Read `SURVEY_EXECUTIVE_SUMMARY.md` for context, then jump to `PORTFOLIO_SURVEY.md` to deep-dive project specifics.
+2. **Move into Gap Details**  
+   Use `IMPLEMENTATION_ANALYSIS.md` for per-project remediation roadmaps. Pair it with `PORTFOLIO_GAP_ANALYSIS.md` for risk summaries.
+3. **Translate Into Workstreams**  
+   Combine `PORTFOLIO_VALIDATION.md`, `PROJECT_COMPLETION_CHECKLIST.md`, and `PORTFOLIO_COMPLETION_PROGRESS.md` to track execution.
+4. **Close the Loop with Infrastructure**  
+   Infrastructure artifacts (`PORTFOLIO_INFRASTRUCTURE_GUIDE.md`, `FOUNDATION_DEPLOYMENT_PLAN.md`, `DEPLOYMENT.md`) convert recommendations into action.
+
+---
+
+## 3. Document Tree (Abbreviated)
+
+```text
+Portfolio-Project/
+├── SURVEY_EXECUTIVE_SUMMARY.md
+├── PORTFOLIO_SURVEY.md
+├── IMPLEMENTATION_ANALYSIS.md
+├── TECHNOLOGY_MATRIX.md
+├── DOCUMENTATION_INDEX.md
+├── PORTFOLIO_GAP_ANALYSIS.md
+├── PORTFOLIO_VALIDATION.md
+├── PORTFOLIO_COMPLETION_PROGRESS.md
+├── PROJECT_COMPLETION_CHECKLIST.md
+├── FOUNDATION_DEPLOYMENT_PLAN.md
+├── DEPLOYMENT.md
+├── docs/
+│   ├── COMPREHENSIVE_PORTFOLIO_IMPLEMENTATION_GUIDE.md
+│   ├── HOMELAB_ENTERPRISE_INFRASTRUCTURE_VOLUME_2.md
+│   └── wiki-js-setup-guide.md
+└── projects/
+    └── 25 portfolio subdirectories with runbooks, docs, and assets
+```
+
+---
+
+## 4. Cross-Reference Matrix
+
+| Workflow Stage | Primary Docs | Secondary Docs | Notes |
+| --- | --- | --- | --- |
+| Discovery | `SURVEY_EXECUTIVE_SUMMARY.md`, `PORTFOLIO_SURVEY.md` | `PORTFOLIO_SUMMARY_TABLE.txt`, `PORTFOLIO_SURVEY.md` | Establish stakeholders and initial scope. |
+| Planning | `IMPLEMENTATION_ANALYSIS.md`, `PORTFOLIO_GAP_ANALYSIS.md` | `CODE_ENHANCEMENTS_SUMMARY.md`, `CRITICAL_FIXES_APPLIED.md` | Identify blockers and quick wins. |
+| Build-Out | `PORTFOLIO_INFRASTRUCTURE_GUIDE.md`, `FOUNDATION_DEPLOYMENT_PLAN.md` | `CONFIGURATION_GUIDE.md`, `DEPLOYMENT_READINESS.md` | Provision infrastructure and pipelines. |
+| Validation | `PORTFOLIO_VALIDATION.md`, `PROJECT_COMPLETION_CHECKLIST.md` | `TEST_SUITE_SUMMARY.md`, `TEST_GENERATION_COMPLETE.md` | Confirm quality gates and regression coverage. |
+| Reporting | `DOCUMENTATION_INDEX.md`, `PORTFOLIO_COMPLETION_PROGRESS.md` | `EXECUTIVE_SUMMARY.md`, `CODE_QUALITY_REPORT.md` | Communicate status to leadership. |
+
+---
+
+## 5. Update Policy
+
+- Keep this file synchronized when new root-level docs are added.  
+- Use the continuation index (`Portfolio_Master_Index_CONTINUATION.md`) for extended references, tables, or appendices that would clutter this overview.  
+- Run `git status` before every commit to ensure only intentional documentation changes are staged.

--- a/Portfolio_Master_Index_CONTINUATION.md
+++ b/Portfolio_Master_Index_CONTINUATION.md
@@ -1,0 +1,63 @@
+# Portfolio Master Index — Continuation Volume
+
+This continuation extends the Complete Edition with deeper cross-links, doc clusters, and follow-up reading. Use it when you need secondary or niche references that support the main delivery artifacts.
+
+---
+
+## A. Extended Document Families
+
+| Cluster | Files | Key Use Cases |
+| --- | --- | --- |
+| **Readiness & Deployments** | `DEPLOYMENT.md`, `DEPLOYMENT_READINESS.md`, `FOUNDATION_DEPLOYMENT_PLAN.md`, `BACKUP_STRATEGY.md` | Promote changes from lab → staging → production, establish rollback and recovery steps. |
+| **Quality & Testing** | `TEST_SUMMARY.md`, `TEST_SUITE_SUMMARY.md`, `TEST_GENERATION_COMPLETE.md`, `CODE_QUALITY_REPORT.md` | Capture regression scope, automation targets, and static analysis outcomes. |
+| **Remediation & Fixes** | `CRITICAL_FIXES_APPLIED.md`, `CODE_ENHANCEMENTS_SUMMARY.md`, `REMEDIATION_PLAN.md`, `STRUCTURE_COMPLETION_NOTES.md` | Track historical fixes and planned improvements. |
+| **Program Management** | `PORTFOLIO_COMPLETION_PROGRESS.md`, `PORTFOLIO_ASSESSMENT_REPORT.md`, `PROJECT_COMPLETION_CHECKLIST.md`, `SESSION_SUMMARY_2025-11-10.md` | Provide stakeholder-ready progress updates. |
+| **Specialty Guides** | `PORTFOLIO_INFRASTRUCTURE_GUIDE.md`, `PORTFOLIO_SURVEY.md`, `PORTFOLIO_VALIDATION.md`, `PORTFOLIO_NAVIGATION_GUIDE.md` | Bridge high-level indexes with task-level instructions. |
+
+---
+
+## B. Directory-Level Navigation
+
+1. **`docs/`**  
+   Houses handbooks (`PRJ-MASTER-HANDBOOK`), V2 infrastructure volumes, and setup guides for wiki/knowledge management stacks.
+2. **`projects/`**  
+   Contains 25 numbered folders. Each folder includes runbooks, architecture notes, and assets. Example: `projects/25-portfolio-website/` exposes a VitePress documentation portal.
+3. **`enterprise-portfolio/`**  
+   Contains the wiki application and supporting frontend assets for enterprise-ready publishing.
+4. **`professional/` and `projects-new/`**  
+   Sandbox and in-flight workstreams kept separate from the canonical portfolio.
+5. **`infrastructure/`, `terraform/`, and `scripts/`**  
+   Automation sources for IaC, bootstrap scripts, and cluster management.
+
+---
+
+## C. Task-Based Jump List
+
+```mermaid
+graph TD
+  A[Start: Need Portfolio Info] --> B{Goal}
+  B -->|High-level KPIs| C[SURVEY_EXECUTIVE_SUMMARY.md]
+  B -->|Per-project details| D[PORTFOLIO_SURVEY.md]
+  B -->|Tech dependencies| E[TECHNOLOGY_MATRIX.md]
+  B -->|Gap remediation| F[IMPLEMENTATION_ANALYSIS.md]
+  B -->|Infra deployment| G[PORTFOLIO_INFRASTRUCTURE_GUIDE.md]
+  B -->|Testing status| H[TEST_SUITE_SUMMARY.md]
+  B -->|Navigation tips| I[Portfolio_Navigation_Guide.md]
+```
+
+---
+
+## D. Referencing Related Assets
+
+- **Visuals**: `assets/` plus each `projects/*/assets` folder for diagrams and mockups.  
+- **Automation**: `scripts/` provides shell helpers (`setup-portfolio-infrastructure.sh`, etc.).  
+- **Front-end artifacts**: `frontend/` and `portfolio-website/` show how documentation appears inside demo portals.
+
+---
+
+## E. Maintenance Checklist
+
+- Update both master index files whenever a new high-visibility document lands in the repo root.
+- Cross-link `Portfolio_Navigation_Guide.md` when navigation instructions change.
+- Verify Markdown tables and mermaid diagrams render in GitHub (use fenced code blocks with explicit languages, as seen above).
+- Document new testing or deployment scripts in the relevant cluster table so teams know where to find them.

--- a/Portfolio_Navigation_Guide.md
+++ b/Portfolio_Navigation_Guide.md
@@ -1,0 +1,72 @@
+# Portfolio Navigation Guide
+
+Use this guide to move between the numerous survey, analysis, and infrastructure documents without losing context. Every section contains exact file paths so you can jump straight to the right artifact from the command line or the GitHub UI.
+
+---
+
+## 1. Quick Entry Points
+
+| Scenario | Start Here | Why |
+| --- | --- | --- |
+| Need executive talking points | `SURVEY_EXECUTIVE_SUMMARY.md` | Contains KPIs, completion tiers, and stakeholder-ready messaging. |
+| Need per-project facts | `PORTFOLIO_SURVEY.md` | Includes README text, tech stacks, and completion status for all 25 projects. |
+| Need remediation steps | `IMPLEMENTATION_ANALYSIS.md` | Breaks down missing components, priorities, and effort ranges. |
+| Need technology mapping | `TECHNOLOGY_MATRIX.md` | Consolidates dependencies, install guides, and quick start commands. |
+| Need progress dashboards | `PORTFOLIO_COMPLETION_PROGRESS.md` | Converts the survey into measurable milestones. |
+
+---
+
+## 2. Navigating by Repository Area
+
+1. **Root Documentation**  
+   Files such as `DOCUMENTATION_INDEX.md`, `PORTFOLIO_GAP_ANALYSIS.md`, and `PORTFOLIO_VALIDATION.md` live at the repository root for instant discovery.
+2. **`docs/` Folder**  
+   Long-form references (`COMPREHENSIVE_PORTFOLIO_IMPLEMENTATION_GUIDE.md`, `HOMELAB_ENTERPRISE_INFRASTRUCTURE_VOLUME_2.md`) and handbooks under `docs/PRJ-MASTER-*` reside here.
+3. **Project Implementations**  
+   Browse `projects/` for numbered directories (`01-*` through `25-*`). Each contains `README.md`, runbooks, and architecture diagrams for the specific solution.
+4. **Productized Sites**  
+   - `portfolio-website/` → VitePress portal with rendered docs.  
+   - `enterprise-portfolio/wiki-app/` → Next.js/React wiki for enterprise publishing.
+5. **Automation**  
+   - `infrastructure/`, `terraform/` → IaC definitions.  
+   - `scripts/` → Shell utilities, e.g., `setup-portfolio-infrastructure.sh` with embedded quick navigation instructions.
+
+---
+
+## 3. CLI Shortcuts
+
+```bash
+# List the five highest-priority documents
+git ls-files SURVEY_EXECUTIVE_SUMMARY.md PORTFOLIO_SURVEY.md \
+  IMPLEMENTATION_ANALYSIS.md TECHNOLOGY_MATRIX.md DOCUMENTATION_INDEX.md
+
+# Preview a document quickly
+bat PORTFOLIO_SURVEY.md | head -n 120
+
+# Jump directly to a project folder
+cd projects/25-portfolio-website && ls
+```
+
+> **Note:** The `bat` command is optional; fall back to `sed -n '1,120p' FILE` if unavailable.
+
+---
+
+## 4. Decision Tree
+
+1. **What do you need?**
+   - **Metrics or KPIs?** → `SURVEY_EXECUTIVE_SUMMARY.md` and `PORTFOLIO_COMPLETION_PROGRESS.md`
+   - **Technical gaps?** → `IMPLEMENTATION_ANALYSIS.md` + `CODE_ENHANCEMENTS_SUMMARY.md`
+   - **Testing coverage?** → `TEST_SUITE_SUMMARY.md`, `TEST_GENERATION_COMPLETE.md`
+   - **Deployment readiness?** → `FOUNDATION_DEPLOYMENT_PLAN.md`, `DEPLOYMENT_READINESS.md`
+2. **Need a guided tour?**
+   - Use this navigation guide in tandem with `Portfolio_Master_Index_COMPLETE.md` and `Portfolio_Master_Index_CONTINUATION.md`.
+3. **Need visuals?**
+   - Open `PORTFOLIO_ARCHITECTURE_DIAGRAMS_COLLECTION.md` or browse `assets/`.
+
+---
+
+## 5. Maintenance
+
+- Update the quick entry table when any primary document is renamed or replaced.
+- Confirm CLI examples stay accurate after structural changes.
+- Cross-link new resources inside the decision tree to keep onboarding smooth.


### PR DESCRIPTION
## Summary
- add a complete master index file that organizes the primary portfolio documents
- add a continuation volume with extended doc families, directory navigation, and maintenance notes
- add a navigation guide that explains how to move between the key documentation assets

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691749ec8028832794781755347c144f)