### PR TITLE
Add automation glue for demos and evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changed
+- ...
+
+## Why
+- ...
+
+## Tests
+- [ ] `make test` passes for touched projects
+- [ ] Evidence added to `/docs/evidence` if user-facing
+
+## Security
+- [ ] No secrets committed
+- [ ] CI gates (semgrep/trivy/gitleaks) green
+
+## Screenshots / Evidence
+(attach or point to files)

--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -1,0 +1,53 @@
+name: evidence-capture
+on:
+  workflow_dispatch:
+    inputs:
+      dashboard:
+        description: Grafana dashboard title
+        required: true
+        default: Demo App
+      panel:
+        description: Grafana panel title
+        required: true
+        default: Latency (p95)
+      lookback:
+        description: Jaeger lookback window
+        required: true
+        default: 30m
+
+permissions:
+  contents: write
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    env:
+      GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+      GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+      JAEGER_BASE: ${{ secrets.JAEGER_BASE }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+
+      - name: Install script deps
+        run: |
+          python -m pip install -U pip
+          pip install -r tools/requirements-scripts.txt
+
+      - name: Capture Grafana & Jaeger artifacts
+        run: |
+          mkdir -p projects/P25-observability/docs/evidence projects/P09-rag-chatbot/docs/evidence
+          python scripts/grafana_list_panels.py --format md > projects/P25-observability/docs/evidence/panels.md
+          bash scripts/capture_grafana_by_title.sh "${{ github.event.inputs.dashboard }}" "${{ github.event.inputs.panel }}" now-15m now "projects/P25-observability/docs/evidence/${{ github.event.inputs.panel }}.png"
+          python scripts/jaeger_recent_trace.py --service rag-chatbot --lookback "${{ github.event.inputs.lookback }}" --export "projects/P09-rag-chatbot/docs/evidence/trace.png"
+
+      - name: Commit artifacts
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "evidence: ${ { github.event.inputs.dashboard } } / ${ { github.event.inputs.panel } } ($(date))"
+          file_pattern: |
+            projects/P25-observability/docs/evidence/*
+            projects/P09-rag-chatbot/docs/evidence/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: detect-private-key
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks: [ { id: black } ]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks: [ { id: flake8, additional_dependencies: ["flake8-bugbear"] } ]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0
+    hooks: [ { id: prettier } ]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks: [ { id: yamllint } ]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks: [ { id: codespell } ]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        args: [ "protect", "--staged", "--no-banner" ]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+* @samueljackson-collab
+/projects/P01-aws-infra/ @samueljackson-collab
+/projects/P05-multicloud-mesh/ @samueljackson-collab
+/projects/P21-dr/ @samueljackson-collab

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: bootstrap status test-all docs-gen demo-day evidence-pack fmt lint pre-commit-install ci-check status-md
+
+bootstrap:
+	python3 -m venv .venv && . .venv/bin/activate && pip install -U pip wheel
+	. .venv/bin/activate && pip install -r tools/requirements-scripts.txt || true
+	@echo "✔ venv ready (.venv)."
+
+status:
+	@bash scripts/portfolio-status.sh
+
+test-all:
+	@for p in $$(ls -1 projects | grep -E '^P[0-9]{2}-'); do \
+		echo "== $$p =="; \
+		make -C projects/$$p test || echo "skip/no tests"; \
+	done
+
+docs-gen:
+	@python3 tools/scaffold_docs.py
+
+demo-day:
+	@bash demos/demo_day_v2.sh
+
+evidence-pack:
+	@[ -n "$(DASH)" ] || (echo "Set DASH and PANEL"; exit 2)
+	. .venv/bin/activate && DASH="$(DASH)" PANEL="$(PANEL)" bash scripts/evidence_pack.sh "$(DASH)" "$(PANEL)" projects/P25-observability projects/P09-rag-chatbot
+
+fmt:
+	@pre-commit run --all-files || true
+
+lint:
+	@pre-commit run --all-files || true
+
+pre-commit-install:
+	@pre-commit install && echo "✔ pre-commit hooks installed"
+
+ci-check:
+	@echo "Running minimal CI checks locally"
+	@pre-commit run --all-files || true
+	@bash scripts/portfolio-status.sh
+
+status-md:
+	@python scripts/status_to_markdown.py && echo "✔ docs/status.md updated"

--- a/demos/demo_day_v2.sh
+++ b/demos/demo_day_v2.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== 1. Start Observability (P25)"
+make -C projects/P25-observability up
+
+echo "== 2. Start RAG (P09) and warm"
+make -C projects/P09-rag-chatbot ingest || true
+( cd projects/P09-rag-chatbot && uvicorn app:app --port 8010 --reload ) &
+RAG_PID=$!
+sleep 3
+for i in {1..40}; do curl -s "http://localhost:8010/q?text=aws%20vpc" >/dev/null || true; done
+
+echo "== 3. Capture evidence (requires GRAFANA_* and JAEGER_BASE env)"
+mkdir -p projects/P25-observability/docs/evidence projects/P09-rag-chatbot/docs/evidence
+if [[ -n "${GRAFANA_URL:-}" && -n "${GRAFANA_TOKEN:-}" ]]; then
+  bash scripts/capture_grafana_by_title.sh "Demo App" "Latency (p95)" now-15m now projects/P25-observability/docs/evidence/Latency_p95.png || true
+else
+  echo "Skip Grafana snapshot (missing env)"
+fi
+python scripts/jaeger_recent_trace.py --service rag-chatbot --lookback 30m --export projects/P09-rag-chatbot/docs/evidence/trace.png || true
+
+echo "Open Grafana:  ${GRAFANA_URL:-http://localhost:3000}"
+echo "Open Jaeger:   ${JAEGER_BASE:-http://localhost:16686}"
+echo "Stop RAG api:  kill $RAG_PID"

--- a/docs/adr/0001-choose-terraform-over-cloudformation.md
+++ b/docs/adr/0001-choose-terraform-over-cloudformation.md
@@ -1,0 +1,14 @@
+# ADR 0001: Choose Terraform over CloudFormation
+Date: 2025-11-17
+Status: Accepted
+
+## Context
+We need vendor-neutral IaC across AWS and multi-cloud (P01, P05, P21).
+
+## Decision
+Use Terraform with modules per layer; TFLint + Terratest in CI.
+
+## Consequences
++ Reusable modules across projects
++ Rich lint/test ecosystem
+- Extra tool to learn; state backend management required

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,17 @@
+# ADR NNN: Title
+Date: YYYY-MM-DD
+
+## Status
+Accepted | Superceded by ADR NNN
+
+## Context
+What problem are we solving?
+
+## Decision
+What choice did we make?
+
+## Consequences
+Positive, negative, tradeoffs.
+
+## Alternatives
+What else we considered and why not.

--- a/docs/raci/portfolio_raci.md
+++ b/docs/raci/portfolio_raci.md
@@ -1,0 +1,9 @@
+# RACI — Portfolio Ops & Demos
+
+| Area            | Responsible | Accountable | Consulted      | Informed       |
+|-----------------|-------------|-------------|----------------|----------------|
+| P01 AWS Infra   | Eng (you)   | You         | Security       | Recruiters     |
+| P05 Mesh        | Eng         | You         | Cloud (AWS/GCP)| Recruiters     |
+| P09 RAG         | Eng         | You         | AI reviewer    | Recruiters     |
+| P24 AIOps       | Eng         | You         | SRE            | Recruiters     |
+| P25 Observab.   | Eng         | You         | SRE/Sec        | Stakeholders   |

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,20 @@
+# Release Checklist (Portfolio)
+
+## Pre-release
+- [ ] All 25 projects: `make test-all` green (or justified skips).
+- [ ] `scripts/portfolio-status.sh` shows ✅ in Code/Doc/Diag/Test/Obs for each.
+- [ ] Security: pre-commit hooks pass; no secrets; CI gates green.
+- [ ] Dashboards: P25 updated; runbooks link from alert annotations.
+
+## Evidence
+- [ ] Demo-day v2 completed; artifacts saved under each `docs/evidence/`.
+- [ ] Grafana snapshot for demo latency; Jaeger trace PNG for RAG.
+
+## Cloud Artifacts
+- [ ] P01 dev/stg/prod tfvars valid; RDS password via SSM.
+- [ ] P05 mesh: two kubecontexts, failover drill recorded.
+- [ ] P21 DR drill timestamps saved.
+
+## Sign-off
+- [ ] README indexes updated; Wiki.js re-imported.
+- [ ] Tag release `vYYYY.MM.DD`; changelog updated.

--- a/scripts/status_to_markdown.py
+++ b/scripts/status_to_markdown.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import json, subprocess, pathlib, re, time
+out = subprocess.check_output(["bash","scripts/portfolio-status.sh"], text=True, stderr=subprocess.STDOUT)
+lines = [l for l in out.splitlines() if re.search(r"^P[0-9]{2}-", l)]
+rows = []
+for l in lines:
+    parts = l.split()
+    rows.append({"project": parts[0], "code": parts[1], "doc": parts[2], "diag": parts[3], "test": parts[4], "obs": parts[5]})
+md = ["# Portfolio Status (auto)", "", f"_generated: {time.strftime('%Y-%m-%d %H:%M:%S')}_", "", "| Project | Code | Doc | Diagram | Test | Obs |", "|---|:---:|:---:|:---:|:---:|:---:|"]
+for r in rows:
+    md.append(f"| {r['project']} | {r['code']} | {r['doc']} | {r['diag']} | {r['test']} | {r['obs']} |")
+path = pathlib.Path("docs/status.md"); path.parent.mkdir(exist_ok=True)
+path.write_text("\n".join(md))
+print("wrote", path)


### PR DESCRIPTION
## Summary
- add a root Makefile with automation targets for demos, evidence, and status rendering
- introduce evidence capture GitHub Action, repo quality gates, and PR/CODEOWNERS metadata
- add demo-day script, release checklist, ADR/RACI templates, and status markdown generator

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b728a09dc8327bc85ce238b7b3c4c)