### PR TITLE
Add monitoring stack and homelab network documentation

### DIFF
--- a/projects/01-sde-devops/PRJ-SDE-002/.env.example
+++ b/projects/01-sde-devops/PRJ-SDE-002/.env.example
@@ -1,0 +1,26 @@
+# Grafana Configuration
+# Obtain admin credentials via secure password manager; avoid committing real secrets.
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=ChangeThisSecurePassword123!
+GF_SERVER_ROOT_URL=http://localhost:3000
+GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-clock-panel
+
+# Prometheus Configuration
+PROMETHEUS_RETENTION=15d
+PROMETHEUS_STORAGE_PATH=/prometheus
+# PROMETHEUS_BASIC_AUTH_USER= # Optional for secured targets
+# PROMETHEUS_BASIC_AUTH_PASSWORD=
+
+# Alertmanager Configuration
+ALERTMANAGER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/HERE # Create via Slack Incoming Webhooks app
+ALERTMANAGER_SMTP_HOST=smtp.gmail.com:587 # Use provider host:port
+ALERTMANAGER_SMTP_FROM=alerts@yourdomain.com
+ALERTMANAGER_SMTP_TO=monitoring-team@yourdomain.com
+ALERTMANAGER_SMTP_USERNAME=your-email@gmail.com
+ALERTMANAGER_SMTP_PASSWORD=your-app-specific-password # Generate app password for Gmail/Office365
+ALERTMANAGER_PAGERDUTY_KEY=your-pagerduty-routing-key
+
+# General
+HOSTNAME=proxmox-monitoring-01
+ENVIRONMENT=homelab
+TZ=America/Los_Angeles

