### PR TITLE
Add portfolio playbooks, wiki seed, and status tooling

### DIFF
--- a/docs/p01-cloudformation-playbook.md
+++ b/docs/p01-cloudformation-playbook.md
@@ -1,0 +1,33 @@
+# P01 CloudFormation Deploy Playbook
+
+This playbook standardizes how to validate and deploy the P01 networking baseline using CloudFormation. It emphasizes template validation before any deploy and enforces a deterministic order so dependent stacks receive the correct outputs.
+
+## Parameters and validation
+- **Required parameters**: `EnvironmentName`, `VpcCIDR`, `SSHKeyName`.
+- **Validation**: run `./scripts/validate.sh` before *every* deploy or change set. The script must return zero before proceeding.
+
+## Deployment order
+1. **IAM baseline** stack (creates roles, instance profiles, and stack permissions).
+2. **VPC stack** (consumes IAM outputs).
+
+## Expected VPC stack resources
+- One VPC using `VpcCIDR` with DNS hostnames enabled.
+- One Internet Gateway attached to the VPC.
+- Public and private subnets across three AZs (at least six total).
+- Three NAT Gateways (one per AZ) with elastic IPs.
+- Route tables and associations for public/private paths.
+- Security groups for bastion, ALB, app tier, and RDS.
+- RDS subnet group spanning the private subnets.
+- Stack outputs for VPC ID, subnet IDs by tier, route tables, security group IDs, and NAT allocations.
+
+## Deploy steps (CLI)
+1. Validate: `./scripts/validate.sh`
+2. Package (if templates are modularized): `aws cloudformation package --template-file infra/p01/main.yml --s3-bucket <artifact-bucket> --output-template-file /tmp/p01-packaged.yml`
+3. Deploy IAM baseline: `aws cloudformation deploy --template-file infra/p01/iam-baseline.yml --stack-name p01-iam-<env> --parameter-overrides EnvironmentName=<env>`
+4. Deploy VPC: `aws cloudformation deploy --template-file /tmp/p01-packaged.yml --stack-name p01-vpc-<env> --capabilities CAPABILITY_NAMED_IAM --parameter-overrides EnvironmentName=<env> VpcCIDR=<cidr> SSHKeyName=<key>`
+
+## Post-deploy verification
+- Confirm three NAT gateways and public/private route table associations exist per AZ.
+- Validate security group ingress/egress rules match architecture baselines.
+- Export stack outputs into parameter store or `.env.<env>` for downstream stacks.
+- Capture an architecture diagram PNG for the environment record.

--- a/docs/p03-cicd-blueprint.md
+++ b/docs/p03-cicd-blueprint.md
@@ -1,0 +1,32 @@
+# P03 CI/CD Blueprint (ArgoCD GitOps)
+
+This blueprint defines the reference pipeline and outcome targets for the portfolio CI/CD system.
+
+## Pipeline stages
+1. **Build & Test**
+   - Run unit, integration, and security scans (SAST/dependency) in parallel.
+   - Artifacts: build outputs, coverage reports, SARIF.
+2. **Staged deploy (GitOps)**
+   - Promote from `dev` to `staging` via ArgoCD syncs tied to environment branches or Helm value overlays.
+   - Require integration smoke tests post-sync before promotion.
+3. **Production canary**
+   - Argo Rollouts or progressive delivery: start at 10% traffic, then 100% after health/metrics gates.
+   - Automated rollback on error rate/latency regression.
+
+## Operational notes
+- Source of truth: Git repository manifests/Helm charts. No manual drift.
+- Environments: dev → staging → prod with promotion by Git change.
+- Security: signed container images and required policy checks before deploy.
+- Observability gates: error rate, p95 latency, and saturation metrics are required for rollout decisions.
+
+## Outcome metrics (placeholders until first runs)
+- Deployment frequency: target ~50 per week.
+- Lead time: reduce from days to hours.
+- Change failure rate: reduce by ~87% from baseline.
+- MTTR: decrease with automated rollback and playbook execution.
+
+## Evidence to collect
+- CI logs for build/test/security stages.
+- ArgoCD sync history for dev/staging.
+- Canary rollout timeline with metrics screenshot.
+- Rollback demonstration and resulting metrics recovery.

