### PR TITLE
Add validation for configurable DB port

### DIFF
--- a/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/dev/variables.tf
+++ b/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/dev/variables.tf
@@ -30,7 +30,16 @@ variable "max_size" { type = number default = 4 }
 variable "app_port" { type = number default = 8080 }
 variable "health_check_path" { type = string default = "/healthz" }
 variable "target_cpu_utilization" { type = number default = 50 }
-variable "db_port" { type = number default = 3306 }
+variable "db_port" {
+  description = "Port used by the database engine (propagates to security groups and NACL rules)"
+  type        = number
+  default     = 3306
+
+  validation {
+    condition     = var.db_port >= 1 && var.db_port <= 65535
+    error_message = "Database port must be between 1 and 65535."
+  }
+}
 
 variable "db_name" { type = string default = "appdb" }
 variable "db_engine" { type = string default = "mysql" }

--- a/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/prod/variables.tf
+++ b/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/prod/variables.tf
@@ -30,7 +30,16 @@ variable "max_size" { type = number default = 4 }
 variable "app_port" { type = number default = 8080 }
 variable "health_check_path" { type = string default = "/healthz" }
 variable "target_cpu_utilization" { type = number default = 50 }
-variable "db_port" { type = number default = 3306 }
+variable "db_port" {
+  description = "Port used by the database engine (propagates to security groups and NACL rules)"
+  type        = number
+  default     = 3306
+
+  validation {
+    condition     = var.db_port >= 1 && var.db_port <= 65535
+    error_message = "Database port must be between 1 and 65535."
+  }
+}
 
 variable "db_name" { type = string default = "appdb" }
 variable "db_engine" { type = string default = "mysql" }

--- a/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/staging/variables.tf
+++ b/projects/01-sde-devops/PRJ-AWS-001/terraform/environments/staging/variables.tf
@@ -30,7 +30,16 @@ variable "max_size" { type = number default = 4 }
 variable "app_port" { type = number default = 8080 }
 variable "health_check_path" { type = string default = "/healthz" }
 variable "target_cpu_utilization" { type = number default = 50 }
-variable "db_port" { type = number default = 3306 }
+variable "db_port" {
+  description = "Port used by the database engine (propagates to security groups and NACL rules)"
+  type        = number
+  default     = 3306
+
+  validation {
+    condition     = var.db_port >= 1 && var.db_port <= 65535
+    error_message = "Database port must be between 1 and 65535."
+  }
+}
 
 variable "db_name" { type = string default = "appdb" }
 variable "db_engine" { type = string default = "mysql" }

--- a/projects/01-sde-devops/PRJ-AWS-001/terraform/modules/networking/variables.tf
+++ b/projects/01-sde-devops/PRJ-AWS-001/terraform/modules/networking/variables.tf
@@ -104,6 +104,11 @@ variable "db_port" {
   description = "Database port for private subnet NACL rules"
   type        = number
   default     = 3306
+
+  validation {
+    condition     = var.db_port >= 1 && var.db_port <= 65535
+    error_message = "Database port must be between 1 and 65535."
+  }
 }
 
 variable "common_tags" {

--- a/projects/01-sde-devops/PRJ-AWS-001/terraform/modules/security/variables.tf
+++ b/projects/01-sde-devops/PRJ-AWS-001/terraform/modules/security/variables.tf
@@ -24,4 +24,9 @@ variable "db_port" {
   description = "Database listener port"
   type        = number
   default     = 3306
+
+  validation {
+    condition     = var.db_port >= 1 && var.db_port <= 65535
+    error_message = "Database port must be between 1 and 65535."
+  }
 }


### PR DESCRIPTION
## Summary
- add validation to the db_port input in the networking and security modules so that the private DB NACL rules stay configurable while preventing invalid port selections
- document and validate the db_port variable in each environment configuration so consumers can safely override the database listener port when different engines are used

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917702c6d3c8327b2ef0312c5e4479d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database port configuration validation across all infrastructure environments. Port settings now enforce valid ranges (1-65535) with descriptive error messages, helping users identify and resolve configuration issues more quickly during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->