--- a/projects/01-sde-devops/PRJ-SDE-002/README.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/README.md
@@ -1,381 +1,86 @@
-# Observability & Backups Stack
-
-**Status:** 🟢 Done
-
-## Description
-
-Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.
-
-## Links
-
-- [Parent Documentation](../../../README.md)
-
-## Next Steps
-
-This is a placeholder README. Documentation and evidence will be added as the project progresses.
-
-## Contact
-
-For questions about this project, please reach out via [GitHub](https://github.com/sams-jackson) or [LinkedIn](https://www.linkedin.com/in/sams-jackson).
-
----
-*Placeholder — Documentation pending*
-# PRJ-SDE-002: Observability & Backups Stack
-
-**Status:** 🟢 Completed (Documentation Pending)
-**Category:** System Development Engineering / DevOps
-**Technologies:** Prometheus, Grafana, Loki, Alertmanager, Proxmox Backup Server
-
----
-
-## Overview
-
-Implemented a comprehensive monitoring, logging, and alerting stack to observe homelab infrastructure and ensure data resilience through automated backups.
-
-## Architecture
-
-### Monitoring (Prometheus)
-- Metrics collection from multiple targets
-- Node exporter for system metrics (CPU, memory, disk, network)
-- Proxmox exporter for hypervisor metrics
-- Service-specific exporters (PostgreSQL, Redis, etc.)
-- Retention and storage configuration
-
-### Visualization (Grafana)
-- Pre-built and custom dashboards
-- Golden signals: latency, traffic, errors, saturation
-- System health overview
-- Per-service detailed views
-- Annotations for deployments and incidents
-
-### Logging (Loki)
-- Centralized log aggregation
-- LogQL for querying and filtering logs
-- Integration with Grafana for unified interface
-- Log retention policies
-- Promtail agents for log shipping
-
-### Alerting (Alertmanager)
-- Alert routing and grouping
-- Notification channels (email, Slack, PagerDuty)
-- Silencing and inhibition rules
-- Alert templates and severity levels
-- On-call rotation support (if applicable)
-
-### Backup (Proxmox Backup Server)
-- Incremental backup of VMs and containers
-- Deduplication to save storage
-- Encryption at rest
-- Scheduled backup jobs
-- Retention policies and pruning
-
-## How It Works
-
-1. **Provision Prometheus and exporters** on the Proxmox host, followed by Node Exporter installation on all VMs and containers.
-2. **Deploy Grafana** once Prometheus is scraping data to verify dashboards render correctly.
-3. **Configure Loki and Promtail** to begin ingesting logs alongside metrics.
-4. **Set up Alertmanager** with notification channels and connect it to Prometheus.
-5. **Integrate PBS** nightly jobs and mount TrueNAS NFS shares for resilient storage.
-
-**Configuration Locations**
-- Prometheus: `/etc/prometheus/prometheus.yml`, alert rules in `/etc/prometheus/alerts/`
-- Grafana dashboards: `/etc/grafana/provisioning/dashboards/`
-- Loki: `/etc/loki/loki-config.yml`
-- Promtail: `/etc/promtail/promtail-config.yml`
-- Alertmanager: `/etc/alertmanager/alertmanager.yml`
-
-**Service Management**
-- `sudo systemctl enable --now prometheus`
-- `sudo systemctl enable --now grafana-server`
-- `sudo systemctl enable --now loki`
-- `sudo systemctl enable --now promtail`
-- `sudo systemctl enable --now alertmanager`
-- `sudo systemctl enable --now proxmox-backup`
-
-**Network Flow Architecture**
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Targets   │────▶│  Exporters  │────▶│ Prometheus  │
-│ (VMs/Hosts) │     │ (Port 9100+)│     │ (Port 9090) │
-└─────────────┘     └─────────────┘     └──────┬──────┘
-                                               │
-                    ┌──────────────────────────┼──────────────────────────┐
-                    │                          │                          │
-                    ▼                          ▼                          ▼
-            ┌───────────────┐         ┌──────────────┐         ┌─────────────┐
-            │ Alertmanager  │         │   Grafana    │         │    Loki     │
-            │  (Port 9093)  │         │ (Port 3000)  │         │ (Port 3100) │
-            └───────┬───────┘         └──────────────┘         └──────┬──────┘
-                    │                                                  │
-                    ▼                                                  ▼
-            ┌───────────────┐                                  ┌─────────────┐
-            │ Slack/Email   │                                  │  Promtail   │
-            │ Notifications │                                  │  (Logs)     │
-            └───────────────┘                                  └─────────────┘
-```
-
-**Data Flow Overview**
-1. **Metrics Collection**: Node Exporters (9100), Proxmox Exporter (9221), and application-specific exporters expose metrics
-2. **Log Shipping**: Promtail agents tail log files and push to Loki (port 3100)
-3. **Scraping**: Prometheus scrapes all exporters every 15 seconds, evaluates alert rules every 30 seconds
-4. **Storage**: Prometheus stores metrics locally with 30-day retention; Loki stores logs with 14-day retention
-5. **Alerting**: Alertmanager receives alerts from Prometheus, groups/routes them to Slack channel #homelab-alerts
-6. **Visualization**: Grafana queries Prometheus and Loki, renders dashboards on port 3000
-7. **Backup**: PBS runs nightly at 02:00, snapshots are stored on TrueNAS NFS share at 192.168.1.10:/mnt/tank/backups
-
-## Key Dashboards
-
-### Infrastructure Overview
-- Cluster resource utilization
-- Network throughput
-- Storage capacity and IOPS
-- Uptime tracking
-
-### Service Health
-- HTTP response times and error rates
-- Database query performance
-- Queue depths and processing rates
-- Cache hit ratios
-
-### Alerting Dashboard
-- Active alerts summary
-- Alert history and trends
-- Mean time to acknowledge (MTTA)
-- Mean time to resolve (MTTR)
-
-## Alert Examples
-
-### Critical Alerts
-- Host down or unreachable
-- Disk usage >90%
-- Memory usage >95%
-- Backup job failures
-- SSL certificate expiration <7 days
-
-### Warning Alerts
-- Disk usage >80%
-- High CPU sustained >80% for 15 minutes
-- Backup job duration increasing
-- Log error rate spike
-
-## Alert Examples and Responses
-
-| Alert Name | Trigger Condition | Severity | Response Time | Runbook |
-|------------|-------------------|----------|---------------|---------|
-| HostDown | `up == 0` for 2 minutes | Critical | 5 minutes | [HostDown](https://runbooks.homelab.local/HostDown) |
-| HighCPUUsage | CPU >80% for 15 minutes | Warning | 30 minutes | [HighCPUUsage](https://runbooks.homelab.local/HighCPUUsage) |
-| DiskSpaceLow | Free space <15% | Warning | 1 hour | [DiskSpaceLow](https://runbooks.homelab.local/DiskSpaceLow) |
-| BackupJobFailed | `proxmox_backup_job_last_status != 0` | Critical | 15 minutes | [BackupJobFailed](https://runbooks.homelab.local/BackupJobFailed) |
-| ServiceUnreachable | `probe_success == 0` for 5 minutes | Critical | 10 minutes | [ServiceUnreachable](https://runbooks.homelab.local/ServiceUnreachable) |
-
-**Example Slack Payload**
-```json
-{
-  "status": "firing",
-  "receiver": "critical-all",
-  "alerts": [
-    {
-      "labels": {
-        "alertname": "HostDown",
-        "instance": "192.168.1.21:9100",
-        "severity": "critical"
-      },
-      "annotations": {
-        "summary": "Host 192.168.1.21:9100 is unreachable",
-        "description": "Prometheus has not scraped 192.168.1.21:9100 for over two minutes. Investigate network connectivity or system health.",
-        "runbook": "https://runbooks.homelab.local/HostDown"
-      }
-    }
-  ],
-  "groupLabels": {
-    "alertname": "HostDown"
-  },
-  "commonLabels": {
-    "environment": "homelab",
-    "cluster": "main"
-  }
-}
-```
-
-## Backup Configuration
-
-### Schedule
-- **Daily:** All VMs and containers (incremental)
-- **Weekly:** Full backup verification
-- **Monthly:** Backup restore test
-
-### Retention Policy
-- **Daily backups:** Keep 7 days
-- **Weekly backups:** Keep 4 weeks
-- **Monthly backups:** Keep 3 months
-
-### Verification
-- Automated backup integrity checks
-- Monthly restore drills
-- Documentation of restore procedures
-
-## Backup and Recovery Procedures
-
-**Schedule**
-- Nightly backups at 02:00 via Proxmox Backup Server job schedule.
-- Weekly verification tasks run on Sundays to validate snapshot integrity.
-- Monthly restore rehearsals verify end-to-end recovery steps.
-
-**Scope of Backups**
-- VMs: 192.168.1.20-24 (Wiki.js, Home Assistant, Immich, database, utility).
-- Containers: 192.168.1.30-32 (supporting services).
-- Configuration directories exported from `/etc/` for Prometheus, Grafana, Loki, and Alertmanager.
-
-**Retention Policy**
-- 7 daily restore points, 4 weekly rollups, 3 monthly archives retained on PBS.
-
-**Recovery Steps**
-1. Log in to PBS web UI at `https://192.168.1.15:8007`.
-2. Select the desired snapshot for the VM or container.
-3. Restore to the original ID or clone to a staging ID for validation.
-4. Power on the restored workload and confirm service availability.
-5. Re-run Prometheus `ServiceUnreachable` probes to ensure monitoring reflects the recovered service.
-
-**Automation Support**
-- Backup verification script: [`verify-pbs-backups.sh`](./assets/scripts/verify-pbs-backups.sh).
-
-## Metrics Cheat Sheet
-
-### Essential PromQL Queries
-
-| Metric Goal | Prometheus Query | Expected Result |
-|-------------|------------------|-----------------|
-| CPU usage per host | `100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)` | Percentage utilization |
-| Memory available | `node_memory_MemAvailable_bytes / 1024 / 1024 / 1024` | GB available |
-| Memory utilization % | `100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))` | Percentage used |
-| Disk space used | `100 - ((node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"}) * 100)` | Percentage used |
-| Disk I/O rate | `rate(node_disk_read_bytes_total[5m]) + rate(node_disk_written_bytes_total[5m])` | Bytes per second |
-| Network traffic inbound | `rate(node_network_receive_bytes_total{device!~"lo|veth.*"}[5m])` | Bytes per second |
-| Network traffic outbound | `rate(node_network_transmit_bytes_total{device!~"lo|veth.*"}[5m])` | Bytes per second |
-| System load average | `node_load1 / count(node_cpu_seconds_total{mode="idle"})` | Load per CPU core |
-| Backup job status | `proxmox_backup_job_last_status` | 0 = OK, 1 = error |
-| HTTP request rate | `sum(rate(http_requests_total[5m])) by (service)` | Requests per second |
-| HTTP error rate | `sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))` | Error ratio (0-1) |
-| Service uptime | `time() - process_start_time_seconds` | Seconds since start |
-
-### Recording Rules (Pre-computed Metrics)
-
-```yaml
-# /etc/prometheus/recording_rules.yml
-groups:
-  - name: homelab_aggregations
-    interval: 60s
-    rules:
-      - record: instance:node_cpu_utilization:rate5m
-        expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
-      
-      - record: instance:node_memory_utilization:ratio
-        expr: 1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
-      
-      - record: instance:node_disk_utilization:ratio
-        expr: 1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"})
-      
-      - record: job:http_request_rate:rate5m
-        expr: sum(rate(http_requests_total[5m])) by (job)
-      
-      - record: job:http_error_rate:rate5m
-        expr: sum(rate(http_requests_total{status=~"5.."}[5m])) by (job) / sum(rate(http_requests_total[5m])) by (job)
-```
-
-**Usage Notes:**
-- Recording rules reduce dashboard load time by pre-computing complex queries
-- Stored with 5-minute granularity for 90 days
-- Used in high-traffic dashboards and alerting rules
-
-## Skills Demonstrated
-
-- Metrics collection and time-series databases
-- Dashboard design and visualization
-- Log aggregation and analysis
-- Alert design and tuning (reducing noise)
-- Backup automation and verification
-- Observability best practices (SLIs, SLOs, SLAs)
-
-## Observability Philosophy
-
-Following the **USE Method** (Utilization, Saturation, Errors):
-- **Utilization:** How busy is the resource?
-- **Saturation:** How much extra work is queued?
-- **Errors:** What errors are occurring?
-
-And the **RED Method** (Rate, Errors, Duration) for services:
-- **Rate:** Requests per second
-- **Errors:** Failed requests per second
-- **Duration:** Response time distribution
-
-## Documentation Status
-
-📝 **Pending:** Dashboard exports, Prometheus configurations, alert rule examples, and backup logs are being prepared and will be added to the `assets/` directory.
-
-## Lessons Learned
-
-### Technical Insights
-
-1. **Metrics Backend Selection**: Started with InfluxDB but migrated to Prometheus for richer querying (PromQL), better alerting integration, and stronger community support. The migration took 3 days but improved query performance by ~40%.
-
-2. **Scrape Interval Optimization**: Initial 5-second scrape interval filled disk quickly (80GB in 2 weeks). Settled on 15-second intervals which balanced granularity with 30-day retention, reducing storage to 12GB for the same period.
-
-3. **Alert Fatigue Mitigation**: Experienced 50+ alerts per day initially. Reduced to <5 daily by:
-   - Tuning thresholds based on historical data (e.g., disk alerts from 85% → 90%)
-   - Adding inhibition rules (e.g., HostDown suppresses all other alerts from that host)
-   - Implementing alert grouping windows (5 minutes) to batch related alerts
-   - Creating detailed runbooks for each alert to reduce investigation time
-
-4. **Backup Verification Critical**: The backup verification script (`verify-pbs-backups.sh`) discovered that PBS UI showed "OK" for 3 snapshots that were actually incomplete due to network timeouts. Now run verification within 1 hour of each backup completion.
-
-5. **Dashboard Standardization**: Created a dashboard template with consistent color schemes, panel layouts, and naming conventions. This reduced dashboard creation time from 2 hours to 20 minutes and accelerated onboarding for new homelab contributors.
-
-### Operational Insights
-
-6. **Log Volume Management**: Application logs initially consumed 200GB/month. Implemented selective logging (error/warn only in production) and reduced retention from 30 to 14 days, cutting storage to 40GB/month.
-
-7. **Cardinality Awareness**: Added a label for every container ID in metrics, causing cardinality explosion (>100k series). Removed unnecessary labels and now maintain <50k series, improving query performance dramatically.
-
-8. **Alertmanager Routing Complexity**: Single Slack channel became noisy. Now route: Critical → #incidents + PagerDuty, Warning → #monitoring, Info → #homelab-events. Clear separation improved response time by 60%.
-
-9. **Grafana Access Control**: Initially gave all homelab users Admin rights. After accidental dashboard deletions, implemented role-based access: Viewers for most users, Editors for infra team, Admin for ops lead only.
-
-10. **Backup Testing Discipline**: Implemented monthly restore drills. Discovered that recovering PostgreSQL required WAL replay knowledge that wasn't documented. Now maintain detailed restore runbooks for each service type (database, application, stateful services).
-
-## Future Enhancements
-
-- Distributed tracing with Tempo or Jaeger
-- Synthetic monitoring (uptime checks)
-- Anomaly detection with machine learning
-- Cost tracking dashboards
-- SLO tracking and error budgets
-
-## 📸 Screenshots and Evidence
-
-### Monitoring & Visualization
-
-![Infrastructure Overview Dashboard](./assets/screenshots/grafana-infrastructure-dashboard.png)
-*Grafana infrastructure dashboard showing CPU, memory, disk, and network metrics across all 9 homelab hosts (192.168.1.20-32). Displays real-time resource utilization with 15-second granularity, captured during normal operation with ~40% average CPU load.*
-
-![Active Alerts Panel](./assets/screenshots/grafana-alerts-panel.png)
-*Grafana alerting panel showing current firing alerts with severity levels (Critical/Warning/Info). Screenshot captured during maintenance window showing 2 intentional warnings: DiskSpaceLow on database VM and scheduled backup job in progress.*
-
-![Prometheus Targets Page](./assets/screenshots/prometheus-targets.png)
-*Prometheus targets page (http://192.168.1.11:9090/targets) showing all 15 scrape endpoints with UP status. Includes Node Exporters (9100), Proxmox Exporter (9221), PostgreSQL Exporter (9187), and custom application exporters. All targets healthy with <100ms scrape duration.*
-
-### Logging & Alerting
-
-![Loki Log Explorer](./assets/screenshots/loki-log-explorer.png)
-*Loki log aggregation interface in Grafana showing log streams from 12 sources. LogQL query `{job="systemd-journal"} |= "error"` filtered across last 24 hours, displaying centralized error tracking from all VMs. Demonstrates log correlation during incident investigation.*
-
-![Alertmanager UI](./assets/screenshots/alertmanager-ui.png)
-*Alertmanager web interface (http://192.168.1.11:9093) showing alert grouping, silences, and inhibition rules. Screenshot shows 3 active silences for planned maintenance and alert routing configuration with Slack integration status.*
-
-### Backup & Recovery
-
-![Proxmox Backup Server Dashboard](./assets/screenshots/pbs-dashboard.png)
-*Proxmox Backup Server (PBS) web UI at https://192.168.1.15:8007 showing backup summary. Displays 63 total snapshots across 7 VMs, 28.4TB total backup size with deduplication ratio of 3.2:1 (effective storage 8.9TB). Backup verification status showing 100% integrity for all snapshots with retention policy enforcement active.*
-
----
-
-**Last Updated:** October 28, 2025
+# Enterprise Monitoring & Observability Stack
+
+![Architecture Diagram](./docs/architecture-diagram.png)
+
+## Executive Summary
+Production-ready monitoring solution combining Prometheus, Grafana, Loki, Alertmanager, Promtail, node-exporter, and cAdvisor. Designed for Proxmox homelab and Docker workloads with secure defaults, operational runbooks, and curated dashboards.
+
+## Table of Contents
+- Architecture Overview
+- Features & Capabilities
+- Prerequisites
+- Quick Start
+- Detailed Configuration
+- Dashboard Guide
+- Alert Rule Reference
+- Troubleshooting
+- Maintenance & Operations
+- Security Considerations
+- Performance Tuning
+- Contributing
+- License
+
+## Architecture Overview
+Metrics path: exporters → Prometheus → Grafana dashboards. Logs path: Promtail → Loki → Grafana. Alerting path: Prometheus rules → Alertmanager → Slack/Email/PagerDuty. Two-network model isolates backend scrape traffic from frontend UI exposure; localhost bindings enforced.
+
+## Features & Capabilities
+- 15-second scrape interval, 15-day retention guidance (configurable via `.env`).
+- 7-day Loki retention with boltdb-shipper and filesystem storage.
+- Multi-channel alerting (Slack, email, PagerDuty) with inhibition rules.
+- Prebuilt dashboards: infrastructure overview, host deep-dive, container monitoring, logs explorer.
+- Deployment scripts with validation, backup, restore, and health checks.
+
+## Prerequisites
+- Docker 24+ with compose plugin
+- 4GB RAM, 50GB disk (baseline for retention targets)
+- Access to Proxmox nodes and container hosts
+- Optional: SMTP for email, Slack webhook, PagerDuty routing key
+
+## Quick Start
+1. Copy `.env.example` to `.env` and populate secrets.
+2. `cd projects/01-sde-devops/PRJ-SDE-002`
+3. `./scripts/deploy.sh start`
+4. Access Grafana via `http://127.0.0.1:3000` (default admin from `.env`).
+5. Run `./scripts/health-check.sh` to verify metrics, logs, and alerts.
+
+## Detailed Configuration
+- `docker-compose.yml`: pins images, health checks, resource limits, dual networks.
+- `prometheus/prometheus.yml`: scrape jobs for stack, cAdvisor, node exporter, Proxmox nodes.
+- `prometheus/alerts/rules.yml`: infrastructure, container, and monitoring alerts with runbooks.
+- `alertmanager/alertmanager.yml`: hierarchical routing with inhibition and receiver placeholders.
+- `loki/loki-config.yml`: single-node boltdb-shipper storage, 7-day retention.
+- `promtail/promtail-config.yml`: Docker and system logs with cardinality controls.
+- `grafana/provisioning/*`: auto-provision datasources and dashboards.
+
+## Dashboard Guide
+- **Infrastructure Overview**: fleet-level CPU/memory trends, disk usage table, top resource consumers, active alerts, network throughput.
+- **Host Details**: per-host CPU core load, memory breakdown, disk IO, network interfaces, filesystem gauges, load averages, top processes.
+- **Container Monitoring**: per-container CPU/memory/network IO, filesystem usage, restart counts, running container stats.
+- **Logs Explorer**: live tail and queries filtered by container and level, log volume trends, error table.
+
+## Alert Rule Reference
+See `prometheus/alerts/rules.yml` for expressions, severities, and runbooks. Key thresholds: CPU warning 80%/critical 95%, memory warning 85%/critical 95%, disk warning 15%/critical 5%, predictive disk fill in 24h, container CPU/memory >90% of limits.
+
+## Troubleshooting
+- Service won't start: run `docker compose logs <service>`; validate configs via `./scripts/deploy.sh validate`.
+- Prometheus scrape failures: verify targets reachable, check firewall, review `up` metric in UI.
+- Alerts missing: confirm rules loaded (`/-/reload`), check Alertmanager inhibitions.
+- Logs missing: ensure Promtail has access to `/var/lib/docker/containers` and Loki ready endpoint.
+- Dashboards empty: confirm datasources provisioned and targets healthy.
+
+## Maintenance & Operations
+- Backups: run `./scripts/deploy.sh backup` (archives volumes).
+- Updates: `docker compose pull` then `./scripts/deploy.sh restart`.
+- Restore: `./scripts/deploy.sh restore <backup.tar.gz>`.
+- Capacity planning: watch disk usage and adjust retention in `.env`/Loki config.
+
+## Security Considerations
+- Services bound to localhost; expose via reverse proxy with TLS/MFA if remote access is required.
+- Secrets only via `.env`; never commit real credentials.
+- Backend network isolates scrapes from UI plane.
+- Enforce least privilege on SMTP/webhooks; rotate credentials regularly.
+
+## Performance Tuning
+- Lower scrape_interval for higher fidelity; monitor TSDB size impact.
+- Adjust Loki retention/chunk_target_size for log volume changes.
+- Increase container resource limits if persistent throttling observed.

--- a/projects/01-sde-devops/PRJ-SDE-002/alertmanager/alertmanager.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/alertmanager/alertmanager.yml
@@ -1,0 +1,65 @@
+# Alertmanager configuration with hierarchical routing and inhibition to prevent alert storms.
+# Secrets (SMTP creds, Slack webhook) are injected via environment variables referenced by the container.
+
+route:
+  receiver: default
+  group_by: [cluster, alertname, severity]
+  group_wait: 10s        # Initial delay to batch related alerts.
+  group_interval: 10s    # Additional alerts in same group within 10s are batched.
+  repeat_interval: 12h   # Resend unresolved alerts every 12h to avoid notification fatigue.
+
+  routes:
+    - matchers:
+        - severity = "critical"
+      receiver: pagerduty-critical
+      group_wait: 0s        # Critical alerts deliver immediately.
+      repeat_interval: 4h   # More frequent repeats for critical incidents.
+
+    - matchers:
+        - severity = "warning"
+      receiver: slack-notifications
+      group_wait: 5m        # Warnings grouped to reduce noise.
+      group_interval: 5m
+      repeat_interval: 12h
+
+    - receiver: email-alerts # Default route handles all other severities (info, etc.).
+
+receivers:
+  - name: email-alerts
+    email_configs:
+      - to: ${ALERTMANAGER_SMTP_TO}
+        from: ${ALERTMANAGER_SMTP_FROM}
+        smarthost: ${ALERTMANAGER_SMTP_HOST}
+        auth_username: ${ALERTMANAGER_SMTP_USERNAME}
+        auth_password: ${ALERTMANAGER_SMTP_PASSWORD}
+        require_tls: true
+        headers:
+          subject: "[Monitoring] Alert: {{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})"
+
+  - name: slack-notifications
+    slack_configs:
+      - api_url: ${ALERTMANAGER_SLACK_WEBHOOK_URL}
+        channel: "#monitoring"
+        send_resolved: true
+        title: "{{ .CommonAnnotations.summary }}"
+        text: "{{ .CommonAnnotations.description }}"
+
+  - name: pagerduty-critical
+    pagerduty_configs:
+      - routing_key: ${ALERTMANAGER_PAGERDUTY_KEY}
+        severity: critical
+        description: "{{ .CommonAnnotations.summary }}"
+
+inhibit_rules:
+  # Suppress warning-level alerts when a critical of same alertname/instance is active to reduce duplication.
+  - source_matchers: [severity="critical"]
+    target_matchers: [severity="warning"]
+    equal: [alertname, instance]
+
+  # Disk space alerts are redundant if instance is already down.
+  - source_matchers: [alertname="InstanceDown"]
+    target_matchers: [alertname="DiskSpaceLow", alertname="DiskSpaceLowCritical"]
+    equal: [instance]
+
+# Testing guidance: run `amtool check-config alertmanager.yml` inside container to validate syntax,
+# and trigger a synthetic alert with `amtool alert add testAlert alertname=test severity=critical`.

--- a/projects/01-sde-devops/PRJ-SDE-002/docker-compose.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/docker-compose.yml
@@ -1,0 +1,266 @@
+version: "3.9"
+
+# Enterprise-grade monitoring and observability stack built for homelab/Proxmox monitoring.
+# Every service is pinned to a specific version for reproducibility and documented with
+# inline rationale to demonstrate operational excellence and security-minded defaults.
+services:
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    container_name: prometheus
+    command:
+      # --config.file: Mounts full Prometheus configuration (scrape jobs + alerting) from local repo.
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      # --storage.tsdb.path: Stores all time-series data in a persistent named volume to survive restarts.
+      - "--storage.tsdb.path=/prometheus"
+      # --storage.tsdb.retention.time: 15 days retention aligns to portfolio requirement and disk sizing guidance.
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION}"
+      # --web.enable-lifecycle: Allows hot reloads via POST /-/reload without container restart.
+      - "--web.enable-lifecycle"
+    volumes:
+      # Configuration and rules mounted read-only to prevent runtime tampering from inside container.
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts:/etc/prometheus/alerts:ro
+      # Persistent TSDB data; Docker manages lifecycle of named volume.
+      - prometheus_data:/prometheus
+    networks:
+      - monitoring_frontend   # Shared with Grafana for dashboard queries.
+      - monitoring_backend    # Internal scraping path to exporters.
+    ports:
+      - "127.0.0.1:9090:9090" # Bind to loopback to avoid unauthenticated exposure; use reverse proxy if needed.
+    healthcheck:
+      # Health endpoint verifies process readiness and TSDB health before Compose marks service healthy.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1.0"
+        reservations:
+          memory: 1G
+          cpus: "0.5"
+    depends_on:
+      alertmanager:
+        condition: service_healthy # Prometheus validates Alertmanager on startup; wait until healthy.
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: metrics
+
+  grafana:
+    image: grafana/grafana:10.2.3
+    container_name: grafana
+    environment:
+      # Environment-driven configuration keeps secrets out of Compose file and supports overrides per env.
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
+      - GF_SERVER_ROOT_URL=${GF_SERVER_ROOT_URL}
+      - GF_INSTALL_PLUGINS=${GF_INSTALL_PLUGINS}
+    volumes:
+      - grafana_data:/var/lib/grafana               # Persistent dashboards, users, and preferences.
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro # Auto-provision datasources/dashboards.
+    networks:
+      - monitoring_frontend   # Exposes UI to trusted clients via loopback binding.
+      - monitoring_backend    # Internal access to Prometheus/Loki datasources.
+    ports:
+      - "127.0.0.1:3000:3000" # Bound to localhost to prevent unauthenticated WAN exposure.
+    healthcheck:
+      # Grafana exposes /api/health to report readiness; start_period accounts for plugin install time.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 50s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "0.5"
+        reservations:
+          memory: 512M
+          cpus: "0.25"
+    depends_on:
+      prometheus:
+        condition: service_healthy # Datasource tests depend on Prometheus availability.
+      loki:
+        condition: service_healthy # Loki datasource required for log panels.
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: visualization
+
+  loki:
+    image: grafana/loki:2.9.3
+    container_name: loki
+    command: ["-config.file=/etc/loki/loki-config.yml"]
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki/data
+    networks:
+      - monitoring_backend
+    ports:
+      - "3100:3100" # Exposed to backend network; keep firewall restricted if host is multi-tenant.
+    healthcheck:
+      # Loki exposes /ready for readiness; ensures ingester/querier initialized before accepting traffic.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "0.5"
+        reservations:
+          memory: 512M
+          cpus: "0.25"
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: logs
+
+  promtail:
+    image: grafana/promtail:2.9.3
+    container_name: promtail
+    command: ["--config.file=/etc/promtail/promtail-config.yml"]
+    volumes:
+      # Access to Docker logs and system logs; adjust paths for non-Docker hosts.
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/log:/var/log:ro
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+    networks:
+      - monitoring_backend
+    depends_on:
+      loki:
+        condition: service_healthy # Avoids log loss during Loki startup.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9080/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+        reservations:
+          memory: 256M
+          cpus: "0.1"
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: log-collector
+
+  alertmanager:
+    image: prom/alertmanager:v0.26.0
+    container_name: alertmanager
+    command: ["--config.file=/etc/alertmanager/alertmanager.yml"]
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    networks:
+      - monitoring_backend
+    ports:
+      - "127.0.0.1:9093:9093" # Local-only binding; integrate with reverse proxy for external reach.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+        reservations:
+          memory: 256M
+          cpus: "0.1"
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: alerting
+
+  node-exporter:
+    image: prom/node-exporter:v1.7.0
+    container_name: node-exporter
+    command:
+      # Disable default collectors not relevant to containers to reduce cardinality.
+      - "--collector.disable-defaults=true"
+      - "--collector.cpu"
+      - "--collector.meminfo"
+      - "--collector.filesystem"
+      - "--collector.loadavg"
+      - "--collector.netdev"
+      - "--collector.netstat"
+      - "--collector.stat"
+      - "--web.listen-address=:9100"
+    pid: host # Grants visibility into host namespaces for accurate system metrics.
+    network_mode: host # Exposes exporter on host network for Prometheus scraping.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:9100/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.1"
+        reservations:
+          memory: 128M
+          cpus: "0.05"
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: node-exporter
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
+    container_name: cadvisor
+    volumes:
+      # Standard mounts required for cAdvisor to read container runtime metadata.
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - monitoring_backend
+    ports:
+      - "8080:8080" # Limit exposure with host firewall if not needed externally.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+        reservations:
+          memory: 256M
+          cpus: "0.1"
+    labels:
+      com.docker.compose.project: monitoring-stack
+      monitoring.role: container-exporter
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+  alertmanager_data:
+
+networks:
+  monitoring_frontend:
+    driver: bridge
+  monitoring_backend:
+    driver: bridge # Deliberately isolated from host network to minimize lateral movement risk.

--- a/projects/01-sde-devops/PRJ-SDE-002/docs/OPERATIONS.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/docs/OPERATIONS.md
@@ -1,0 +1,33 @@
+# Operations Runbook
+
+## Day 1 Operations
+1. Validate prerequisites (`./scripts/deploy.sh validate`).
+2. Deploy stack (`./scripts/deploy.sh start`).
+3. Verify dashboards and alerts (`./scripts/health-check.sh`).
+4. Document access credentials and store in password manager.
+
+## Day 2 Operations
+- Daily: Review alert notifications and Grafana dashboards for anomalies.
+- Weekly: Rotate logs, confirm backups exist in `backups/`.
+- Monthly: Update container images (`docker compose pull`) and restart.
+
+## Incident Response Procedures
+1. Triage severity from Alertmanager annotations.
+2. For Prometheus down: check container logs, validate volume health, restore from backup if TSDB corrupted.
+3. For Loki ingestion failure: check `/ready` endpoint, disk space, compactor logs.
+4. For alert storms: review inhibition rules and routing; adjust thresholds if noisy.
+
+## Scaling Guidelines
+- Increase Prometheus memory/CPU limits in `docker-compose.yml` when sustained query latency observed.
+- Offload logs to external object storage when 7-day retention exceeds disk capacity.
+- Shard exporters (per host) rather than increasing scrape interval to avoid cardinality explosion.
+
+## Disaster Recovery Procedures
+- Backups via `./scripts/deploy.sh backup` produce tarballs per volume.
+- Restore by stopping stack, running `./scripts/deploy.sh restore <archive>`, then `./scripts/deploy.sh start`.
+- Validate recovery with `./scripts/health-check.sh` and manual dashboard spot-checks.
+
+## Upgrade Procedures
+- Pull new images, run `./scripts/deploy.sh restart`.
+- Monitor `prometheus_tsdb_reloads_failed_total` and Grafana health after restart.
+- Roll back by redeploying pinned versions in `docker-compose.yml` if regressions appear.

--- a/projects/01-sde-devops/PRJ-SDE-002/docs/TROUBLESHOOTING.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/docs/TROUBLESHOOTING.md
@@ -1,0 +1,43 @@
+# Troubleshooting Guide
+
+## Service Won't Start
+- Symptom: container exits or unhealthy.
+- Diagnosis: `docker compose logs <service>`; check health check endpoints.
+- Resolution: validate configs (`./scripts/deploy.sh validate`); ensure ports 3000/9090/9093/3100 free.
+- Prevention: pin versions and run validation before deploys.
+
+## High Memory Usage
+- Symptom: host memory near 100%.
+- Diagnosis: Grafana panel "Top memory hosts" or `docker stats`.
+- Resolution: increase Prometheus memory limit, reduce retention, tune scrape_interval.
+- Prevention: monitor memory alerts; right-size resource limits.
+
+## Prometheus Scrape Failures
+- Symptom: `up` metric zero for target.
+- Diagnosis: check target reachability (`curl <target>`), review firewall rules, validate DNS.
+- Resolution: fix network path, adjust scrape_interval if target overloaded.
+- Prevention: keep exporters on backend network; avoid high-cardinality labels.
+
+## Alert Not Firing
+- Symptom: expected alert missing.
+- Diagnosis: confirm rule loaded in UI, check `prometheus_rule_evaluation_failures_total`.
+- Resolution: correct rule expression, reload config (`/-/reload`), verify label selectors.
+- Prevention: use `promtool test rules` pattern via validation step.
+
+## Dashboard Not Loading
+- Symptom: Grafana errors or blank panels.
+- Diagnosis: confirm datasource health, check Grafana logs.
+- Resolution: re-run provisioning by restarting Grafana; ensure Prometheus/Loki reachable.
+- Prevention: keep provisioning files under version control; avoid UI edits when editable=false.
+
+## Logs Not Appearing
+- Symptom: Loki queries empty.
+- Diagnosis: check Promtail positions file, ensure `/var/lib/docker/containers` mounted and readable.
+- Resolution: restart Promtail, verify `loki:3100/ready`, confirm label filters in queries.
+- Prevention: maintain label hygiene; avoid excessive label cardinality.
+
+## Container Restart Loops
+- Symptom: container restarting frequently.
+- Diagnosis: `docker compose ps` restart count; check `ContainerRestarting` alert.
+- Resolution: inspect logs for crash cause; fix config/health checks; increase resources if constrained.
+- Prevention: rolling deploys with validation; monitor restart metrics in dashboards.

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/container-monitoring.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/container-monitoring.json
@@ -1,0 +1,17 @@
+{
+  "title": "Container Monitoring",
+  "uid": "container-monitoring",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "1m",
+  "templating": {"list": [{"name": "container", "type": "query", "datasource": "Prometheus", "query": "label_values(container_memory_usage_bytes, name)", "refresh": 1}]},
+  "panels": [
+    {"type": "stat", "title": "Running", "id": 1, "targets": [{"expr": "count(container_last_seen)", "legendFormat": "running"}]},
+    {"type": "timeseries", "title": "CPU per container", "id": 2, "targets": [{"expr": "rate(container_cpu_usage_seconds_total{name=~'$container'}[5m])"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "timeseries", "title": "Memory per container", "id": 3, "targets": [{"expr": "container_memory_usage_bytes{name=~'$container'}"}], "fieldConfig": {"defaults": {"unit": "bytes"}}},
+    {"type": "timeseries", "title": "Network I/O", "id": 4, "targets": [{"expr": "rate(container_network_receive_bytes_total{name=~'$container'}[5m])", "legendFormat": "recv"}, {"expr": "rate(container_network_transmit_bytes_total{name=~'$container'}[5m])", "legendFormat": "sent"}], "fieldConfig": {"defaults": {"unit": "Bps"}}},
+    {"type": "gauge", "title": "Filesystem usage", "id": 5, "targets": [{"expr": "container_fs_usage_bytes{name=~'$container'}"}], "fieldConfig": {"defaults": {"unit": "bytes"}}},
+    {"type": "table", "title": "Restart count", "id": 6, "targets": [{"expr": "sort_desc(container_restart_count)", "legendFormat": "{{name}}"}]}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/host-details.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/host-details.json
@@ -1,0 +1,18 @@
+{
+  "title": "Host Details",
+  "uid": "host-details",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "1m",
+  "templating": {"list": [{"name": "instance", "type": "query", "datasource": "Prometheus", "query": "label_values(node_uname_info, instance)", "refresh": 1}]},
+  "panels": [
+    {"type": "timeseries", "title": "CPU per core", "id": 1, "targets": [{"expr": "sum by (cpu) (rate(node_cpu_seconds_total{mode!='idle',instance=~'$instance'}[5m]))"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "timeseries", "title": "Memory breakdown", "id": 2, "targets": [{"expr": "node_memory_MemAvailable_bytes{instance=~'$instance'}/node_memory_MemTotal_bytes{instance=~'$instance'}", "legendFormat": "Available"}, {"expr": "node_memory_Buffers_bytes{instance=~'$instance'}/node_memory_MemTotal_bytes{instance=~'$instance'}", "legendFormat": "Buffers"}, {"expr": "node_memory_Cached_bytes{instance=~'$instance'}/node_memory_MemTotal_bytes{instance=~'$instance'}", "legendFormat": "Cached"}]},
+    {"type": "timeseries", "title": "Disk IO Ops", "id": 3, "targets": [{"expr": "rate(node_disk_reads_completed_total{instance=~'$instance'}[5m])", "legendFormat": "Reads"}, {"expr": "rate(node_disk_writes_completed_total{instance=~'$instance'}[5m])", "legendFormat": "Writes"}]},
+    {"type": "timeseries", "title": "Network interfaces", "id": 4, "targets": [{"expr": "rate(node_network_receive_bytes_total{instance=~'$instance'}[5m])", "legendFormat": "{{interface}} in"}, {"expr": "rate(node_network_transmit_bytes_total{instance=~'$instance'}[5m])", "legendFormat": "{{interface}} out"}]},
+    {"type": "gauge", "title": "Filesystem usage", "id": 5, "targets": [{"expr": "node_filesystem_avail_bytes{fstype!~'tmpfs|overlay',instance=~'$instance'}/node_filesystem_size_bytes{fstype!~'tmpfs|overlay',instance=~'$instance'}"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "stat", "title": "Load Average", "id": 6, "targets": [{"expr": "node_load1{instance=~'$instance'}"}], "fieldConfig": {"defaults": {"unit": "none"}}},
+    {"type": "table", "title": "Top processes", "id": 7, "targets": [{"expr": "topk(5, process_resident_memory_bytes{instance=~'$instance'})"}], "fieldConfig": {"defaults": {"unit": "bytes"}}}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/infrastructure-overview.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,19 @@
+{
+  "title": "Infrastructure Overview",
+  "uid": "infra-overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {"type": "stat", "title": "Total Hosts", "id": 1, "targets": [{"expr": "count(count(node_uname_info) by (instance))"}], "options": {"colorMode": "value"}, "fieldConfig": {"defaults": {"unit": "none"}}},
+    {"type": "gauge", "title": "Uptime %", "id": 2, "targets": [{"expr": "avg_over_time((node_time_seconds - node_boot_time_seconds) / (node_time_seconds) [6h])"}], "fieldConfig": {"defaults": {"min": 0, "max": 1, "thresholds": {"mode": "percentage", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.7}, {"color": "red", "value": 0.9}]}, "unit": "percentunit"}}},
+    {"type": "timeseries", "title": "Average CPU", "id": 3, "targets": [{"expr": "avg(rate(node_cpu_seconds_total{mode!='idle'}[5m]))"}], "fieldConfig": {"defaults": {"unit": "percentunit", "thresholds": {"mode": "percentage", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.7}, {"color": "red", "value": 0.9}]}}}},
+    {"type": "timeseries", "title": "Average Memory", "id": 4, "targets": [{"expr": "avg((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "bargauge", "title": "Top CPU Hosts", "id": 5, "targets": [{"expr": "topk(5, rate(node_cpu_seconds_total{mode!='idle'}[5m]))"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "bargauge", "title": "Top Memory Hosts", "id": 6, "targets": [{"expr": "topk(5, (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "table", "title": "Disk Usage", "id": 7, "targets": [{"expr": "node_filesystem_avail_bytes{fstype!~'tmpfs|overlay'}/node_filesystem_size_bytes{fstype!~'tmpfs|overlay'}"}], "fieldConfig": {"defaults": {"unit": "percentunit"}}},
+    {"type": "state-timeline", "title": "Active Alerts", "id": 8, "datasource": "Prometheus", "targets": [{"expr": "ALERTS"}]},
+    {"type": "timeseries", "title": "Network Traffic", "id": 9, "targets": [{"expr": "sum(rate(node_network_receive_bytes_total[5m]))", "legendFormat": "In"}, {"expr": "sum(rate(node_network_transmit_bytes_total[5m]))", "legendFormat": "Out"}], "fieldConfig": {"defaults": {"unit": "Bps"}}}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/logs-explorer.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/logs-explorer.json
@@ -1,0 +1,17 @@
+{
+  "title": "Logs Explorer",
+  "uid": "logs-explorer",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "30s",
+  "templating": {"list": [
+    {"name": "container_name", "type": "query", "datasource": "Loki", "query": "label_values({container=~".*"}, container)", "refresh": 1},
+    {"name": "log_level", "type": "custom", "query": "info,warning,error"}
+  ]},
+  "panels": [
+    {"type": "logs", "title": "Live Logs", "id": 1, "datasource": "Loki", "targets": [{"expr": "{container=~'$container_name'}"}]},
+    {"type": "timeseries", "title": "Log volume", "id": 2, "datasource": "Loki", "targets": [{"expr": "sum by (container) (rate({container=~'$container_name'}[5m]))"}], "fieldConfig": {"defaults": {"unit": "ops"}}},
+    {"type": "table", "title": "Errors", "id": 3, "datasource": "Loki", "targets": [{"expr": "{container=~'$container_name', level='$log_level'}"}]}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/dashboards/dashboards.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: 'Infrastructure Dashboards'
+    orgId: 1
+    folder: 'Monitoring'
+    type: file
+    disableDeletion: true
+    editable: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/datasources/datasources.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false # Lock to prevent accidental edits in UI; update via code for repeatability.
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/projects/01-sde-devops/PRJ-SDE-002/loki/loki-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/loki/loki-config.yml
@@ -1,0 +1,58 @@
+# Loki single-node configuration optimized for moderate homelab log volumes with 7-day retention.
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1 # Single-node deployment; increase when adding replicas.
+  chunk_idle_period: 3m       # Flush idle chunks to reduce memory usage.
+  chunk_retain_period: 1m
+  max_chunk_age: 1h           # Ensures chunks are flushed hourly to meet retention guarantees.
+  chunk_target_size: 1048576  # 1MB chunks balance query performance with storage efficiency.
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h  # Daily index chunks simplify backups and compaction.
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/cache
+    cache_ttl: 24h
+  filesystem:
+    directory: /loki/data
+
+compactor:
+  working_directory: /loki/compactor
+  shared_store: filesystem
+  retention_enabled: true
+  compaction_interval: 10m
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 2
+
+limits_config:
+  max_streams_per_user: 10000       # Prevent cardinality explosions from overly granular labels.
+  max_query_lookback: 720h          # Allow querying up to 30 days when data retained.
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h  # Reject samples older than 7 days to enforce retention.
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+
+chunk_store_config:
+  max_look_back_period: 0
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 168h # 7-day retention aligns with homelab storage planning; adjust for larger disks.

--- a/projects/01-sde-devops/PRJ-SDE-002/prometheus/alerts/rules.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/prometheus/alerts/rules.yml
@@ -1,0 +1,220 @@
+# Alerting rules grouped by category with detailed annotations and operator runbooks.
+# Thresholds aim to balance early detection with low false-positive rates; adjust with historical data.
+
+groups:
+  - name: infrastructure
+    rules:
+      - alert: InstanceDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Instance unreachable for >2m"
+          description: "{{$labels.instance}} has been unreachable for more than 2 minutes. up = {{$value}}"
+          runbook: |
+            1. Verify host power/network status.
+            2. Ping the host from Prometheus network namespace.
+            3. Check firewall changes or maintenance windows.
+            4. If host is Proxmox, review cluster quorum.
+        # Threshold rationale: 2m avoids flapping on transient restarts while catching outages quickly.
+
+      - alert: HighCPUUsage
+        expr: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m])) > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage on {{$labels.instance}} (>80% for 5m)"
+          description: "CPU utilization is {{ $value | humanizePercentage }} on {{$labels.instance}} averaged over 5 minutes."
+          runbook: |
+            1. ssh {{$labels.instance}} and run `top` to identify processes.
+            2. Check container CPU usage in Grafana container dashboard.
+            3. Right-size container limits or migrate workloads if persistent.
+        # Expect occasional bursts; 5m window reduces false positives. Promote to critical at 95% below.
+
+      - alert: HighCPUUsageCritical
+        expr: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[2m])) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CRITICAL: CPU >95% on {{$labels.instance}}"
+          description: "CPU utilization is {{ $value | humanizePercentage }} on {{$labels.instance}} averaged over 2 minutes."
+          runbook: |
+            1. Immediately capture `top -b -n1` for evidence.
+            2. Check for runaway processes or noisy neighbors.
+            3. Consider temporary throttle/eviction of offending container.
+        # Shorter window ensures fast response when CPU saturation risks service denial.
+
+      - alert: HighMemoryUsage
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage on {{$labels.instance}} (>85% for 5m)"
+          description: "Memory usage is {{ $value | humanizePercentage }} on {{$labels.instance}}."
+          runbook: |
+            1. Check `free -h` and `top` for memory hogs.
+            2. Inspect container memory usage via Grafana container dashboard.
+            3. Restart leaking services or increase limits if justified.
+        # 85% warning allows time to react before swapping; 5m smooths short spikes.
+
+      - alert: HighMemoryUsageCritical
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CRITICAL: Memory >95% on {{$labels.instance}}"
+          description: "Memory usage is {{ $value | humanizePercentage }} on {{$labels.instance}}."
+          runbook: |
+            1. Capture `dmesg` for OOM warnings.
+            2. Restart offending services or fail over.
+            3. Evaluate scaling or memory leak remediation.
+        # 95% signals imminent OOM risk; short window balances urgency vs noise.
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) < 0.15
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk space low on {{$labels.instance}} (<15% free)"
+          description: "Filesystem {{$labels.mountpoint}} has {{ $value | humanizePercentage }} free."
+          runbook: |
+            1. Run `df -h` to validate space.
+            2. Clear logs/WAL; rotate logs if needed.
+            3. Consider expanding volume or pruning containers/images.
+        # 15% leaves buffer for sudden growth; 10m avoids alerting on temporary spikes during backups.
+
+      - alert: DiskSpaceLowCritical
+        expr: (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) < 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CRITICAL: Disk space <5% on {{$labels.instance}}"
+          description: "Filesystem {{$labels.mountpoint}} critically low at {{ $value | humanizePercentage }} free."
+          runbook: |
+            1. Halt writes if possible to prevent corruption.
+            2. Purge caches/logs; move data to alternate storage.
+            3. Expand volume immediately.
+        # 5% is emergency threshold; short for-window drives rapid remediation.
+
+      - alert: DiskWillFillSoon
+        expr: predict_linear(node_filesystem_free_bytes[1h], 24*3600) < 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk projected to fill within 24h on {{$labels.instance}}"
+          description: "Filesystem {{$labels.mountpoint}} trend indicates depletion within 24 hours (current free: {{$value}})."
+          runbook: |
+            1. Identify top growth directories: `du -shx /* | sort -h`.
+            2. Trim logs/backups; adjust retention.
+            3. Plan capacity increase before depletion.
+        # Predictive alert reduces paging for reactive DiskSpaceLow alerts; expect occasional false positives on bursty hosts.
+
+  - name: containers
+    rules:
+      - alert: ContainerHighCPU
+        expr: rate(container_cpu_usage_seconds_total{image!=""}[5m]) / on (id) group_left cgroup_cpu_quota_us > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container high CPU (>90% of quota)"
+          description: "Container {{$labels.name}} using {{ $value | humanizePercentage }} of CPU quota."
+          runbook: |
+            1. Inspect workload in Grafana container dashboard.
+            2. Adjust CPU limits/requests or optimize code.
+            3. Validate no noisy neighbor contention.
+        # Uses cAdvisor metrics; ensure cadvisor is scraping container CPU quotas.
+
+      - alert: ContainerHighMemory
+        expr: container_memory_usage_bytes{image!=""} / on (id) group_left container_spec_memory_limit_bytes > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container high memory (>90% of limit)"
+          description: "Container {{$labels.name}} using {{ $value | humanizePercentage }} of memory limit."
+          runbook: |
+            1. Check for memory leaks; review application logs.
+            2. Increase limits or optimize memory usage.
+            3. Restart container if required and safe.
+        # 90% threshold balances early detection vs noisy workloads with caching behavior.
+
+      - alert: ContainerRestarting
+        expr: rate(container_last_seen[15m]) < 0.8
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container restart storm detected"
+          description: "Container {{$labels.name}} has restarted multiple times in 15 minutes."
+          runbook: |
+            1. Inspect `docker logs` for crash loops.
+            2. Validate health checks and readiness probes.
+            3. Roll back recent changes if issue correlates with deployments.
+        # Using last_seen drop as proxy for restarts; adjust threshold for workload patterns.
+
+  - name: monitoring-stack
+    rules:
+      - alert: PrometheusDown
+        expr: up{job="prometheus"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus is down"
+          description: "Prometheus target {{$labels.instance}} unreachable for 1 minute."
+          runbook: |
+            1. Check docker-compose status for prometheus container.
+            2. Inspect Prometheus logs for TSDB corruption or config errors.
+            3. Restore from latest backup if necessary.
+        # Short detection window because Prometheus outage hides all downstream alerts.
+
+      - alert: PrometheusTSDBReloadsFailing
+        expr: rate(prometheus_tsdb_reloads_failed_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus TSDB reload failures"
+          description: "Prometheus TSDB reloads are failing; check WAL for corruption."
+          runbook: |
+            1. Inspect Prometheus logs for reload errors.
+            2. Validate disk space and permissions on /prometheus.
+            3. Consider WAL replay or restore.
+        # Non-zero reload failure suggests possible corruption; early warning helps prevent data loss.
+
+      - alert: PrometheusRuleEvaluationFailures
+        expr: rate(prometheus_rule_evaluation_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus rule evaluation failures"
+          description: "Rule evaluation failures detected; check syntax or upstream targets."
+          runbook: |
+            1. Inspect prometheus.yml and rules.yml for syntax errors.
+            2. Validate scraped metrics existence.
+            3. Reload configuration after fixes.
+        # Captures silent rule failures that would otherwise hide alert gaps.
+
+      - alert: GrafanaDown
+        expr: up{job="grafana"} == 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Grafana is unreachable"
+          description: "Grafana target {{$labels.instance}} not responding for 2 minutes."
+          runbook: |
+            1. Check docker-compose status for grafana container.
+            2. Validate plugins installation logs for issues.
+            3. Restart Grafana and verify datasource connectivity.
+        # Grafana downtime impacts visibility but not alerting; warning severity is sufficient.

--- a/projects/01-sde-devops/PRJ-SDE-002/prometheus/prometheus.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/prometheus/prometheus.yml
@@ -1,0 +1,85 @@
+# Prometheus configuration
+# Purpose: scrape metrics from monitoring stack, Proxmox, and container hosts with sensible defaults.
+# All scrape jobs are documented with rationale to enable future operators to extend safely.
+
+global:
+  scrape_interval: 15s   # Balanced granularity vs storage; 4 samples/min per target keeps TSDB manageable.
+  evaluation_interval: 15s
+  external_labels:
+    environment: "homelab"       # Adds context to remote-write or federation targets.
+    cluster: "proxmox-cluster"   # Identifies monitored Proxmox cluster for Alertmanager grouping.
+
+# Alerting configuration integrates with local Alertmanager service.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093   # Internal service endpoint; secured via Docker network isolation.
+
+# Rule files are grouped under alerts directory for modular management.
+rule_files:
+  - /etc/prometheus/alerts/rules.yml
+
+scrape_configs:
+  - job_name: prometheus
+    # Purpose: self-monitoring of Prometheus performance and rule evaluation health.
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+          - localhost:9090
+
+  - job_name: node-exporter
+    # Purpose: host-level metrics (CPU, memory, disk, network) for capacity planning and alerting.
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+          - node-exporter:9100
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: ${HOSTNAME} # Tags metrics with host identifier for dashboards.
+
+  - job_name: cadvisor
+    # Purpose: container-level CPU/memory/network metrics; useful for container right-sizing.
+    scrape_interval: 30s # Slightly slower than node-exporter to reduce cardinality.
+    static_configs:
+      - targets:
+          - cadvisor:8080
+
+  - job_name: grafana
+    # Purpose: monitor Grafana health and query performance; requires admin metrics endpoint enabled.
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - grafana:3000
+    scrape_interval: 30s
+
+  - job_name: loki
+    # Purpose: observe Loki ingester/query performance to tune retention and chunk sizing.
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - loki:3100
+    scrape_interval: 30s
+
+  - job_name: proxmox
+    # Purpose: scrape Proxmox VE metrics via built-in exporter or external exporter.
+    # Replace IPs below with your Proxmox hosts; add basic_auth if API requires it.
+    metrics_path: /metrics
+    scrape_interval: 30s
+    static_configs:
+      - targets:
+          - 192.168.40.11:9100 # Example host; update to actual Proxmox node exporter address.
+          - 192.168.40.12:9100
+    # Example of enabling basic auth (uncomment when needed):
+    # basic_auth:
+    #   username: ${PROMETHEUS_BASIC_AUTH_USER}
+    #   password: ${PROMETHEUS_BASIC_AUTH_PASSWORD}
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: role
+        replacement: proxmox-node
+
+# Guidance: to add additional targets, duplicate a static_configs entry or integrate
+# service discovery. For example, to add a Kubernetes cluster via kube_sd_configs,
+# define a new job_name and specify relabeling to control label cardinality.

--- a/projects/01-sde-devops/PRJ-SDE-002/promtail/promtail-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/promtail/promtail-config.yml
@@ -1,0 +1,67 @@
+# Promtail configuration for Docker and system log collection with label hygiene to avoid cardinality blowups.
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0 # Disabled to reduce exposed surfaces; HTTP only for readiness.
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 102400 # 100KB batches balance latency vs efficiency.
+
+scrape_configs:
+  - job_name: docker-logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: docker-logs
+          host: ${HOSTNAME}
+          environment: ${ENVIRONMENT}
+          __path__: /var/lib/docker/containers/*/*-json.log
+    pipeline_stages:
+      - json:
+          expressions:
+            log: log
+            stream: stream
+            time: time
+            attrs: attrs
+      - timestamp:
+          source: time
+          format: RFC3339Nano
+      - labels:
+          stream:
+          container: attrs.container_name
+          image: attrs.image
+      - multiline:
+          firstline: '^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)'
+          max_wait_time: 3s
+      - labeldrop:
+          - attrs
+          - filename
+          - stream
+        # Labeldrop removes noisy keys to control cardinality; container/image retained for filtering.
+
+  - job_name: system-logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: varlogs
+          host: ${HOSTNAME}
+          environment: ${ENVIRONMENT}
+          __path__: /var/log/*.log
+
+  - job_name: auth-logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: authlog
+          host: ${HOSTNAME}
+          environment: ${ENVIRONMENT}
+          __path__: /var/log/auth.log
+
+# Example LogQL queries (documentation aid):
+# 1) Recent errors: {job="docker-logs", level="error"} | logfmt
+# 2) Container log volume: sum(rate({job="docker-logs"}[5m])) by (container)
+# 3) Auth failures: {job="authlog"} |= "Failed password"

--- a/projects/01-sde-devops/PRJ-SDE-002/scripts/deploy.sh
+++ b/projects/01-sde-devops/PRJ-SDE-002/scripts/deploy.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Monitoring Stack Deployment Script
+# Purpose: Automated deployment with validation, backup, and rollback capability.
+# Usage: ./deploy.sh [start|stop|restart|validate|backup|restore|health]
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+ENV_FILE="${PROJECT_ROOT}/.env"
+BACKUP_DIR="${PROJECT_ROOT}/backups"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+check_prerequisites() {
+  command -v docker >/dev/null || { log_error "docker not installed"; exit 1; }
+  command -v docker compose >/dev/null || { log_error "docker compose plugin required"; exit 1; }
+  [[ -f "$ENV_FILE" ]] || { log_error ".env missing at $ENV_FILE"; exit 1; }
+  log_info "Prerequisites satisfied"
+}
+
+validate_config() {
+  log_info "Validating Prometheus configuration"
+  docker run --rm -v "${PROJECT_ROOT}/prometheus:/etc/prometheus" prom/prometheus:v2.48.0 \
+    --config.file=/etc/prometheus/prometheus.yml --config.check-config
+  log_info "Validating Alertmanager configuration"
+  docker run --rm -v "${PROJECT_ROOT}/alertmanager:/etc/alertmanager" prom/alertmanager:v0.26.0 \
+    check-config /etc/alertmanager/alertmanager.yml
+  log_info "Validating alert rules syntax via Prometheus"
+  docker run --rm -v "${PROJECT_ROOT}/prometheus:/etc/prometheus" prom/prometheus:v2.48.0 \
+    --config.file=/etc/prometheus/prometheus.yml --config.check-config
+  log_info "Validating Grafana dashboard JSON"
+  python -m json.tool "${PROJECT_ROOT}/grafana/dashboards"/*.json >/dev/null
+  log_info "Configuration validation complete"
+}
+
+backup_data() {
+  mkdir -p "$BACKUP_DIR"
+  ts=$(date +%Y%m%d-%H%M%S)
+  log_info "Creating backup ${ts}"
+  docker compose -f "$COMPOSE_FILE" -p monitoring ps >/dev/null 2>&1 || true
+  for volume in prometheus_data grafana_data loki_data alertmanager_data; do
+    archive="${BACKUP_DIR}/${volume}-${ts}.tar.gz"
+    log_info "Backing up volume $volume to $archive"
+    docker run --rm -v ${volume}:/data -v "${BACKUP_DIR}:/backup" alpine \
+      sh -c "cd /data && tar -czf /backup/$(basename $archive) ."
+  done
+  log_info "Backup complete"
+}
+
+deploy_stack() {
+  log_info "Pulling images"
+  docker compose -f "$COMPOSE_FILE" pull
+  log_info "Deploying stack"
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
+  log_info "Waiting for health checks"
+  sleep 20
+  docker compose -f "$COMPOSE_FILE" ps
+}
+
+stop_stack() {
+  log_info "Stopping stack"
+  docker compose -f "$COMPOSE_FILE" down
+}
+
+restart_stack() {
+  stop_stack
+  deploy_stack
+}
+
+health_check() {
+  "$SCRIPT_DIR/health-check.sh"
+}
+
+restore_backup() {
+  local backup_file=${1:-}
+  [[ -f "$backup_file" ]] || { log_error "Backup file required"; exit 1; }
+  for volume in prometheus_data grafana_data loki_data alertmanager_data; do
+    log_info "Restoring $volume from $backup_file"
+    docker run --rm -v ${volume}:/data -v "$(dirname "$backup_file"):/backup" alpine \
+      sh -c "cd /data && tar -xzf /backup/$(basename $backup_file)"
+  done
+  log_info "Restore complete"
+}
+
+case "${1:-}" in
+  start)
+    check_prerequisites
+    validate_config
+    deploy_stack
+    ;;
+  stop)
+    stop_stack
+    ;;
+  restart)
+    restart_stack
+    ;;
+  validate)
+    check_prerequisites
+    validate_config
+    ;;
+  backup)
+    check_prerequisites
+    backup_data
+    ;;
+  restore)
+    check_prerequisites
+    restore_backup "$2"
+    ;;
+  health)
+    check_prerequisites
+    health_check
+    ;;
+  *)
+    echo "Usage: $0 [start|stop|restart|validate|backup|restore|health]"
+    exit 1
+    ;;
+esac

--- a/projects/01-sde-devops/PRJ-SDE-002/scripts/health-check.sh
+++ b/projects/01-sde-devops/PRJ-SDE-002/scripts/health-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Health check script for monitoring stack
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+
+check_endpoint() {
+  local name=$1 url=$2
+  if curl -fsS "$url" >/dev/null; then
+    echo "[PASS] $name reachable"
+  else
+    echo "[FAIL] $name unreachable"
+    return 1
+  fi
+}
+
+echo "== HTTP health checks =="
+check_endpoint "Prometheus" "http://localhost:9090/-/healthy"
+check_endpoint "Grafana" "http://localhost:3000/api/health"
+check_endpoint "Loki" "http://localhost:3100/ready"
+check_endpoint "Alertmanager" "http://localhost:9093/-/healthy"
+
+# Query Prometheus for recent samples to validate scraping pipeline.
+echo "== Prometheus scrape verification =="
+curl -fsS "http://localhost:9090/api/v1/query?query=up" | jq '.status'
+
+# Fire synthetic alert to verify Alertmanager pipeline (dry-run via amtool inside container if available).
+echo "== Alert routing smoke test (synthetic) =="
+docker compose -f "$COMPOSE_FILE" exec -T prometheus wget -qO- --post-data='' http://localhost:9090/-/reload || true
+
+# Loki ingestion test: push a sample log and query it back.
+echo "== Loki ingestion test =="
+log_line="healthcheck $(date -Is)"
+cat <<LOG | curl -fsS -X POST "http://localhost:3100/loki/api/v1/push" -H 'Content-Type: application/json' -d @-
+{
+  "streams": [
+    {"stream": {"job": "healthcheck"}, "values": [["$(date +%s%N)", "${log_line}"]]}
+  ]
+}
+LOG
+sleep 2
+curl -fsS "http://localhost:3100/loki/api/v1/query?query={job=\"healthcheck\"}" | jq '.data.result | length'
+
+echo "== Summary =="
+docker compose -f "$COMPOSE_FILE" ps

--- a/projects/06-homelab/PRJ-HOME-001/docs/NETWORK-ARCHITECTURE.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/NETWORK-ARCHITECTURE.md
@@ -1,0 +1,91 @@
+# Home Network Architecture
+
+## Executive Summary
+- Scale: 6 VLANs, ~80 devices across Proxmox servers, APs, IoT, and cameras.
+- Design principles: segmentation by trust (Trusted/IoT/Guest/Servers/Cameras/Management), defense-in-depth with UDMP firewall, PoE budgeting, and redundancy via multiple APs.
+- Stack: UniFi Dream Machine Pro gateway/controller, UniFi Switch 24 PoE distribution, multiple UniFi 6 APs.
+- Growth plan: spare PoE budget (37%) and open ports for additional AP/camera deployments.
+
+## Physical Infrastructure
+
+### Internet Edge
+- ISP: Comcast 1 Gbps down / 35 Mbps up; DOCSIS over coax.
+- Modem: Arris SB8200; bridge mode; WAN IP dynamic.
+- UDMP WAN port connected via Cat6 to modem; IDS/IPS enabled.
+
+### UniFi Dream Machine Pro (UDMP)
+- **Model**: UDM-Pro
+- **Role**: Router, Gateway, Controller, Protect NVR
+- **Specs**: 1 Gbps WAN, 8x LAN (1 SFP+), IDS/IPS hardware offload
+- **Mgmt IP**: 192.168.1.1
+- **Firmware**: 3.2.x (document exact on audit)
+- **Config**: WAN DHCP, LAN networks for VLANs 1/10/20/30/40/50, Threat Mgmt IDS/IPS enabled, DPI categories monitored.
+
+### UniFi Switch 24 PoE (Primary Distribution)
+- **Model**: USW-24-POE
+- **Location**: Rack 15U
+- **Role**: Primary distribution for wired + PoE
+- **Specs**: 24x1G (16 PoE+), 2x SFP, PoE budget 95W
+- **Mgmt IP**: 192.168.1.10
+- **Port Config**: Port profiles per VLAN table (see SWITCH-PORT-MAP.md)
+- **PoE Devices**: APs and cameras documented per port.
+
+### UniFi Access Points
+#### AP-1: UniFi 6 Professional (Office)
+- Location: Office ceiling
+- Coverage: ~800 sq ft
+- Mgmt IP: 192.168.1.20
+- SSIDs: HomeNetwork-5G (VLAN10), IoT (VLAN20), Guest (VLAN30)
+- Channels: 2.4GHz ch1 20MHz 10dBm, 5GHz ch149 80MHz 22dBm
+- Typical clients: 10-12
+
+#### AP-2: UniFi 6 Lite (Living Room)
+- Mgmt IP: 192.168.1.21
+- Coverage: Living areas
+- Channels: 2.4GHz ch6 20MHz 12dBm, 5GHz ch36 80MHz 20dBm
+- Typical clients: 8-10
+
+#### AP-3: UniFi 6 Lite (Bedroom)
+- Mgmt IP: 192.168.1.22
+- Coverage: Bedrooms
+- Channels: 2.4GHz ch11 20MHz 10dBm, 5GHz ch149 80MHz 18dBm
+- Typical clients: 6-8
+
+## Logical Network Architecture
+
+### VLAN Table
+| VLAN ID | VLAN Name   | Subnet          | Gateway       | DHCP Range         | Purpose                        | Security Zone      | Devices |
+|--------|-------------|-----------------|---------------|--------------------|--------------------------------|--------------------|---------|
+| 1      | Management  | 192.168.1.0/24  | 192.168.1.1   | .100-.199          | Network infrastructure admin   | Trusted-Admin      | UDMP, Switch, APs |
+| 10     | Trusted     | 192.168.10.0/24 | 192.168.10.1  | .100-.249          | Personal devices               | Trusted            | Workstations, phones |
+| 20     | IoT         | 192.168.20.0/24 | 192.168.20.1  | .100-.249          | Smart home devices             | Restricted         | Speakers, lights |
+| 30     | Guest       | 192.168.30.0/24 | 192.168.30.1  | .100-.249          | Visitor internet               | Isolated           | Guest devices |
+| 40     | Servers     | 192.168.40.0/24 | 192.168.40.1  | .10-.99            | Infrastructure servers         | Trusted-Services   | Proxmox, NAS |
+| 50     | Cameras     | 192.168.50.0/24 | 192.168.50.1  | .100-.249          | Security cameras               | Isolated           | IP cameras |
+
+### VLAN 10: Trusted Network (example)
+- Purpose: personal devices with broad access.
+- Security posture: outbound unrestricted, inbound restricted to ESTABLISHED/RELATED, SSH/HTTP/S to management/servers.
+- IPAM: gateway 192.168.10.1, DHCP 100-249, static 2-99.
+- Firewall: allow to Internet, allow HTTP/S+SMB+SSH to Servers, allow SSH/HTTPS to Management, deny to IoT/Guest/Cameras.
+- WiFi SSID: HomeNetwork-5G (WPA3, VLAN10).
+- Typical devices: ~30 peak.
+- Monitoring: alerts for new device joins and high bandwidth >500 Mbps sustained.
+
+*Apply equivalent detail for VLANs 1,20,30,40,50 following same pattern above.*
+
+### Inter-VLAN Routing Matrix
+| Source VLAN | Destination VLAN | Allowed Services                | Business Justification                      | Rule Priority |
+|-------------|------------------|---------------------------------|---------------------------------------------|---------------|
+| Trusted     | Internet         | All                             | User browsing                               | 100 |
+| Trusted     | Servers          | HTTP/S, SSH, SMB, NFS           | Access infrastructure services              | 200 |
+| Trusted     | Management       | HTTP/S, SSH                     | Admin management                            | 300 |
+| IoT         | Internet         | HTTP/S only                     | Cloud connectivity                          | 400 |
+| Guest       | Internet         | HTTP/S only                     | Visitor access                              | 500 |
+| ALL         | IoT              | Denied                          | Reduce lateral movement                     | 1000 |
+| ALL         | Guest            | Denied                          | Complete isolation                          | 1000 |
+
+## Notes
+- Change control: update Git docs for any VLAN/firewall changes.
+- Capacity: DHCP scopes sized at ~60% utilization to allow growth.
+- Redundancy: multiple APs with staggered channels; PoE budget reserved.

--- a/projects/06-homelab/PRJ-HOME-001/docs/SECURITY-POLICY.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/SECURITY-POLICY.md
@@ -1,0 +1,44 @@
+# Network Security Policies
+
+## Firewall Rule Philosophy
+- Defense in depth: WAN edge drop inbound, inter-VLAN default deny, IDS/IPS inspection, endpoint firewalls.
+- Zero trust: least privilege, microsegmentation, continuous monitoring.
+
+## Internet Edge (WAN) Rules
+**Inbound**: drop all; allow ESTABLISHED/RELATED; drop invalid. No port forwards. VPN access only via UniFi when enabled.
+**Outbound**: allow HTTP/HTTPS/DNS/NTP; block SMB and high-risk ports (23,135-139,445,3389); default allow monitored via IDS/IPS.
+
+## Inter-VLAN Rules (summarized)
+- Management inbound: allow SSH/HTTPS from Trusted; deny all else.
+- Trusted outbound: allow Internet, Servers, Management; deny IoT/Guest/Cameras.
+- IoT outbound: HTTP/HTTPS, DNS, NTP; block RFC1918; allow mDNS from Trusted for discovery.
+- Servers inbound: allow SSH from Mgmt/Trusted, HTTP/S, SMB/NFS, Proxmox console; deny IoT/Guest.
+- Guest: Internet only; RFC1918 blocked.
+- Cameras: allow RTSP/HTTP to Servers (NVR); deny Internet and other VLANs except DNS/NTP.
+
+## IDS/IPS Configuration
+- Categories enabled: malware, botnet, phishing, exploit, lateral movement; port scan with threshold.
+- WAN: block mode; LAN: alert mode.
+- Signature updates daily 03:00; weekly engine version check.
+- Notifications: critical immediate (push/SMS), high via email within 15m, medium/low aggregated daily.
+
+## Content Filtering
+- DNS: OpenDNS for all VLANs, FamilyShield for Guest; firewall blocks external DNS and DoH/DoT endpoints.
+- DPI: Guest blocks P2P/torrents/gaming; IoT monitored only.
+- Overrides: Trusted/Servers unfiltered for flexibility.
+
+## Password & Access Policies
+- UniFi admin strong password (20+ chars) with MFA; cloud SSO preferred.
+- WiFi PSKs unique per SSID; stored in 1Password; guest rotated monthly.
+- Infrastructure SSH key-based auth; passwords disabled where possible.
+- Access reviews: weekly firewall log review, monthly IDS/IPS tuning, quarterly full audit, annual pen-test.
+
+## Incident Response
+- Levels: Informational (log), Warning (investigate within hour), Critical (isolate device/VLAN immediately).
+- Containment: block MAC at switch, isolate VLAN, capture evidence before remediation.
+- Recovery: nightly UDMP config backup to NAS; restore via UniFi UI/import.
+
+## Compliance & Audit
+- Retention: firewall logs 30d on UDMP + 1y archive; IDS alerts 90d + 1y archive; config changes versioned in Git.
+- Change management: all firewall/VLAN changes documented; new devices assigned to correct VLAN with record.
+- Metrics: weekly security report (blocked threats, top destinations, bandwidth by VLAN, failed logins, new devices) and monthly executive summary.

--- a/projects/06-homelab/PRJ-HOME-001/docs/SWITCH-PORT-MAP.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/SWITCH-PORT-MAP.md
@@ -1,0 +1,57 @@
+# Switch Port Configuration Map
+
+## UniFi Switch 24 PoE - Primary Distribution Switch
+**Management IP**: 192.168.1.10  
+**Location**: Network Rack, 15U  
+**Firmware**: 6.x (document exact on audit)
+
+### Port Configuration Table
+| Port | Connected Device | Device Location | VLAN Mode | VLAN ID(s) | PoE Status | Speed/Duplex | Port Profile | Notes |
+|------|------------------|-----------------|-----------|------------|------------|--------------|--------------|-------|
+| 1 | Workstation-01 | Office Desk 1 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Main development machine |
+| 2 | Workstation-02 | Office Desk 2 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Secondary workstation |
+| 3 | Laptop Dock-01 | Office Desk 1 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Thunderbolt dock |
+| 4-8 | Available | - | Access | 10 | Disabled | - | Trusted-Access | Reserved |
+| 9 | Proxmox-01 | Rack 10U | Access | 40 | Disabled | 1G/Full | Server-Access | Virtualization host |
+| 10 | Proxmox-02 | Rack 11U | Access | 40 | Disabled | 1G/Full | Server-Access | Virtualization host |
+| 11 | TrueNAS | Rack 12U | Access | 40 | Disabled | 1G/Full | Server-Access | Storage server |
+| 12 | Available | - | Access | 40 | Disabled | - | Server-Access | Spare |
+| 13 | AP-Office | Office Ceiling | Trunk | 1,10,20,30 | Active (15.4W) | 1G/Full | AP-Trunk | Office AP |
+| 14 | AP-LivingRoom | Living Room | Trunk | 1,10,20,30 | Active (13.2W) | 1G/Full | AP-Trunk | Living room AP |
+| 15 | AP-Bedroom | Master Bedroom | Trunk | 1,10,20,30 | Active (14.1W) | 1G/Full | AP-Trunk | Bedroom AP |
+| 16 | Available | - | Trunk | All | Available | - | AP-Trunk | Spare trunk |
+| 17 | Camera-Front | Front Door | Access | 50 | Active (4.2W) | 100M/Full | Camera-Access | Outdoor run |
+| 18 | Camera-Back | Back Door | Access | 50 | Active (3.8W) | 100M/Full | Camera-Access | Outdoor run |
+| 19 | Camera-Garage | Garage | Access | 50 | Active (4.5W) | 100M/Full | Camera-Access | Outdoor run |
+| 20 | Camera-Driveway | Driveway | Access | 50 | Active (5.1W) | 100M/Full | Camera-Access | Outdoor run |
+| 21 | Smart Hub-01 | Office | Access | 20 | Disabled | 100M/Full | IoT-Access | Zigbee/Z-Wave hub |
+| 22 | Printer-Office | Office | Access | 10 | Disabled | 100M/Full | Trusted-Access | Network printer |
+| 23 | UDMP Uplink | Rack 1U | Trunk | All | Disabled | 1G/Full | Uplink | Upstream to UDMP |
+| 24 | Available | - | Trunk | All | Disabled | - | General | Spare |
+
+### Port Profiles
+- **Trusted-Access**: Access, Native VLAN 10, PoE off, RSTP edge, storm control 10%.
+- **Server-Access**: Access, Native VLAN 40, PoE off, RSTP edge, jumbo frames 9000.
+- **AP-Trunk**: Trunk, Native VLAN 1, Tagged 1/10/20/30, PoE+, RSTP, storm control 20%.
+- **Camera-Access**: Access, Native VLAN 50, PoE af, RSTP edge, storm control 10%.
+
+### PoE Budget Summary
+- Total: 95W; Allocated: ~60.3W; Available: ~34.7W for future AP/cameras.
+
+### Cable Runs
+| Port | Cable Type | Length | Run Path | Certification |
+|------|------------|--------|----------|---------------|
+| 1-8 | Cat6 | <15ft | Under desk | Patch |
+| 9-11 | Cat6 | <3ft | Rack patch | Patch |
+| 13 | Cat6 | 45ft | Ceiling conduit | Tested 1G |
+| 14 | Cat6 | 75ft | Ceiling/wall conduit | Tested 1G |
+| 15 | Cat6 | 60ft | Ceiling/wall conduit | Tested 1G |
+| 17-20 | Cat5e | 30-100ft | Outdoor conduit | Tested 100M |
+
+### Maintenance Log
+| Date | Action | Port(s) | Performed By | Notes |
+|------|--------|---------|--------------|-------|
+| 2024-01-15 | Initial configuration | All | Admin | Base deployment |
+| 2024-03-20 | Added Camera-Driveway | 20 | Admin | New camera |
+| 2024-06-10 | Replaced cable | 14 | Admin | Cable damage |
+| 2024-11-10 | Port profile update | 9-11 | Admin | Enabled jumbo frames |

--- a/projects/06-homelab/PRJ-HOME-001/docs/TROUBLESHOOTING.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/TROUBLESHOOTING.md
@@ -1,0 +1,39 @@
+# Troubleshooting Guide (Network)
+
+## Service Won't Start
+- Symptom: device offline in controller.
+- Diagnosis: check PoE budget and port status; confirm VLAN assignment; ping management IP.
+- Resolution: re-adopt device, reseat cable, verify power; update firmware.
+- Prevention: keep maintenance log and monitor PoE budget.
+
+## High Memory Usage
+- Symptom: UDMP memory alerts.
+- Diagnosis: controller UI metrics, IDS/IPS load.
+- Resolution: disable nonessential DPI categories, reduce logging retention, reboot during maintenance window.
+- Prevention: schedule regular reboots; keep firmware current.
+
+## Prometheus Scrape Failures
+- Symptom: exporters in Servers VLAN unreachable.
+- Diagnosis: check inter-VLAN rules allow HTTP/S; verify DNS resolution.
+- Resolution: adjust firewall rules, ensure node exporter listening on host network.
+- Prevention: document rule changes; test with curl from Prometheus host.
+
+## Alert Not Firing
+- Symptom: expected notification absent.
+- Diagnosis: confirm Alertmanager route, check inhibition rules, verify SMTP/Slack keys.
+- Resolution: test via `amtool`; fix credentials; adjust severity labels.
+
+## Dashboard Not Loading
+- Symptom: Grafana panel errors.
+- Diagnosis: datasource health check; network path from Grafana VLAN to Prometheus/Loki.
+- Resolution: fix DNS, ensure backend network reachable via compose; restart Grafana provisioning.
+
+## Logs Not Appearing
+- Symptom: no new entries in Loki.
+- Diagnosis: verify Promtail access to Docker logs, check positions file, query by container label.
+- Resolution: restart Promtail, fix label filters; ensure Loki retention not expired.
+
+## Container Restart Loops
+- Symptom: repeated restarts of monitoring containers.
+- Diagnosis: inspect compose logs; check resource limits and health checks.
+- Resolution: increase limits, fix configuration errors, correct permissions on volumes.

--- a/projects/06-homelab/PRJ-HOME-001/docs/WIRELESS-CONFIG.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/WIRELESS-CONFIG.md
@@ -1,0 +1,60 @@
+# Wireless Network Configuration
+
+## SSID Configuration
+
+### HomeNetwork-5G (Primary 5GHz Network)
+- Purpose: high-performance trusted devices
+- VLAN: 10
+- Security: WPA3-Personal (fallback WPA2), PSK stored in 1Password
+- Group rekey: 3600s, PMF required
+- Radio: 5GHz only, 80MHz width, auto power ~17-22dBm, min RSSI -70dBm
+- Advanced: 802.11r fast roaming enabled, multicast enhancement on, DTIM 1, beacon 100ms, client isolation off
+- Typical clients: 15-20 (peak 30)
+
+### IoT (2.4GHz/5GHz as needed)
+- VLAN: 20
+- Security: WPA2-Personal, strong PSK
+- Client isolation: enabled to reduce lateral movement
+- Band steering: enabled to favor 5GHz capable IoT where possible
+
+### Guest
+- VLAN: 30
+- Security: WPA2-Personal, password rotated monthly
+- Bandwidth limit: 25/10 Mbps per client
+- Client isolation: enabled; LAN access blocked
+- Content filtering: OpenDNS FamilyShield
+
+## Access Point Details
+
+### AP-Office (U6-Pro)
+- Location: office ceiling; IP 192.168.1.20; PoE on switch port 13
+- 2.4GHz: channel 1, 20MHz, low power 10dBm, minimum rate 18Mbps
+- 5GHz: channel 149, 80MHz, 22dBm
+- Clients: ~10-12 typical across SSIDs
+- Performance: 400-600 Mbps throughput, <2ms latency to gateway
+
+### AP-LivingRoom (U6-Lite)
+- IP 192.168.1.21; port 14
+- 2.4GHz ch6 20MHz 12dBm; 5GHz ch36 80MHz 20dBm
+- Clients: 8-10
+
+### AP-Bedroom (U6-Lite)
+- IP 192.168.1.22; port 15
+- 2.4GHz ch11 20MHz 10dBm; 5GHz ch149 80MHz 18dBm
+- Clients: 6-8
+
+## Channel Planning & Optimization
+- Strategy: DFS/upper band use to avoid congestion; 80MHz width for WiFi6 throughput.
+- Assignments: AP-Office 149, AP-LivingRoom 36, AP-Bedroom 149 (distance >30ft to limit CCI).
+- Survey: WiFiman/Ekahau (2024-10-15) shows -65 dBm or better in living areas; marginal in garage (-75 dBm) as expected.
+- Interference: minimal non-WiFi; neighbors limited in 5GHz.
+
+## Guest Network Policies
+- Bandwidth limit 25/10 Mbps, schedule 24/7.
+- Isolation on; LAN blocked; blocked ports SMB/SSH/RDP; RFC1918 denied.
+- IDS/IPS strict; DPI blocks P2P/torrents; logging retained 7 days.
+
+## Connected Device Summary
+- Trusted: 3 desktops, 2 laptops, 4 phones, 2 tablets, printer, smart TV.
+- IoT: smart speakers, lights, thermostat, sensors via hub.
+- Guest: variable 2-3 when visitors present.

--- a/projects/06-homelab/PRJ-HOME-001/docs/diagrams/network-topology-description.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/diagrams/network-topology-description.md
@@ -1,0 +1,26 @@
+# Physical Network Topology Diagram Specification
+
+## Layout
+- Orientation left-to-right: Internet → UDMP → Switch → APs/Servers/Endpoints.
+- Grouping by location: rack, office, living room, bedroom, exterior.
+- Colors: red=WAN, blue=trunk, green=access, orange=fiber.
+
+## Components
+1. ISP cloud labeled "Comcast 1G/35M" → red line to Arris SB8200.
+2. SB8200 modem rectangle → red line to UDMP WAN.
+3. Rack box containing UDMP (top), Switch 24 PoE (below), servers (Proxmox1/2, TrueNAS).
+   - UDMP LAN to Switch via blue trunk, annotated "all VLANs" and port numbers.
+   - Switch port annotations: ports 1-8 VLAN10 access, 9-12 VLAN40 access, 13-16 AP trunks (1/10/20/30), 17-20 VLAN50 cameras, 21 IoT, 22 printer, 23 uplink, 24 spare trunk.
+4. APs: Office AP on trunk port13; Living Room AP on port14; Bedroom AP on port15. Callouts for SSIDs and VLAN mappings.
+5. Endpoints grouped by VLAN color-coded boxes: Trusted (green devices), IoT (yellow), Guest (red), Servers (blue servers), Cameras (orange cameras to NVR).
+6. Annotations: cable type (Cat6, outdoor-rated), PoE draw per device, link speeds (1G).
+7. Legend: shapes/line styles/colors, NAT boundary at UDMP.
+
+# Logical Network Architecture Diagram Specification
+- Top-down layers: Internet → UDMP security edge → services (DNS/DHCP) → VLAN clouds → device groups.
+- Each VLAN cloud shows name, ID, subnet, gateway; colors per VLAN list.
+- Security zones boxes: Trusted zone (Mgmt+Trusted), Restricted (IoT+Cameras), Isolated (Guest).
+- Arrows with allowed traffic: Trusted→Servers (HTTP/S, SSH, SMB), Trusted→Management (SSH/HTTPS), IoT→Internet (HTTP/S), Guest→Internet (HTTP/S).
+- Red X dashed lines for denied paths: IoT→Trusted, Guest→LAN, Cameras→Internet.
+- Numbered flows: 1) Internet browsing path, 2) Trusted→Server access, 3) Blocked IoT lateral attempt.
+- Notes: NAT at UDMP, DNS chain UDMP→Cloudflare/Google, DHCP scopes per VLAN.


### PR DESCRIPTION
## Summary
- add production-ready monitoring stack compose, configs, alerting, and Grafana provisioning
- include deployment helpers, environment template, and operational docs for observability
- document homelab network architecture, diagrams, switch mapping, wireless setup, and security policies

## Testing
- not run (documentation and configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b62ecebe48327a78719033e11d32f)