--- a/docs/portfolio-goals-and-social.md
+++ b/docs/portfolio-goals-and-social.md
@@ -1,0 +1,21 @@
+# Portfolio Goals and Social Templates
+
+## Public success metrics to track
+- Deployment frequency (target ~50/week once pipelines are steady).
+- Lead time for changes (reduce from days to hours).
+- Change failure rate (target ~87% reduction through canary + rollback).
+- MTTR (trend downward with auto-restart and runbooks).
+- Observability coverage: services emitting traces/metrics/logs.
+- Documentation completeness: README, ADR, runbook, diagram per project.
+
+## LinkedIn blurb (25-project portfolio)
+> Delivered a 25-project cloud portfolio featuring GitOps CI/CD (ArgoCD canaries), AWS networking foundations, DR/backup drills, and an observability stack (Prometheus/Grafana/Jaeger). Drove deployment frequency toward 50/week with reduced lead time and automated rollback coverage.
+
+## Resume bullet template
+- "Built and operated a 25-project portfolio across AWS/EKS with GitOps delivery; increased deployment frequency toward 50/week while cutting change-failure rate ~87% via canary + automated rollbacks."
+- "Implemented observability baseline (Prometheus/Grafana/Jaeger) and health-check auto-restart scripts, shrinking MTTR and improving runbook adherence."
+
+## Sharing guidelines
+- Pair metrics with evidence: dashboards, ArgoCD rollout history, and DR drill results.
+- Keep placeholder percentages until first runs complete, then overwrite with measured data.
+- Link to wiki pages for `/home` and `/projects` plus architecture diagrams for the featured projects.

--- a/docs/portfolio-structure-and-index.md
+++ b/docs/portfolio-structure-and-index.md
@@ -1,0 +1,47 @@
+# Portfolio Repo Structure and 25-Project Index
+
+Use this scaffold for every project to keep documentation, code, and operations consistent.
+
+## Repository scaffold
+```
+/projects/PXX-<slug>/{src,infra,helm,tests,docs,runbooks,scripts}
+/common/{ci,observability,security,templates}
+.github/workflows/portfolio-ci.yml
+```
+
+Recommended contents:
+- `/common/observability`: Prometheus, Grafana, Jaeger docker-compose and OpenTelemetry snippets.
+- `/common/security`: pre-commit, gitleaks, semgrep rules, and Trivy usage notes.
+- `/common/templates`: README, ADR, runbook, and diagram templates.
+- `/common/ci`: reusable workflow job fragments for lint, test, scan, package, and deploy.
+
+## 25-project index (keep synchronized)
+| ID | Project | Scope |
+| --- | --- | --- |
+| P01 | AWS CloudFormation VPC baseline | VPC + IAM foundation |
+| P02 | Database migration factory | Dry-run + reporting |
+| P03 | CI/CD with ArgoCD & canary | GitOps progressive delivery |
+| P04 | DevSecOps guardrails | SAST/DAST, secrets, supply chain |
+| P05 | Service mesh rollout | mTLS, traffic policy |
+| P06 | Streaming data platform | Kafka + consumers |
+| P07 | AI/ML automation | Pipelines and feature stores |
+| P08 | Serverless apps | Event-driven patterns |
+| P09 | RAG chatbot | Retrieval augmented QA |
+| P10 | Data lake (Iceberg) | Ingest + analytics |
+| P11 | Zero trust identity | IAM and policy |
+| P12 | Smart contracts | Solidity + auditing |
+| P13 | Post-quantum crypto | PQC readiness |
+| P14 | SIEM/SOAR | Detection engineering |
+| P15 | IAM hardening | Least privilege |
+| P16 | IoT pipeline | Device to cloud |
+| P17 | Quantum experiments | Simulators |
+| P18 | Edge AI | On-device inference |
+| P19 | AR/VR demo | Experience prototype |
+| P20 | 5G slice lab | Latency profiles |
+| P21 | Disaster recovery | Playbooks and tests |
+| P22 | CRDT collaboration | Yjs/WebSocket demo |
+| P23 | GPU/CUDA workloads | Accelerated compute |
+| P24 | Analytics/reporting | Automated reporting |
+| P25 | Observability baseline | Prometheus/Grafana/Jaeger |
+
+Document the “Definition of Ready” for each project in `/projects/PXX-*/.project.json` including region, secrets approach, environments, demo scope, and success KPI.

--- a/runbooks/auto-restart-healthcheck.sh
+++ b/runbooks/auto-restart-healthcheck.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${SERVICE_NAME:-app}"        # systemd unit or kubectl deployment name
+HEALTH_URL="${HEALTH_URL:-http://localhost:8080/healthz}"
+TIMEOUT="${TIMEOUT:-5}"
+RETRIES="${RETRIES:-3}"
+SLEEP="${SLEEP:-5}"
+
+log() { echo "$(date -Is) $*"; }
+
+check_health() {
+  curl -fsS --max-time "${TIMEOUT}" "${HEALTH_URL}" >/dev/null
+}
+
+restart_service() {
+  if command -v systemctl >/dev/null; then
+    log "Restarting systemd service ${SERVICE_NAME}" && sudo systemctl restart "${SERVICE_NAME}"
+  elif command -v kubectl >/dev/null; then
+    log "Restarting Kubernetes deployment ${SERVICE_NAME}" && kubectl rollout restart deployment "${SERVICE_NAME}"
+  else
+    log "No restart mechanism available for ${SERVICE_NAME}" && return 1
+  fi
+}
+
+attempt=0
+until check_health; do
+  attempt=$((attempt + 1))
+  log "Health check failed for ${HEALTH_URL} (attempt ${attempt}/${RETRIES})"
+  if [[ ${attempt} -ge ${RETRIES} ]]; then
+    log "Threshold reached; triggering restart"
+    restart_service || log "Restart failed"
+    attempt=0
+  fi
+  sleep "${SLEEP}"
+done
+
+log "Service ${SERVICE_NAME} healthy at ${HEALTH_URL}"

--- a/runbooks/connectivity-troubleshooting.md
+++ b/runbooks/connectivity-troubleshooting.md
@@ -1,0 +1,28 @@
+# Connectivity Troubleshooting Decision Tree
+
+Use this decision flow to isolate networking and service reachability issues.
+
+## Decision tree
+1. **Is DNS resolving?**
+   - No: check `/etc/resolv.conf`, CoreDNS/Route53 health; flush local cache.
+   - Yes: continue.
+2. **Is the host reachable (ping/TCP)?**
+   - No: validate security groups/NSGs, NACLs, and route tables for the source subnet. Check IGW/NAT attachment and AZ route propagation.
+   - Yes: continue.
+3. **Is TLS/HTTP responding?**
+   - No: confirm load balancer listener/target group health; inspect cert expiration; verify inbound security group rules for 80/443.
+   - Yes: continue.
+4. **Is the application healthy?**
+   - No: review application logs, pod status, and liveness/readiness probes. Roll back recent deploy if probes failing.
+   - Yes: continue.
+5. **Is downstream dependency available?**
+   - No: check database endpoint connectivity, SGs, and subnet ACLs; retry with bastion from same subnet. Validate RDS subnet group spans correct AZs.
+   - Yes: open incident with evidence (traces, metrics, curl outputs).
+
+## Quick checks
+- `dig <host>` for DNS; `curl -v https://<host>/healthz` for HTTP.
+- `aws ec2 describe-route-tables --filters Name=vpc-id,Values=<vpc>` to confirm routes.
+- `kubectl describe endpoints <svc>` to ensure pods are registered.
+
+## Escalation
+- If P1/P2: page on-call, capture traceroute, curl with `--trace-ascii`, and ArgoCD rollout history. Attach screenshots of Grafana dashboards and Jaeger traces.

--- a/runbooks/operations-checklists.md
+++ b/runbooks/operations-checklists.md
@@ -1,0 +1,47 @@
+# Operations Checklists and Runbooks (P01, P03, P25)
+
+Use these daily/weekly/monthly routines and deployment procedures across infrastructure (P01), CI/CD (P03), and observability (P25).
+
+## Daily
+- [ ] Review overnight alerts; acknowledge and create incident tickets for P1/P2.
+- [ ] Check CI pipeline health and queued jobs; rerun failed tests if flaky.
+- [ ] Verify ArgoCD sync status for dev/staging/prod; resolve drift immediately.
+- [ ] Confirm observability stack is scraping targets and ingesting traces.
+
+## Weekly
+- [ ] Patch CI runners and bastion hosts; rotate ephemeral tokens.
+- [ ] Run backup restore test for critical data stores (RDS snapshots, S3 bucket versions).
+- [ ] Exercise DR drill: fail over NAT gateway AZ or simulate loss of one AZ route table and confirm traffic re-converges.
+- [ ] Review deployment frequency and failure rates; adjust rollout policy thresholds if needed.
+
+## Monthly
+- [ ] Full disaster recovery rehearsal with documented RTO/RPO results.
+- [ ] Patch cadence review: ensure OS and container base images are updated; rebuild golden AMIs/base images.
+- [ ] Audit IAM roles, security groups, and ArgoCD RBAC for least-privilege adherence.
+- [ ] Capacity planning check using Grafana dashboards (CPU/mem, NAT utilization, database IOPS).
+
+## Alert tiers (P1–P4)
+- **P1**: Prod outage or security incident. Page immediately, start incident bridge, and trigger rollback if deployment-related.
+- **P2**: User-impacting degradation. Notify on-call and product owner; consider traffic shift to last stable release.
+- **P3**: Limited impact or single component impaired. Create ticket, address within business day.
+- **P4**: Informational. Track in backlog.
+
+## Start/Stop procedures
+- **Start**: bring up observability stack (`docker compose -f common/observability/docker-compose.yml up -d`), then CI services, then app workloads via ArgoCD sync.
+- **Stop**: disable ArgoCD auto-sync, drain traffic (set weights to 0 on canary), stop app workloads, then observability services.
+
+## Deployment (blue/green with health gates)
+1. Prepare release manifest or Helm values and push to the GitOps repo.
+2. Enable Argo Rollouts canary: start at 10% traffic with health checks on error rate and p95 latency.
+3. Promote to 50% then 100% only when health gates pass; otherwise automatically rollback to previous ReplicaSet.
+4. Validate post-deploy with smoke tests and security checks (bandit/semgrep) before closing the change.
+
+## Rollback steps
+- **ArgoCD/Argo Rollouts**: `kubectl argo rollouts undo <rollout>` or revert Git commit triggering the sync.
+- **Infrastructure change**: execute `aws cloudformation cancel-update-stack` or redeploy last successful template version.
+- **Database migration**: apply corresponding down migration or restore last backup snapshot; document impact window.
+
+## Backup and restore tests
+- [ ] Verify automated snapshots exist for RDS and EBS; test restoring to staging weekly.
+- [ ] Validate S3 versioning and lifecycle rules; restore a random object monthly.
+- [ ] Capture metrics on restore time and data integrity; log in DR register.

--- a/scripts/portfolio-status.sh
+++ b/scripts/portfolio-status.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+METRICS_FILE="${METRICS_FILE:-portfolio-metrics.json}"
+WIKI_FILE="${WIKI_FILE:-wiki/initial-structure.json}"
+REPO="${GITHUB_REPO:-}" # format: owner/repo
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
+}
+
+require_cmd jq
+
+overall_completion() {
+  jq -r '.overall_completion // "N/A"' "${METRICS_FILE}" 2>/dev/null || echo "N/A"
+}
+
+projects_with_code() {
+  jq '[.project_details[] | select(.has_code==true)] | length' "${METRICS_FILE}" 2>/dev/null || echo "N/A"
+}
+
+total_projects() {
+  jq -r '.projects.total // "N/A"' "${METRICS_FILE}" 2>/dev/null || echo "N/A"
+}
+
+wiki_pages() {
+  jq 'length' "${WIKI_FILE}" 2>/dev/null || echo "N/A"
+}
+
+github_stats() {
+  if [[ -z "${REPO}" ]]; then
+    echo "GitHub stars/forks: set GITHUB_REPO=owner/repo to fetch"; return
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "GitHub stars/forks: curl not available"; return
+  fi
+  response=$(curl -fsS "https://api.github.com/repos/${REPO}" 2>/dev/null || true)
+  if [[ -z "${response}" ]]; then
+    echo "GitHub stars/forks: API call failed"; return
+  fi
+  stars=$(printf '%s' "${response}" | jq -r '.stargazers_count // "N/A"')
+  forks=$(printf '%s' "${response}" | jq -r '.forks_count // "N/A"')
+  echo "GitHub stars: ${stars}, forks: ${forks}"
+}
+
+main() {
+  echo "Portfolio status"
+  echo "----------------"
+  echo "Overall completion: $(overall_completion)%"
+  echo "Projects with code: $(projects_with_code)/$(total_projects)"
+  echo "Wiki pages: $(wiki_pages)"
+  github_stats
+}
+
+main "$@"

--- a/wiki/initial-structure.json
+++ b/wiki/initial-structure.json
@@ -1,0 +1,37 @@
+[
+  {
+    "title": "Home",
+    "slug": "home",
+    "content": "# Portfolio Home\nWelcome to the 25-project portfolio. Track progress, links, and evidence here.",
+    "isPublished": true,
+    "parent": null
+  },
+  {
+    "title": "Projects",
+    "slug": "projects",
+    "content": "# Projects\nIndex of all projects with links to docs, code, and runbooks.",
+    "isPublished": true,
+    "parent": "home"
+  },
+  {
+    "title": "P01 - CloudFormation VPC",
+    "slug": "projects/p01-cloudformation-vpc",
+    "content": "## P01\nDeploy playbook for IAM baseline and VPC with NAT gateways and subnet groups.",
+    "isPublished": true,
+    "parent": "projects"
+  },
+  {
+    "title": "P03 - CI/CD GitOps",
+    "slug": "projects/p03-cicd-gitops",
+    "content": "## P03\nArgoCD-driven pipeline with canary rollout and security gates.",
+    "isPublished": true,
+    "parent": "projects"
+  },
+  {
+    "title": "P25 - Observability",
+    "slug": "projects/p25-observability",
+    "content": "## P25\nPrometheus, Grafana, and Jaeger baseline with alerts and dashboards.",
+    "isPublished": true,
+    "parent": "projects"
+  }
+]


### PR DESCRIPTION
## Summary
- document the P01 CloudFormation deploy playbook, P03 GitOps CI/CD blueprint, portfolio structure, and public goals/templates
- add shared runbooks for operations, connectivity triage, and a healthcheck auto-restart helper
- seed Wiki.js initial pages and provide a portfolio status script for completion and repo signals

## Testing
- ./scripts/portfolio-status.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7149460483278fbe6de355178ea9)