### PR TITLE
Add README generator and documentation scaffolding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:14
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: portfolio
+      POSTGRES_PASSWORD: portfolio
+      POSTGRES_DB: portfolio
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build:
+      context: ./backend
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql+asyncpg://portfolio:portfolio@db:5432/portfolio
+      SECRET_KEY: dev-secret-change-me
+      ALGORITHM: HS256
+      ACCESS_TOKEN_EXPIRE_MINUTES: "60"
+      CORS_ORIGINS: '["http://localhost:3000","http://localhost:5173"]'
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ./frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
+
+volumes:
+  db_data:

--- a/docs/MASTER_FACTORY_PROMPT.md
+++ b/docs/MASTER_FACTORY_PROMPT.md
@@ -1,0 +1,71 @@
+# Portfolio Project Generation Factory
+
+This meta-prompt packages the instructions needed to generate the complete deliverable set for any of the P01–P25 portfolio projects. Use it when you want an AI to produce README drafts, architecture diagrams, testing plans, code prompts, runbooks, ADRs, threat models, and risk registers in one pass.
+
+## How to Use
+
+1. Copy the **Activation Prompt** below into your AI tool of choice.
+2. Replace `PXX` with the project code and `<project name>` with the short title.
+3. Run the prompt and wait for the AI to output the full deliverable pack in the prescribed order.
+4. Review for accuracy, then file or commit the outputs into the matching project folder.
+
+> The generation target is comprehensive: minimum 6,000 words per project, complete diagrams, quality gates, and reviewer-ready formatting.
+
+## Activation Prompt
+
+```
+You are an ENTERPRISE-GRADE PROJECT GENERATION ENGINE.
+
+When I say:
+    "Generate PXX – <project name> in full."
+
+You must produce all deliverables in this exact section order:
+1) Executive Summary
+2) README
+3) Architecture Diagram Pack (mermaid + ASCII + explanations)
+4) Code Generation Prompts (IaC, backend, frontend, containers, CI/CD, observability)
+5) Testing Suite (strategy, plan, cases, API, security, performance, CI gates)
+6) Operational Documents (playbook, runbook, SOP, on-call guide, migration runbook)
+7) Reporting Package (status/KPI/OKR templates, findings, ROI, timeline)
+8) Metrics & Observability (SLO/SLI/error budgets, PromQL, dashboards, logs, traces)
+9) Security Package (STRIDE+MITRE threat model, access control, encryption, secrets)
+10) Risk Management (risk register with scores, mitigations, owners)
+11) Architecture Decision Records (at least ADR-001..005)
+12) Business Value Narrative (why it matters and recruiter-ready summary)
+
+Formatting rules:
+- Use professional Markdown with headings, bullets, tables, and fenced code blocks.
+- Provide valid Mermaid for every diagram and ASCII alternatives.
+- Include CI/CD variants (GitHub Actions, GitLab CI, Jenkins) and IaC variants (Terraform, CloudFormation, CDK).
+- Add comments to code snippets and specify reviewer acceptance criteria.
+- Never use placeholders; fully elaborate each section.
+- Do not shorten content unless explicitly asked to summarize.
+- Follow AWS/Azure/GCP and security best practices relevant to the project domain.
+
+Behavior rules:
+- Never say "as an AI language model." Be decisive and explicit.
+- Keep outputs recruiter- and hiring-manager-ready with concrete details.
+- Everything must look production-grade and audit-friendly.
+```
+
+## Domain Detection Guidance
+
+The meta-prompt expects the AI to infer domain, tech stack, and complexity from the project title. Typical domains include cloud/DevOps, data/ML pipelines, security, networking, or observability. The AI should:
+
+- Select relevant cloud platforms and IaC tools.
+- Map to appropriate languages/frameworks (Python/Go/Node, Kubernetes/Helm, Terraform/CDK, etc.).
+- Align with security frameworks (CIS/NIST/SOC2/ISO27001) when applicable.
+- Reflect enterprise rigor for advanced or portfolio-ready projects.
+
+## Recommended Usage Notes
+
+- Run the prompt per project to avoid context loss in long sessions.
+- If you need multiple projects at once, generate them in batches of 5 (P01–P05, P06–P10, etc.).
+- Save each AI output into the corresponding `projects/<id>-<name>/` directory for traceability.
+- Pair generation with manual review: validate diagrams, scrub secrets, and verify commands before publishing.
+
+## Example Invocation
+
+> "Generate P03 – Kubernetes CI/CD Pipeline in full."
+
+This should return a fully structured artifact set matching the twelve required sections with diagrams, prompts, testing plans, and governance content that can be dropped directly into the project repository.

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -1,0 +1,29 @@
+# Portfolio Project Index
+
+| Title | Category | Status | Slug |
+| --- | --- | --- | --- |
+| SOC Playbook Modernization | Blue Team | Completed | p-bt-01 |
+| Endpoint Telemetry Uplift | Blue Team | In Progress | p-bt-02 |
+| SIEM Content as Code | Blue Team | Completed | p-bt-03 |
+| Threat Hunting Sprint | Blue Team | Completed | p-bt-04 |
+| Incident Response Playoff | Blue Team | Planned | p-bt-05 |
+| Cloud Guardrails Blueprint | Cloud Security | Completed | p-cs-01 |
+| Kubernetes Runtime Hardening | Cloud Security | In Progress | p-cs-02 |
+| Data Loss Prevention Rollout | Cloud Security | Completed | p-cs-03 |
+| Secrets Management Unification | Cloud Security | In Progress | p-cs-04 |
+| Cloud Security Monitoring Fabric | Cloud Security | Planned | p-cs-05 |
+| GitOps Platform Build | DevOps / SRE | Completed | p-devops-01 |
+| Resilience Testing Program | DevOps / SRE | In Progress | p-devops-02 |
+| Platform Observability Mesh | DevOps / SRE | Completed | p-devops-03 |
+| Cost Optimization Lab | DevOps / SRE | Completed | p-devops-04 |
+| Reliability Runbooks | DevOps / SRE | Planned | p-devops-05 |
+| ISO 27001 Readiness | GRC | Completed | p-grc-01 |
+| Risk Register Automation | GRC | In Progress | p-grc-02 |
+| Vendor Security Review | GRC | Completed | p-grc-03 |
+| Policy Library Refresh | GRC | In Progress | p-grc-04 |
+| BCP/DR Program | GRC | Planned | p-grc-05 |
+| Red Team Cloud Pivot | Red Team | Completed | p-rt-01 |
+| Adversary Emulation for OT Lab | Red Team | In Progress | p-rt-02 |
+| Wireless Intrusion Assessment | Red Team | Completed | p-rt-03 |
+| Web App Exploitation Playbook | Red Team | Planned | p-rt-04 |
+| Physical Security Bypass | Red Team | Completed | p-rt-05 |

--- a/docs/blue-team/p-bt-01.md
+++ b/docs/blue-team/p-bt-01.md
@@ -1,0 +1,12 @@
+# SOC Playbook Modernization
+
+**Slug:** p-bt-01  
+**Category:** Blue Team  
+**Status:** Completed
+
+## Overview
+Refreshed SOC runbooks with cloud-first detections, unified triage steps, and response automation hooks.
+
+## Where to Start
+- Project README: [projects/p-bt-01/README.md](../../projects/p-bt-01/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/blue-team/p-bt-02.md
+++ b/docs/blue-team/p-bt-02.md
@@ -1,0 +1,12 @@
+# Endpoint Telemetry Uplift
+
+**Slug:** p-bt-02  
+**Category:** Blue Team  
+**Status:** In Progress
+
+## Overview
+Expanded EDR telemetry coverage for Linux servers and macOS endpoints with standardized baselines.
+
+## Where to Start
+- Project README: [projects/p-bt-02/README.md](../../projects/p-bt-02/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/blue-team/p-bt-03.md
+++ b/docs/blue-team/p-bt-03.md
@@ -1,0 +1,12 @@
+# SIEM Content as Code
+
+**Slug:** p-bt-03  
+**Category:** Blue Team  
+**Status:** Completed
+
+## Overview
+Implemented version-controlled SIEM detections with CI linting, staged promotion, and automated packaging.
+
+## Where to Start
+- Project README: [projects/p-bt-03/README.md](../../projects/p-bt-03/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/blue-team/p-bt-04.md
+++ b/docs/blue-team/p-bt-04.md
@@ -1,0 +1,12 @@
+# Threat Hunting Sprint
+
+**Slug:** p-bt-04  
+**Category:** Blue Team  
+**Status:** Completed
+
+## Overview
+Ran a two-week hunting sprint focused on identity misuse and cloud console anomalies using hypothesis-driven hunts.
+
+## Where to Start
+- Project README: [projects/p-bt-04/README.md](../../projects/p-bt-04/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/blue-team/p-bt-05.md
+++ b/docs/blue-team/p-bt-05.md
@@ -1,0 +1,12 @@
+# Incident Response Playoff
+
+**Slug:** p-bt-05  
+**Category:** Blue Team  
+**Status:** Planned
+
+## Overview
+Designing a gamified IR exercise that pits teams against live-fire scenarios with measured MTTR targets.
+
+## Where to Start
+- Project README: [projects/p-bt-05/README.md](../../projects/p-bt-05/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/cloud-security/p-cs-01.md
+++ b/docs/cloud-security/p-cs-01.md
@@ -1,0 +1,12 @@
+# Cloud Guardrails Blueprint
+
+**Slug:** p-cs-01  
+**Category:** Cloud Security  
+**Status:** Completed
+
+## Overview
+Authored baseline guardrails for AWS, Azure, and GCP covering identity, networking, and data protection.
+
+## Where to Start
+- Project README: [projects/p-cs-01/README.md](../../projects/p-cs-01/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/cloud-security/p-cs-02.md
+++ b/docs/cloud-security/p-cs-02.md
@@ -1,0 +1,12 @@
+# Kubernetes Runtime Hardening
+
+**Slug:** p-cs-02  
+**Category:** Cloud Security  
+**Status:** In Progress
+
+## Overview
+Elevating cluster security with PSP replacements, runtime scanning, and managed identities.
+
+## Where to Start
+- Project README: [projects/p-cs-02/README.md](../../projects/p-cs-02/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/cloud-security/p-cs-03.md
+++ b/docs/cloud-security/p-cs-03.md
@@ -1,0 +1,12 @@
+# Data Loss Prevention Rollout
+
+**Slug:** p-cs-03  
+**Category:** Cloud Security  
+**Status:** Completed
+
+## Overview
+Implemented DLP controls for SaaS and cloud storage with classification, alerting, and user education.
+
+## Where to Start
+- Project README: [projects/p-cs-03/README.md](../../projects/p-cs-03/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/cloud-security/p-cs-04.md
+++ b/docs/cloud-security/p-cs-04.md
@@ -1,0 +1,12 @@
+# Secrets Management Unification
+
+**Slug:** p-cs-04  
+**Category:** Cloud Security  
+**Status:** In Progress
+
+## Overview
+Consolidating secrets storage across clouds and CI/CD with automated rotation and least-privilege access.
+
+## Where to Start
+- Project README: [projects/p-cs-04/README.md](../../projects/p-cs-04/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/cloud-security/p-cs-05.md
+++ b/docs/cloud-security/p-cs-05.md
@@ -1,0 +1,12 @@
+# Cloud Security Monitoring Fabric
+
+**Slug:** p-cs-05  
+**Category:** Cloud Security  
+**Status:** Planned
+
+## Overview
+Designing unified cloud monitoring with event hubs, schema normalization, and golden signals for security.
+
+## Where to Start
+- Project README: [projects/p-cs-05/README.md](../../projects/p-cs-05/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/devops/p-devops-01.md
+++ b/docs/devops/p-devops-01.md
@@ -1,0 +1,12 @@
+# GitOps Platform Build
+
+**Slug:** p-devops-01  
+**Category:** DevOps / SRE  
+**Status:** Completed
+
+## Overview
+Built GitOps delivery for microservices with policy checks, progressive delivery, and secrets handling.
+
+## Where to Start
+- Project README: [projects/p-devops-01/README.md](../../projects/p-devops-01/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/devops/p-devops-02.md
+++ b/docs/devops/p-devops-02.md
@@ -1,0 +1,12 @@
+# Resilience Testing Program
+
+**Slug:** p-devops-02  
+**Category:** DevOps / SRE  
+**Status:** In Progress
+
+## Overview
+Standing up a resilience testing program with chaos experiments, SLOs, and automated rollbacks.
+
+## Where to Start
+- Project README: [projects/p-devops-02/README.md](../../projects/p-devops-02/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/devops/p-devops-03.md
+++ b/docs/devops/p-devops-03.md
@@ -1,0 +1,12 @@
+# Platform Observability Mesh
+
+**Slug:** p-devops-03  
+**Category:** DevOps / SRE  
+**Status:** Completed
+
+## Overview
+Unified logs, metrics, and traces with opinionated defaults and developer self-service dashboards.
+
+## Where to Start
+- Project README: [projects/p-devops-03/README.md](../../projects/p-devops-03/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/devops/p-devops-04.md
+++ b/docs/devops/p-devops-04.md
@@ -1,0 +1,12 @@
+# Cost Optimization Lab
+
+**Slug:** p-devops-04  
+**Category:** DevOps / SRE  
+**Status:** Completed
+
+## Overview
+Built a lab to evaluate autoscaling, rightsizing, and storage lifecycle policies with measurable savings.
+
+## Where to Start
+- Project README: [projects/p-devops-04/README.md](../../projects/p-devops-04/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/devops/p-devops-05.md
+++ b/docs/devops/p-devops-05.md
@@ -1,0 +1,12 @@
+# Reliability Runbooks
+
+**Slug:** p-devops-05  
+**Category:** DevOps / SRE  
+**Status:** Planned
+
+## Overview
+Creating standardized runbooks for on-call with graphs, queries, and decision trees per service.
+
+## Where to Start
+- Project README: [projects/p-devops-05/README.md](../../projects/p-devops-05/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/grc/p-grc-01.md
+++ b/docs/grc/p-grc-01.md
@@ -1,0 +1,12 @@
+# ISO 27001 Readiness
+
+**Slug:** p-grc-01  
+**Category:** GRC  
+**Status:** Completed
+
+## Overview
+Prepared an ISO 27001 readiness pack covering scope, controls, and evidence mapping.
+
+## Where to Start
+- Project README: [projects/p-grc-01/README.md](../../projects/p-grc-01/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/grc/p-grc-02.md
+++ b/docs/grc/p-grc-02.md
@@ -1,0 +1,12 @@
+# Risk Register Automation
+
+**Slug:** p-grc-02  
+**Category:** GRC  
+**Status:** In Progress
+
+## Overview
+Automating risk register updates with workflows for scoring, approvals, and reporting dashboards.
+
+## Where to Start
+- Project README: [projects/p-grc-02/README.md](../../projects/p-grc-02/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/grc/p-grc-03.md
+++ b/docs/grc/p-grc-03.md
@@ -1,0 +1,12 @@
+# Vendor Security Review
+
+**Slug:** p-grc-03  
+**Category:** GRC  
+**Status:** Completed
+
+## Overview
+Standardized vendor assessments with questionnaires, evidence collection, and remediation tracking.
+
+## Where to Start
+- Project README: [projects/p-grc-03/README.md](../../projects/p-grc-03/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/grc/p-grc-04.md
+++ b/docs/grc/p-grc-04.md
@@ -1,0 +1,12 @@
+# Policy Library Refresh
+
+**Slug:** p-grc-04  
+**Category:** GRC  
+**Status:** In Progress
+
+## Overview
+Refreshing the security policy library with versioning, owner accountability, and crosswalks to frameworks.
+
+## Where to Start
+- Project README: [projects/p-grc-04/README.md](../../projects/p-grc-04/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/grc/p-grc-05.md
+++ b/docs/grc/p-grc-05.md
@@ -1,0 +1,12 @@
+# BCP/DR Program
+
+**Slug:** p-grc-05  
+**Category:** GRC  
+**Status:** Planned
+
+## Overview
+Building a business continuity and disaster recovery program with impact analysis and test cycles.
+
+## Where to Start
+- Project README: [projects/p-grc-05/README.md](../../projects/p-grc-05/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Samuel Jackson — Security & DevOps Portfolio
+
+Welcome! I'm Sam Jackson, a systems-minded engineer who blends security, DevOps, and documentation rigor to ship reliable services. This site collects my portfolio projects, experiment notes, and supporting evidence so reviewers can quickly understand the impact and how to reproduce it.
+
+## How to use this portfolio
+
+- **Scan the Portfolio Index:** Jump to the [project index](PROJECT_INDEX.md) for a sortable view of all projects by category, status, and slug.
+- **Open any project:** Each project links to a detailed README with scenario, responsibilities, architecture notes, and reproduction steps.
+- **Reuse the patterns:** Feel free to adapt runbooks, IaC snippets, or detection content for your own environments. Most artifacts are designed to be portable.
+
+## What you'll find
+
+- Security exercises across red/blue/purple teaming, cloud guardrails, and policy work.
+- DevOps/SRE initiatives such as GitOps, observability meshes, and resilience testing.
+- GRC programs with audit readiness, risk automation, and business continuity planning.
+
+Thanks for visiting! If you want a guided walkthrough, start with the Portfolio Index or open any of the category pages in the navigation.

--- a/docs/red-team/p-rt-01.md
+++ b/docs/red-team/p-rt-01.md
@@ -1,0 +1,12 @@
+# Red Team Cloud Pivot
+
+**Slug:** p-rt-01  
+**Category:** Red Team  
+**Status:** Completed
+
+## Overview
+Simulated a multi-stage intrusion from phishing to cloud pivoting to validate detection depth across SaaS and IaaS assets.
+
+## Where to Start
+- Project README: [projects/p-rt-01/README.md](../../projects/p-rt-01/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/red-team/p-rt-02.md
+++ b/docs/red-team/p-rt-02.md
@@ -1,0 +1,12 @@
+# Adversary Emulation for OT Lab
+
+**Slug:** p-rt-02  
+**Category:** Red Team  
+**Status:** In Progress
+
+## Overview
+Built an emulation plan for ICS/SCADA environments using MITRE ATT&CK for ICS to validate segmentation controls.
+
+## Where to Start
+- Project README: [projects/p-rt-02/README.md](../../projects/p-rt-02/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/red-team/p-rt-03.md
+++ b/docs/red-team/p-rt-03.md
@@ -1,0 +1,12 @@
+# Wireless Intrusion Assessment
+
+**Slug:** p-rt-03  
+**Category:** Red Team  
+**Status:** Completed
+
+## Overview
+Evaluated enterprise Wi-Fi security by performing rogue AP, evil-twin, and PMKID harvesting attacks.
+
+## Where to Start
+- Project README: [projects/p-rt-03/README.md](../../projects/p-rt-03/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/red-team/p-rt-04.md
+++ b/docs/red-team/p-rt-04.md
@@ -1,0 +1,12 @@
+# Web App Exploitation Playbook
+
+**Slug:** p-rt-04  
+**Category:** Red Team  
+**Status:** Planned
+
+## Overview
+Curated repeatable exploit chains for a legacy Java web stack, focusing on deserialization and SSRF risks.
+
+## Where to Start
+- Project README: [projects/p-rt-04/README.md](../../projects/p-rt-04/README.md)
+- Evidence and assets: See links inside the README.

--- a/docs/red-team/p-rt-05.md
+++ b/docs/red-team/p-rt-05.md
@@ -1,0 +1,12 @@
+# Physical Security Bypass
+
+**Slug:** p-rt-05  
+**Category:** Red Team  
+**Status:** Completed
+
+## Overview
+Tested badge cloning and tailgating controls for a regional office, including social engineering resilience.
+
+## Where to Start
+- Project README: [projects/p-rt-05/README.md](../../projects/p-rt-05/README.md)
+- Evidence and assets: See links inside the README.

--- a/exports/projects.json
+++ b/exports/projects.json
@@ -1,0 +1,930 @@
+[
+  {
+    "slug": "p-rt-01",
+    "title": "Red Team Cloud Pivot",
+    "role_category": "Red Team",
+    "status": "Completed",
+    "executive_summary": "Simulated a multi-stage intrusion from phishing to cloud pivoting to validate detection depth across SaaS and IaaS assets.",
+    "scenario_scope": "Assumed-compromise of a user mailbox with expansion into an Azure workload landing zone.",
+    "responsibilities": [
+      "Designed realistic phishing lure and payload chain",
+      "Abused OAuth token reuse to access cloud resources",
+      "Coordinated purple-team debrief with defenders"
+    ],
+    "tools_tech": ["Evilginx", "Azure CLI", "BloodHound", "KQL", "Burp Suite"],
+    "architecture_notes": "Isolated attack infrastructure in a throwaway VNet with rotating outbound IPs and strict logging to a separate SIEM tenant.",
+    "process_walkthrough": [
+      "Conducted controlled phishing campaign with time-boxed scope",
+      "Harvested tokens and validated MFA resilience",
+      "Pivoted into Azure via misconfigured app registrations",
+      "Documented detection opportunities and compensating controls"
+    ],
+    "outcomes_metrics": [
+      "Reduced risky OAuth app registrations by 80%",
+      "Implemented conditional access policies for legacy protocols",
+      "Added KQL detections for anomalous consent grants"
+    ],
+    "evidence_links": [
+      "reports/p-rt-01/phishing-report.pdf",
+      "dashboards/kql-detections.md"
+    ],
+    "reproduction_steps": [
+      "Deploy the throwaway VNet using the provided Terraform module",
+      "Run the phishing workflow with pre-approved targets",
+      "Review SIEM alerts generated during the exercise"
+    ],
+    "interview_points": [
+      "Why token-based persistence is harder to detect than password reuse",
+      "How to scope red-team exercises to protect production tenants",
+      "Cloud-specific detections for OAuth consent abuse"
+    ]
+  },
+  {
+    "slug": "p-rt-02",
+    "title": "Adversary Emulation for OT Lab",
+    "role_category": "Red Team",
+    "status": "In Progress",
+    "executive_summary": "Built an emulation plan for ICS/SCADA environments using MITRE ATT&CK for ICS to validate segmentation controls.",
+    "scenario_scope": "Targeted a lab with Modbus/TCP devices behind a jump host and engineering workstation.",
+    "responsibilities": [
+      "Mapped ATT&CK for ICS techniques to lab assets",
+      "Authored safe payloads to avoid process disruption",
+      "Ran purple-team tabletop with SOC and OT engineers"
+    ],
+    "tools_tech": ["Caldera", "Atomic Red Team", "Wireshark", "GNS3", "ModbusPal"],
+    "architecture_notes": "Segmentation enforced via dual-firewall zones; testing executed from a hardened Ubuntu jump box with strict egress rules.",
+    "process_walkthrough": [
+      "Cataloged OT assets and network flows",
+      "Selected low-impact techniques for the lab",
+      "Executed emulation steps with real-time monitoring",
+      "Captured packet traces and log artifacts for SOC tuning"
+    ],
+    "outcomes_metrics": [
+      "Documented 12 new OT detections",
+      "Validated firewall ACLs for engineering subnets",
+      "Provided evidence pack for compliance reviewers"
+    ],
+    "evidence_links": ["reports/p-rt-02/ot-emulation.pdf"],
+    "reproduction_steps": [
+      "Start the OT lab VMs using the provided compose file",
+      "Launch Caldera with the ICS plugin",
+      "Replay the scripted ATT&CK sequences and capture logs"
+    ],
+    "interview_points": [
+      "Balancing realism and safety in OT testing",
+      "Mapping ATT&CK for ICS to detection engineering",
+      "Coordinating with operations teams during emulation"
+    ]
+  },
+  {
+    "slug": "p-rt-03",
+    "title": "Wireless Intrusion Assessment",
+    "role_category": "Red Team",
+    "status": "Completed",
+    "executive_summary": "Evaluated enterprise Wi-Fi security by performing rogue AP, evil-twin, and PMKID harvesting attacks.",
+    "scenario_scope": "Office SSIDs with WPA2-Enterprise and guest networks segmented via VLANs.",
+    "responsibilities": [
+      "Configured rogue AP with automatic credential capture",
+      "Performed controlled deauth and PMKID collection",
+      "Delivered hardening guidance for RADIUS and certificate validation"
+    ],
+    "tools_tech": ["Kali", "hostapd-wpe", "hcxdumptool", "Wireshark", "Aircrack-ng"],
+    "architecture_notes": "Used battery-powered rogue AP kit with 4G uplink; logs streamed to central syslog for chain-of-custody.",
+    "process_walkthrough": [
+      "Surveyed spectrum and SSIDs",
+      "Executed evil-twin and deauth scenarios",
+      "Captured PMKID handshakes and attempted offline crack",
+      "Validated 802.1X certificate pinning settings"
+    ],
+    "outcomes_metrics": [
+      "Enabled EAP-TLS enforcement for corporate devices",
+      "Blocked legacy TKIP negotiation",
+      "Added rogue AP detection alerts to NMS"
+    ],
+    "evidence_links": ["reports/p-rt-03/wifi-assessment.pdf"],
+    "reproduction_steps": [
+      "Flash the rogue AP SD card with the provided image",
+      "Run the collection script and monitor syslog",
+      "Test 802.1X validation on sample devices"
+    ],
+    "interview_points": [
+      "Defending against evil-twin attacks",
+      "Why certificate validation stops most credential theft",
+      "Coordinating wireless testing with facilities"
+    ]
+  },
+  {
+    "slug": "p-rt-04",
+    "title": "Web App Exploitation Playbook",
+    "role_category": "Red Team",
+    "status": "Planned",
+    "executive_summary": "Curated repeatable exploit chains for a legacy Java web stack, focusing on deserialization and SSRF risks.",
+    "scenario_scope": "Internal bug bounty mirror environment with outdated app server and S3-compatible storage.",
+    "responsibilities": [
+      "Catalog CVE coverage and detection gaps",
+      "Develop SSRF-to-RCE chain with metadata abuse",
+      "Package exploits into safe, repeatable scripts"
+    ],
+    "tools_tech": ["Burp Suite", "ysoserial", "ffuf", "Go", "Docker"],
+    "architecture_notes": "Isolated testing network with replayable fixtures; S3 bucket emulated via MinIO to avoid production access.",
+    "process_walkthrough": [
+      "Set up vulnerable app via docker-compose",
+      "Enumerate endpoints and test deserialization gadgets",
+      "Craft SSRF payloads targeting instance metadata",
+      "Automate exploit chain with safety toggles"
+    ],
+    "outcomes_metrics": [
+      "Documented four exploit playbooks with mitigations",
+      "Provided developer-safe repro scripts",
+      "Enabled CI security gate for deserialization payload detection"
+    ],
+    "evidence_links": ["playbooks/p-rt-04/web-exploit-playbook.md"],
+    "reproduction_steps": [
+      "Start the vulnerable stack with docker-compose",
+      "Run the exploit scripts with sandbox credentials",
+      "Capture logs for S3 access and metadata calls"
+    ],
+    "interview_points": [
+      "Tradeoffs between patching and virtual patching",
+      "Safe exploitation practices in shared labs",
+      "How SSRF escalates in cloud environments"
+    ]
+  },
+  {
+    "slug": "p-rt-05",
+    "title": "Physical Security Bypass",
+    "role_category": "Red Team",
+    "status": "Completed",
+    "executive_summary": "Tested badge cloning and tailgating controls for a regional office, including social engineering resilience.",
+    "scenario_scope": "Two-floor office with HID badges, visitor kiosks, and mantrap entry.",
+    "responsibilities": [
+      "Captured badge IDs using proximity readers",
+      "Attempted clone with reflashable cards",
+      "Conducted staff awareness checks and debriefs"
+    ],
+    "tools_tech": ["Proxmark3", "Flipper Zero", "GoPro", "Kali"],
+    "architecture_notes": "Coordinated with facilities and security; all tests logged with timestamps and video capture for auditability.",
+    "process_walkthrough": [
+      "Surveyed entry points and badge readers",
+      "Captured card data and attempted clones",
+      "Validated door controller logging and alarms",
+      "Ran awareness recap with office leadership"
+    ],
+    "outcomes_metrics": [
+      "Upgraded to SEOS badges for cryptographic validation",
+      "Improved tailgating enforcement through policy updates",
+      "Added door event feeds into SOC dashboards"
+    ],
+    "evidence_links": ["reports/p-rt-05/physical-bypass.pdf"],
+    "reproduction_steps": [
+      "Use lab-issued test badges with Proxmark3",
+      "Attempt clone and test against demo door controller",
+      "Review SOC alerts for unauthorized entries"
+    ],
+    "interview_points": [
+      "Physical security integration with SOC",
+      "Badge technology differences (HID vs SEOS)",
+      "Coordinating red-team ops with facilities"
+    ]
+  },
+  {
+    "slug": "p-bt-01",
+    "title": "SOC Playbook Modernization",
+    "role_category": "Blue Team",
+    "status": "Completed",
+    "executive_summary": "Refreshed SOC runbooks with cloud-first detections, unified triage steps, and response automation hooks.",
+    "scenario_scope": "Coverage across Windows, Linux, and cloud audit logs with integration into a central SOAR.",
+    "responsibilities": [
+      "Mapped alerts to MITRE ATT&CK",
+      "Defined triage decision trees",
+      "Added SOAR automation triggers and rollbacks"
+    ],
+    "tools_tech": ["Sentinel", "Splunk", "SOAR", "KQL", "Sigma"],
+    "architecture_notes": "Standardized ingestion pipelines with schema validation; SOAR playbooks run in isolated worker VMs.",
+    "process_walkthrough": [
+      "Prioritized alerts based on threat intel",
+      "Documented triage steps and data sources",
+      "Automated containment for high-fidelity alerts",
+      "Performed tabletop exercises to validate runbooks"
+    ],
+    "outcomes_metrics": [
+      "Reduced mean time to respond by 30%",
+      "Unified alert taxonomy across tools",
+      "Added rollback steps for automated actions"
+    ],
+    "evidence_links": ["runbooks/p-bt-01/soc-playbooks.md"],
+    "reproduction_steps": [
+      "Import Sigma rules into the SIEM",
+      "Deploy SOAR workflows via provided scripts",
+      "Run tabletop scenarios with the sample alerts"
+    ],
+    "interview_points": [
+      "Balancing automation with analyst oversight",
+      "Mapping ATT&CK techniques to detection content",
+      "Versioning and testing SOC runbooks"
+    ]
+  },
+  {
+    "slug": "p-bt-02",
+    "title": "Endpoint Telemetry Uplift",
+    "role_category": "Blue Team",
+    "status": "In Progress",
+    "executive_summary": "Expanded EDR telemetry coverage for Linux servers and macOS endpoints with standardized baselines.",
+    "scenario_scope": "Hybrid fleet across cloud VMs and corporate laptops with varying OS baselines.",
+    "responsibilities": [
+      "Defined minimum viable telemetry events",
+      "Rolled out new agent policies via MDM",
+      "Validated detections for persistence and lateral movement"
+    ],
+    "tools_tech": ["Elastic Agent", "osquery", "FleetDM", "MDM", "Ansible"],
+    "architecture_notes": "Used staged rollout rings with health checks; events forward through message queue before SIEM ingestion.",
+    "process_walkthrough": [
+      "Captured current state of endpoint logging",
+      "Authored baseline policies for each OS",
+      "Piloted deployment with rollback plans",
+      "Measured detection fidelity against atomic tests"
+    ],
+    "outcomes_metrics": [
+      "Expanded Linux coverage from 40% to 95%",
+      "Standardized 25 baseline queries",
+      "Reduced false positives through tuned rules"
+    ],
+    "evidence_links": ["dashboards/p-bt-02/endpoint-coverage.md"],
+    "reproduction_steps": [
+      "Enroll a test device via FleetDM",
+      "Apply the baseline policy profile",
+      "Trigger atomic persistence tests and review alerts"
+    ],
+    "interview_points": [
+      "How to phase agent rollouts safely",
+      "Balancing telemetry volume with cost",
+      "Detecting lateral movement with osquery"
+    ]
+  },
+  {
+    "slug": "p-bt-03",
+    "title": "SIEM Content as Code",
+    "role_category": "Blue Team",
+    "status": "Completed",
+    "executive_summary": "Implemented version-controlled SIEM detections with CI linting, staged promotion, and automated packaging.",
+    "scenario_scope": "Centralized SIEM with multiple tenants and environment-specific overrides.",
+    "responsibilities": [
+      "Converted ad-hoc KQL queries into reusable modules",
+      "Built CI checks for schema validation",
+      "Created release pipeline for content promotion"
+    ],
+    "tools_tech": ["Azure DevOps", "KQL", "YAML", "Git", "Python"],
+    "architecture_notes": "Detection content stored in Git repo with environment overlays; CI builds signed packages deployed via API.",
+    "process_walkthrough": [
+      "Migrated existing queries into modules",
+      "Added unit tests and linters for KQL",
+      "Published signed content to staging, then production",
+      "Monitored detections for drift and false positives"
+    ],
+    "outcomes_metrics": [
+      "Reduced manual deployment errors to zero",
+      "Cut detection promotion time by 60%",
+      "Enabled rollback via signed artifact history"
+    ],
+    "evidence_links": ["pipelines/p-bt-03/sien-content-ci.md"],
+    "reproduction_steps": [
+      "Clone the detection repo and install dev dependencies",
+      "Run the CI lint workflow locally",
+      "Publish a signed content package to the staging SIEM"
+    ],
+    "interview_points": [
+      "Versioning strategies for detection content",
+      "Testing KQL queries before production",
+      "Handling environment-specific overrides"
+    ]
+  },
+  {
+    "slug": "p-bt-04",
+    "title": "Threat Hunting Sprint",
+    "role_category": "Blue Team",
+    "status": "Completed",
+    "executive_summary": "Ran a two-week hunting sprint focused on identity misuse and cloud console anomalies using hypothesis-driven hunts.",
+    "scenario_scope": "Identity provider logs, cloud audit trails, and VPN telemetry.",
+    "responsibilities": [
+      "Formulated hunting hypotheses",
+      "Built detections for anomalous sign-ins",
+      "Created dashboards for hunt findings"
+    ],
+    "tools_tech": ["Splunk", "Jupyter", "Python", "Sigma", "Okta logs"],
+    "architecture_notes": "Data lake backed by object storage; hunts executed in notebooks with saved KQL/SPL queries for reuse.",
+    "process_walkthrough": [
+      "Defined hunt scope and data sources",
+      "Ran exploratory analytics and baselines",
+      "Converted hunts into persistent detections",
+      "Reported findings and tuned alerts"
+    ],
+    "outcomes_metrics": [
+      "Discovered two misconfigured admin accounts",
+      "Built four new identity anomaly detections",
+      "Documented baselines for VPN geolocation alerts"
+    ],
+    "evidence_links": ["hunts/p-bt-04/hunt-report.md"],
+    "reproduction_steps": [
+      "Load the sample Okta and VPN logs",
+      "Run the provided notebooks to compute baselines",
+      "Deploy the Sigma-derived rules to your SIEM"
+    ],
+    "interview_points": [
+      "Hypothesis-driven hunting",
+      "Turning hunts into detections",
+      "Data quality considerations for identity telemetry"
+    ]
+  },
+  {
+    "slug": "p-bt-05",
+    "title": "Incident Response Playoff",
+    "role_category": "Blue Team",
+    "status": "Planned",
+    "executive_summary": "Designing a gamified IR exercise that pits teams against live-fire scenarios with measured MTTR targets.",
+    "scenario_scope": "Simulated ransomware across mixed Windows/Linux estate with cloud workloads.",
+    "responsibilities": [
+      "Author inject timeline and artifacts",
+      "Define scoring tied to MTTR and containment",
+      "Provide post-incident review templates"
+    ],
+    "tools_tech": ["Velociraptor", "Azure Sentinel", "Ansible", "Caldera", "Slack bots"],
+    "architecture_notes": "Exercise lab isolated via virtualization; snapshot/restore enabled for repeatability and safety.",
+    "process_walkthrough": [
+      "Prepare lab images and data sets",
+      "Execute injects via automation scripts",
+      "Score responses and track timelines",
+      "Facilitate post-incident reviews"
+    ],
+    "outcomes_metrics": [
+      "Baseline MTTR benchmarks for ransomware cases",
+      "Standardized after-action reporting",
+      "Improved collaboration runbooks across teams"
+    ],
+    "evidence_links": ["exercises/p-bt-05/ir-playoff.md"],
+    "reproduction_steps": [
+      "Spin up the lab with provided scripts",
+      "Run the inject automation",
+      "Record response times and compare to benchmarks"
+    ],
+    "interview_points": [
+      "Designing safe yet realistic IR exercises",
+      "Metrics that matter beyond MTTR",
+      "Automating injects and resets"
+    ]
+  },
+  {
+    "slug": "p-cs-01",
+    "title": "Cloud Guardrails Blueprint",
+    "role_category": "Cloud Security",
+    "status": "Completed",
+    "executive_summary": "Authored baseline guardrails for AWS, Azure, and GCP covering identity, networking, and data protection.",
+    "scenario_scope": "Greenfield multi-cloud foundation with centralized identity and logging.",
+    "responsibilities": [
+      "Mapped CIS benchmarks to cloud policies",
+      "Built landing zone guardrails",
+      "Published reusable policy-as-code modules"
+    ],
+    "tools_tech": ["Terraform", "AWS Organizations", "Azure Policy", "GCP Organization Policy", "OPA"],
+    "architecture_notes": "Guardrails enforced via org-level policies with exception workflows; logs aggregated into a security account.",
+    "process_walkthrough": [
+      "Defined baseline security controls",
+      "Implemented policies via Terraform modules",
+      "Tested enforcement with exception paths",
+      "Documented runbooks for tenant onboarding"
+    ],
+    "outcomes_metrics": [
+      "Achieved 95% policy coverage for new accounts",
+      "Reduced manual exceptions by introducing approvals",
+      "Centralized audit logging across clouds"
+    ],
+    "evidence_links": ["guardrails/p-cs-01/policies.md"],
+    "reproduction_steps": [
+      "Deploy the org-level Terraform stack",
+      "Onboard a test account/subscription",
+      "Validate policy enforcement and logging"
+    ],
+    "interview_points": [
+      "Balancing guardrails with developer velocity",
+      "Handling exceptions and drift",
+      "Cross-cloud identity alignment"
+    ]
+  },
+  {
+    "slug": "p-cs-02",
+    "title": "Kubernetes Runtime Hardening",
+    "role_category": "Cloud Security",
+    "status": "In Progress",
+    "executive_summary": "Elevating cluster security with PSP replacements, runtime scanning, and managed identities.",
+    "scenario_scope": "EKS and AKS clusters running internal services with GitOps delivery.",
+    "responsibilities": [
+      "Defined baseline policies for pods and namespaces",
+      "Integrated admission controllers and image scanning",
+      "Enabled managed identities for service-to-service auth"
+    ],
+    "tools_tech": ["Kyverno", "Trivy", "OPA Gatekeeper", "IRSA", "Azure AD Workload Identity"],
+    "architecture_notes": "Policy bundles managed via GitOps; scanners run pre-deploy and at runtime; secrets offloaded to cloud KMS.",
+    "process_walkthrough": [
+      "Audited existing cluster settings",
+      "Implemented admission policies",
+      "Added runtime and supply chain scanning",
+      "Tested break-glass scenarios and RBAC controls"
+    ],
+    "outcomes_metrics": [
+      "Blocked privileged pod deployments",
+      "Achieved 100% image scanning coverage",
+      "Improved service identity posture without secrets in pods"
+    ],
+    "evidence_links": ["clusters/p-cs-02/k8s-hardening.md"],
+    "reproduction_steps": [
+      "Apply Kyverno policies via Helm",
+      "Run Trivy scans on images pre-deploy",
+      "Validate IRSA/Workload Identity mappings"
+    ],
+    "interview_points": [
+      "Admission control vs runtime controls",
+      "Identity handling for Kubernetes workloads",
+      "Testing policies without blocking deploys"
+    ]
+  },
+  {
+    "slug": "p-cs-03",
+    "title": "Data Loss Prevention Rollout",
+    "role_category": "Cloud Security",
+    "status": "Completed",
+    "executive_summary": "Implemented DLP controls for SaaS and cloud storage with classification, alerting, and user education.",
+    "scenario_scope": "Microsoft 365, Google Workspace, and S3 buckets storing regulated data.",
+    "responsibilities": [
+      "Classified data with sensitivity labels",
+      "Defined DLP policies for email and storage",
+      "Built user-friendly justifications and overrides"
+    ],
+    "tools_tech": ["Microsoft Purview", "Google DLP", "Amazon Macie", "KMS", "Power Automate"],
+    "architecture_notes": "Centralized DLP events forwarded to SIEM; override workflows log justifications for audit.",
+    "process_walkthrough": [
+      "Mapped data types to labels",
+      "Deployed DLP policies in audit mode",
+      "Educated users and enabled enforcement",
+      "Monitored alerts and tuned policies"
+    ],
+    "outcomes_metrics": [
+      "Cut outbound sensitive emails by 70%",
+      "Tagged 90% of S3 objects with labels",
+      "Captured override justifications for audits"
+    ],
+    "evidence_links": ["policies/p-cs-03/dlp-rollout.md"],
+    "reproduction_steps": [
+      "Enable labels in M365 and Workspace",
+      "Deploy DLP policies in audit then enforce",
+      "Review Macie findings and SIEM alerts"
+    ],
+    "interview_points": [
+      "Balancing user productivity with DLP",
+      "Cross-platform labeling consistency",
+      "Handling false positives gracefully"
+    ]
+  },
+  {
+    "slug": "p-cs-04",
+    "title": "Secrets Management Unification",
+    "role_category": "Cloud Security",
+    "status": "In Progress",
+    "executive_summary": "Consolidating secrets storage across clouds and CI/CD with automated rotation and least-privilege access.",
+    "scenario_scope": "AWS, Azure, and GitHub Actions workloads consuming shared secrets.",
+    "responsibilities": [
+      "Inventory existing secrets and owners",
+      "Migrated credentials into managed vaults",
+      "Automated rotation and audit logging"
+    ],
+    "tools_tech": ["HashiCorp Vault", "AWS Secrets Manager", "Azure Key Vault", "GitHub OIDC", "Terraform"],
+    "architecture_notes": "Federated OIDC access for CI; apps retrieve secrets via short-lived tokens with per-service namespaces.",
+    "process_walkthrough": [
+      "Mapped secrets to services and lifecycle",
+      "Provisioned vault namespaces and policies",
+      "Implemented rotation jobs and alerting",
+      "Removed plaintext secrets from repos"
+    ],
+    "outcomes_metrics": [
+      "Eliminated long-lived CI secrets",
+      "Rotated 100% of high-risk credentials",
+      "Added audit trails and owner metadata"
+    ],
+    "evidence_links": ["runbooks/p-cs-04/secrets-unification.md"],
+    "reproduction_steps": [
+      "Deploy Vault with the provided helm chart",
+      "Configure GitHub OIDC roles for CI",
+      "Migrate application secrets and test rotation"
+    ],
+    "interview_points": [
+      "Choosing between cloud-native and Vault",
+      "Designing least privilege for secrets",
+      "Automating rotation without downtime"
+    ]
+  },
+  {
+    "slug": "p-cs-05",
+    "title": "Cloud Security Monitoring Fabric",
+    "role_category": "Cloud Security",
+    "status": "Planned",
+    "executive_summary": "Designing unified cloud monitoring with event hubs, schema normalization, and golden signals for security.",
+    "scenario_scope": "Multi-cloud log aggregation with detections for identity, network, and data access.",
+    "responsibilities": [
+      "Define canonical schemas for audit logs",
+      "Build ingestion pipelines with buffering",
+      "Publish golden signals dashboards"
+    ],
+    "tools_tech": ["Event Hub", "Kinesis", "Pub/Sub", "Fluent Bit", "BigQuery"],
+    "architecture_notes": "Hub-and-spoke log ingestion with buffering; normalization via stream processors; storage in data lake with tiered retention.",
+    "process_walkthrough": [
+      "Survey cloud audit sources",
+      "Implement streaming normalization",
+      "Publish metrics and dashboards",
+      "Pilot detections and alert routing"
+    ],
+    "outcomes_metrics": [
+      "Unified schema for 12 log types",
+      "Reduced ingestion failures via buffering",
+      "Published actionable golden signals"
+    ],
+    "evidence_links": ["designs/p-cs-05/monitoring-fabric.md"],
+    "reproduction_steps": [
+      "Deploy the event hub stack",
+      "Connect cloud audit sources",
+      "Run sample normalization jobs"
+    ],
+    "interview_points": [
+      "Why normalization matters for multi-cloud",
+      "Buffering strategies for log spikes",
+      "Golden signals for security telemetry"
+    ]
+  },
+  {
+    "slug": "p-devops-01",
+    "title": "GitOps Platform Build",
+    "role_category": "DevOps / SRE",
+    "status": "Completed",
+    "executive_summary": "Built GitOps delivery for microservices with policy checks, progressive delivery, and secrets handling.",
+    "scenario_scope": "Kubernetes clusters with Argo CD and progressive delivery for internal APIs.",
+    "responsibilities": [
+      "Implemented repo layout and templates",
+      "Added policy checks and image attestations",
+      "Enabled blue/green and canary strategies"
+    ],
+    "tools_tech": ["Argo CD", "Argo Rollouts", "Kyverno", "Cosign", "Helm"],
+    "architecture_notes": "App-of-apps pattern with per-env overlays; admission policies enforce signed images; metrics drive rollout gates.",
+    "process_walkthrough": [
+      "Structured repos for apps and ops",
+      "Configured Argo CD projects and RBAC",
+      "Enabled rollout strategies with metrics",
+      "Documented secrets patterns with external vaults"
+    ],
+    "outcomes_metrics": [
+      "Reduced deployment lead time by 50%",
+      "Achieved 100% signed image enforcement",
+      "Improved rollback time via Git history"
+    ],
+    "evidence_links": ["platform/p-devops-01/gitops-build.md"],
+    "reproduction_steps": [
+      "Install Argo CD and Rollouts via Helm",
+      "Apply the app-of-apps manifests",
+      "Trigger a canary and monitor metrics"
+    ],
+    "interview_points": [
+      "Structuring GitOps repos",
+      "Progressive delivery patterns",
+      "Policy checks in the delivery pipeline"
+    ]
+  },
+  {
+    "slug": "p-devops-02",
+    "title": "Resilience Testing Program",
+    "role_category": "DevOps / SRE",
+    "status": "In Progress",
+    "executive_summary": "Standing up a resilience testing program with chaos experiments, SLOs, and automated rollbacks.",
+    "scenario_scope": "Microservices on Kubernetes with stateful services in managed databases.",
+    "responsibilities": [
+      "Defined SLOs and error budgets",
+      "Authored chaos experiments for dependencies",
+      "Integrated rollback automation based on KPIs"
+    ],
+    "tools_tech": ["LitmusChaos", "Grafana", "Prometheus", "Fluent Bit", "Terraform"],
+    "architecture_notes": "Experiments executed in non-prod first; metrics exported to Grafana; alerting tied to error budgets.",
+    "process_walkthrough": [
+      "Capture service level indicators",
+      "Design chaos scenarios for dependencies",
+      "Automate rollbacks when SLOs breach",
+      "Review experiments in weekly ops council"
+    ],
+    "outcomes_metrics": [
+      "Established SLOs for five services",
+      "Reduced outage MTTR via automated rollbacks",
+      "Documented playbooks for repeatable chaos runs"
+    ],
+    "evidence_links": ["resilience/p-devops-02/chaos-program.md"],
+    "reproduction_steps": [
+      "Deploy LitmusChaos and install CRDs",
+      "Run sample experiments against staging",
+      "Monitor SLO dashboards during tests"
+    ],
+    "interview_points": [
+      "Running chaos safely",
+      "Choosing SLOs and SLIs",
+      "Automating rollback decisions"
+    ]
+  },
+  {
+    "slug": "p-devops-03",
+    "title": "Platform Observability Mesh",
+    "role_category": "DevOps / SRE",
+    "status": "Completed",
+    "executive_summary": "Unified logs, metrics, and traces with opinionated defaults and developer self-service dashboards.",
+    "scenario_scope": "Multi-cluster setup with shared observability stack and tenant isolation.",
+    "responsibilities": [
+      "Deployed distributed tracing",
+      "Normalized logs and metrics schemas",
+      "Built golden signal dashboards"
+    ],
+    "tools_tech": ["OpenTelemetry", "Tempo", "Loki", "Prometheus", "Grafana"],
+    "architecture_notes": "Control plane cluster hosts observability stack; tenants onboard via Helm charts with scoped credentials.",
+    "process_walkthrough": [
+      "Set up OTel collectors and exporters",
+      "Enabled tracing libraries for services",
+      "Created reusable dashboard templates",
+      "Documented tenant onboarding steps"
+    ],
+    "outcomes_metrics": [
+      "Achieved trace coverage for 90% of services",
+      "Standardized log labels across clusters",
+      "Reduced triage time via golden dashboards"
+    ],
+    "evidence_links": ["observability/p-devops-03/mesh.md"],
+    "reproduction_steps": [
+      "Deploy the observability stack via Helmfile",
+      "Install OTel collectors per cluster",
+      "Instrument sample services and verify dashboards"
+    ],
+    "interview_points": [
+      "Multi-tenant observability design",
+      "Tradeoffs between push vs pull metrics",
+      "Rollout strategies for tracing"
+    ]
+  },
+  {
+    "slug": "p-devops-04",
+    "title": "Cost Optimization Lab",
+    "role_category": "DevOps / SRE",
+    "status": "Completed",
+    "executive_summary": "Built a lab to evaluate autoscaling, rightsizing, and storage lifecycle policies with measurable savings.",
+    "scenario_scope": "Workloads across AWS and Azure with mixed batch and web services.",
+    "responsibilities": [
+      "Benchmarked autoscaling policies",
+      "Evaluated storage lifecycle rules",
+      "Modeled savings scenarios"
+    ],
+    "tools_tech": ["AWS Compute Optimizer", "Azure Advisor", "Grafana", "Karpenter", "FinOps dashboards"],
+    "architecture_notes": "Lab workloads tagged for cost tracking; dashboards aggregate costs by service and environment.",
+    "process_walkthrough": [
+      "Instrument workloads with cost tags",
+      "Run autoscaling experiments",
+      "Apply lifecycle rules to storage",
+      "Summarize savings and recommendations"
+    ],
+    "outcomes_metrics": [
+      "Identified 25% compute savings",
+      "Reduced storage spend via lifecycle rules",
+      "Produced FinOps-ready dashboards"
+    ],
+    "evidence_links": ["finops/p-devops-04/cost-lab.md"],
+    "reproduction_steps": [
+      "Deploy sample workloads with tags",
+      "Run autoscaling scenarios",
+      "Review cost dashboards and recommendations"
+    ],
+    "interview_points": [
+      "Balancing performance and cost",
+      "Autoscaling strategies across clouds",
+      "Building FinOps dashboards"
+    ]
+  },
+  {
+    "slug": "p-devops-05",
+    "title": "Reliability Runbooks",
+    "role_category": "DevOps / SRE",
+    "status": "Planned",
+    "executive_summary": "Creating standardized runbooks for on-call with graphs, queries, and decision trees per service.",
+    "scenario_scope": "Critical services spanning APIs, queues, and databases across regions.",
+    "responsibilities": [
+      "Document service overviews and owners",
+      "Provide quick diagnostics and graphs",
+      "Define escalation and rollback paths"
+    ],
+    "tools_tech": ["Grafana", "PagerDuty", "RunWhen", "Terraform", "Markdown"],
+    "architecture_notes": "Runbooks stored with code; linked dashboards auto-open with relevant variables for incidents.",
+    "process_walkthrough": [
+      "Interview service owners",
+      "Document golden signals and alerts",
+      "Publish runbooks with decision trees",
+      "Pilot with on-call rotations"
+    ],
+    "outcomes_metrics": [
+      "Faster incident triage",
+      "Consistent escalation paths",
+      "Reduced toil via scripted diagnostics"
+    ],
+    "evidence_links": ["runbooks/p-devops-05/reliability-runbooks.md"],
+    "reproduction_steps": [
+      "Clone the runbooks repo",
+      "Open service pages in Grafana",
+      "Test the diagnostic scripts"
+    ],
+    "interview_points": [
+      "Designing actionable runbooks",
+      "Keeping runbooks versioned with code",
+      "Measuring runbook effectiveness"
+    ]
+  },
+  {
+    "slug": "p-grc-01",
+    "title": "ISO 27001 Readiness",
+    "role_category": "GRC",
+    "status": "Completed",
+    "executive_summary": "Prepared an ISO 27001 readiness pack covering scope, controls, and evidence mapping.",
+    "scenario_scope": "SaaS platform with multi-tenant architecture across two regions.",
+    "responsibilities": [
+      "Defined ISMS scope",
+      "Mapped Annex A controls",
+      "Gathered evidence with owners"
+    ],
+    "tools_tech": ["Confluence", "Jira", "Drata", "Excel", "PowerPoint"],
+    "architecture_notes": "Evidence library stored in versioned folders; control owners tracked via ticketing with due dates.",
+    "process_walkthrough": [
+      "Kickoff with leadership",
+      "Run gap assessment",
+      "Assign control owners",
+      "Compile evidence and risk register"
+    ],
+    "outcomes_metrics": [
+      "Closed 75% of gaps ahead of audit",
+      "Documented clear scope statement",
+      "Streamlined evidence collection workflows"
+    ],
+    "evidence_links": ["grc/p-grc-01/iso-readiness.md"],
+    "reproduction_steps": [
+      "Review the scope document",
+      "Follow the gap assessment checklist",
+      "Collect evidence using the templates"
+    ],
+    "interview_points": [
+      "Scoping ISMS boundaries",
+      "Tracking control ownership",
+      "Common pitfalls before certification"
+    ]
+  },
+  {
+    "slug": "p-grc-02",
+    "title": "Risk Register Automation",
+    "role_category": "GRC",
+    "status": "In Progress",
+    "executive_summary": "Automating risk register updates with workflows for scoring, approvals, and reporting dashboards.",
+    "scenario_scope": "Enterprise risk program spanning product, infra, and vendor risks.",
+    "responsibilities": [
+      "Defined risk scoring model",
+      "Built intake workflow",
+      "Published reporting dashboards"
+    ],
+    "tools_tech": ["Power Automate", "Power BI", "SharePoint", "Python", "SQL"],
+    "architecture_notes": "Risk data stored in SQL backend with API; workflows enforce approvals; dashboards pull nightly snapshots.",
+    "process_walkthrough": [
+      "Design intake forms",
+      "Implement scoring automation",
+      "Notify owners for reviews",
+      "Publish dashboards to leadership"
+    ],
+    "outcomes_metrics": [
+      "Reduced manual updates by 60%",
+      "Improved visibility into high risks",
+      "Automated reminders for reviews"
+    ],
+    "evidence_links": ["grc/p-grc-02/risk-automation.md"],
+    "reproduction_steps": [
+      "Deploy the SQL schema",
+      "Set up Power Automate flows",
+      "Publish the Power BI dashboard"
+    ],
+    "interview_points": [
+      "Designing usable risk workflows",
+      "Choosing scoring models",
+      "Reporting risk to leadership"
+    ]
+  },
+  {
+    "slug": "p-grc-03",
+    "title": "Vendor Security Review",
+    "role_category": "GRC",
+    "status": "Completed",
+    "executive_summary": "Standardized vendor assessments with questionnaires, evidence collection, and remediation tracking.",
+    "scenario_scope": "Third-party SaaS providers handling customer data across regions.",
+    "responsibilities": [
+      "Authored questionnaire templates",
+      "Built scoring rubric",
+      "Tracked remediation tasks"
+    ],
+    "tools_tech": ["OneTrust", "Jira", "SharePoint", "Excel", "PowerPoint"],
+    "architecture_notes": "Assessments stored in central library; remediation tasks synced to Jira with due dates and owners.",
+    "process_walkthrough": [
+      "Collect vendor responses",
+      "Score controls and gaps",
+      "Assign remediation tasks",
+      "Provide summary to stakeholders"
+    ],
+    "outcomes_metrics": [
+      "Reduced assessment turnaround time",
+      "Improved consistency across vendors",
+      "Clear audit trail for decisions"
+    ],
+    "evidence_links": ["grc/p-grc-03/vendor-review.md"],
+    "reproduction_steps": [
+      "Send the standard questionnaire",
+      "Score responses using the rubric",
+      "Track remediation in Jira"
+    ],
+    "interview_points": [
+      "Balancing depth vs speed in assessments",
+      "Scoring approaches for vendor risk",
+      "Handling partial responses"
+    ]
+  },
+  {
+    "slug": "p-grc-04",
+    "title": "Policy Library Refresh",
+    "role_category": "GRC",
+    "status": "In Progress",
+    "executive_summary": "Refreshing the security policy library with versioning, owner accountability, and crosswalks to frameworks.",
+    "scenario_scope": "Corporate policies covering data, access, change management, and incident response.",
+    "responsibilities": [
+      "Catalog policies and owners",
+      "Map policies to frameworks",
+      "Publish versioned updates"
+    ],
+    "tools_tech": ["Git", "Markdown", "Confluence", "Lucidchart", "Jira"],
+    "architecture_notes": "Policies stored in Git with semantic versioning; publication handled via static site for easy access.",
+    "process_walkthrough": [
+      "Inventory existing policies",
+      "Crosswalk to CIS/NIST",
+      "Update documents with owners",
+      "Publish and collect acknowledgments"
+    ],
+    "outcomes_metrics": [
+      "Clear ownership per policy",
+      "Crosswalks for auditors",
+      "Versioned history of changes"
+    ],
+    "evidence_links": ["policies/p-grc-04/policy-library.md"],
+    "reproduction_steps": [
+      "Clone the policy repo",
+      "Review the crosswalk tables",
+      "Publish updates via static site generator"
+    ],
+    "interview_points": [
+      "Version control for policies",
+      "Mapping to frameworks",
+      "Communicating policy changes"
+    ]
+  },
+  {
+    "slug": "p-grc-05",
+    "title": "BCP/DR Program",
+    "role_category": "GRC",
+    "status": "Planned",
+    "executive_summary": "Building a business continuity and disaster recovery program with impact analysis and test cycles.",
+    "scenario_scope": "Critical customer-facing services with dependencies on cloud infrastructure and third parties.",
+    "responsibilities": [
+      "Conduct business impact analysis",
+      "Define RTO/RPO targets",
+      "Schedule tabletop and technical tests"
+    ],
+    "tools_tech": ["BIA templates", "Runbooks", "Tabletop playbooks", "Terraform", "AWS/Azure"],
+    "architecture_notes": "BCP artifacts stored centrally; DR tests follow standard scenarios with evidence capture for auditors.",
+    "process_walkthrough": [
+      "Interview service owners for BIA",
+      "Document dependencies and targets",
+      "Plan and execute DR tests",
+      "Capture findings and improvements"
+    ],
+    "outcomes_metrics": [
+      "Defined RTO/RPO per service",
+      "Scheduled quarterly DR tests",
+      "Improved readiness documentation"
+    ],
+    "evidence_links": ["dr/p-grc-05/bcp-program.md"],
+    "reproduction_steps": [
+      "Run the BIA workshop",
+      "Document service dependencies",
+      "Execute the DR test plan"
+    ],
+    "interview_points": [
+      "Structuring BCP/DR programs",
+      "Measuring readiness",
+      "Communicating with stakeholders"
+    ]
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: "Samuel Jackson — Security & DevOps Portfolio"
+repo_url: "https://github.com/samueljackson-collab/Portfolio-Project"
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tabs
+markdown_extensions:
+  - toc:
+      permalink: true
+  - admonition
+  - tables
+  - footnotes
+  - def_list
+nav:
+  - Home: index.md
+  - Portfolio: PROJECT_INDEX.md
+  - Red Team:
+      - "Red Team Project 1 (slug: p-rt-01)": red-team/p-rt-01.md
+      - "Red Team Project 2 (slug: p-rt-02)": red-team/p-rt-02.md
+      - "Red Team Project 3 (slug: p-rt-03)": red-team/p-rt-03.md
+      - "Red Team Project 4 (slug: p-rt-04)": red-team/p-rt-04.md
+      - "Red Team Project 5 (slug: p-rt-05)": red-team/p-rt-05.md
+  - Blue Team:
+      - "Blue Team Project 1 (slug: p-bt-01)": blue-team/p-bt-01.md
+      - "Blue Team Project 2 (slug: p-bt-02)": blue-team/p-bt-02.md
+      - "Blue Team Project 3 (slug: p-bt-03)": blue-team/p-bt-03.md
+      - "Blue Team Project 4 (slug: p-bt-04)": blue-team/p-bt-04.md
+      - "Blue Team Project 5 (slug: p-bt-05)": blue-team/p-bt-05.md
+  - Cloud Security:
+      - "Cloud Security Project 1 (slug: p-cs-01)": cloud-security/p-cs-01.md
+      - "Cloud Security Project 2 (slug: p-cs-02)": cloud-security/p-cs-02.md
+      - "Cloud Security Project 3 (slug: p-cs-03)": cloud-security/p-cs-03.md
+      - "Cloud Security Project 4 (slug: p-cs-04)": cloud-security/p-cs-04.md
+      - "Cloud Security Project 5 (slug: p-cs-05)": cloud-security/p-cs-05.md
+  - DevOps / SRE:
+      - "DevOps/SRE Project 1 (slug: p-devops-01)": devops/p-devops-01.md
+      - "DevOps/SRE Project 2 (slug: p-devops-02)": devops/p-devops-02.md
+      - "DevOps/SRE Project 3 (slug: p-devops-03)": devops/p-devops-03.md
+      - "DevOps/SRE Project 4 (slug: p-devops-04)": devops/p-devops-04.md
+      - "DevOps/SRE Project 5 (slug: p-devops-05)": devops/p-devops-05.md
+  - GRC:
+      - "GRC Project 1 (slug: p-grc-01)": grc/p-grc-01.md
+      - "GRC Project 2 (slug: p-grc-02)": grc/p-grc-02.md
+      - "GRC Project 3 (slug: p-grc-03)": grc/p-grc-03.md
+      - "GRC Project 4 (slug: p-grc-04)": grc/p-grc-04.md
+      - "GRC Project 5 (slug: p-grc-05)": grc/p-grc-05.md

--- a/projects/p-bt-01/README.md
+++ b/projects/p-bt-01/README.md
@@ -1,0 +1,49 @@
+# SOC Playbook Modernization
+
+- **Role Category:** Blue Team
+- **Status:** Completed
+
+## Executive Summary
+Refreshed SOC runbooks with cloud-first detections, unified triage steps, and response automation hooks.
+
+## Scenario & Scope
+Coverage across Windows, Linux, and cloud audit logs with integration into a central SOAR.
+
+## Responsibilities
+- Mapped alerts to MITRE ATT&CK
+- Defined triage decision trees
+- Added SOAR automation triggers and rollbacks
+
+## Tools & Technologies
+- Sentinel
+- Splunk
+- SOAR
+- KQL
+- Sigma
+
+## Architecture Notes
+Standardized ingestion pipelines with schema validation; SOAR playbooks run in isolated worker VMs.
+
+## Process Walkthrough
+- Prioritized alerts based on threat intel
+- Documented triage steps and data sources
+- Automated containment for high-fidelity alerts
+- Performed tabletop exercises to validate runbooks
+
+## Outcomes & Metrics
+- Reduced mean time to respond by 30%
+- Unified alert taxonomy across tools
+- Added rollback steps for automated actions
+
+## Evidence Links
+- runbooks/p-bt-01/soc-playbooks.md
+
+## Reproduction Steps
+- Import Sigma rules into the SIEM
+- Deploy SOAR workflows via provided scripts
+- Run tabletop scenarios with the sample alerts
+
+## Interview Points
+- Balancing automation with analyst oversight
+- Mapping ATT&CK techniques to detection content
+- Versioning and testing SOC runbooks

--- a/projects/p-bt-02/README.md
+++ b/projects/p-bt-02/README.md
@@ -1,0 +1,49 @@
+# Endpoint Telemetry Uplift
+
+- **Role Category:** Blue Team
+- **Status:** In Progress
+
+## Executive Summary
+Expanded EDR telemetry coverage for Linux servers and macOS endpoints with standardized baselines.
+
+## Scenario & Scope
+Hybrid fleet across cloud VMs and corporate laptops with varying OS baselines.
+
+## Responsibilities
+- Defined minimum viable telemetry events
+- Rolled out new agent policies via MDM
+- Validated detections for persistence and lateral movement
+
+## Tools & Technologies
+- Elastic Agent
+- osquery
+- FleetDM
+- MDM
+- Ansible
+
+## Architecture Notes
+Used staged rollout rings with health checks; events forward through message queue before SIEM ingestion.
+
+## Process Walkthrough
+- Captured current state of endpoint logging
+- Authored baseline policies for each OS
+- Piloted deployment with rollback plans
+- Measured detection fidelity against atomic tests
+
+## Outcomes & Metrics
+- Expanded Linux coverage from 40% to 95%
+- Standardized 25 baseline queries
+- Reduced false positives through tuned rules
+
+## Evidence Links
+- dashboards/p-bt-02/endpoint-coverage.md
+
+## Reproduction Steps
+- Enroll a test device via FleetDM
+- Apply the baseline policy profile
+- Trigger atomic persistence tests and review alerts
+
+## Interview Points
+- How to phase agent rollouts safely
+- Balancing telemetry volume with cost
+- Detecting lateral movement with osquery

--- a/projects/p-bt-03/README.md
+++ b/projects/p-bt-03/README.md
@@ -1,0 +1,49 @@
+# SIEM Content as Code
+
+- **Role Category:** Blue Team
+- **Status:** Completed
+
+## Executive Summary
+Implemented version-controlled SIEM detections with CI linting, staged promotion, and automated packaging.
+
+## Scenario & Scope
+Centralized SIEM with multiple tenants and environment-specific overrides.
+
+## Responsibilities
+- Converted ad-hoc KQL queries into reusable modules
+- Built CI checks for schema validation
+- Created release pipeline for content promotion
+
+## Tools & Technologies
+- Azure DevOps
+- KQL
+- YAML
+- Git
+- Python
+
+## Architecture Notes
+Detection content stored in Git repo with environment overlays; CI builds signed packages deployed via API.
+
+## Process Walkthrough
+- Migrated existing queries into modules
+- Added unit tests and linters for KQL
+- Published signed content to staging, then production
+- Monitored detections for drift and false positives
+
+## Outcomes & Metrics
+- Reduced manual deployment errors to zero
+- Cut detection promotion time by 60%
+- Enabled rollback via signed artifact history
+
+## Evidence Links
+- pipelines/p-bt-03/sien-content-ci.md
+
+## Reproduction Steps
+- Clone the detection repo and install dev dependencies
+- Run the CI lint workflow locally
+- Publish a signed content package to the staging SIEM
+
+## Interview Points
+- Versioning strategies for detection content
+- Testing KQL queries before production
+- Handling environment-specific overrides

--- a/projects/p-bt-04/README.md
+++ b/projects/p-bt-04/README.md
@@ -1,0 +1,49 @@
+# Threat Hunting Sprint
+
+- **Role Category:** Blue Team
+- **Status:** Completed
+
+## Executive Summary
+Ran a two-week hunting sprint focused on identity misuse and cloud console anomalies using hypothesis-driven hunts.
+
+## Scenario & Scope
+Identity provider logs, cloud audit trails, and VPN telemetry.
+
+## Responsibilities
+- Formulated hunting hypotheses
+- Built detections for anomalous sign-ins
+- Created dashboards for hunt findings
+
+## Tools & Technologies
+- Splunk
+- Jupyter
+- Python
+- Sigma
+- Okta logs
+
+## Architecture Notes
+Data lake backed by object storage; hunts executed in notebooks with saved KQL/SPL queries for reuse.
+
+## Process Walkthrough
+- Defined hunt scope and data sources
+- Ran exploratory analytics and baselines
+- Converted hunts into persistent detections
+- Reported findings and tuned alerts
+
+## Outcomes & Metrics
+- Discovered two misconfigured admin accounts
+- Built four new identity anomaly detections
+- Documented baselines for VPN geolocation alerts
+
+## Evidence Links
+- hunts/p-bt-04/hunt-report.md
+
+## Reproduction Steps
+- Load the sample Okta and VPN logs
+- Run the provided notebooks to compute baselines
+- Deploy the Sigma-derived rules to your SIEM
+
+## Interview Points
+- Hypothesis-driven hunting
+- Turning hunts into detections
+- Data quality considerations for identity telemetry

--- a/projects/p-bt-05/README.md
+++ b/projects/p-bt-05/README.md
@@ -1,0 +1,49 @@
+# Incident Response Playoff
+
+- **Role Category:** Blue Team
+- **Status:** Planned
+
+## Executive Summary
+Designing a gamified IR exercise that pits teams against live-fire scenarios with measured MTTR targets.
+
+## Scenario & Scope
+Simulated ransomware across mixed Windows/Linux estate with cloud workloads.
+
+## Responsibilities
+- Author inject timeline and artifacts
+- Define scoring tied to MTTR and containment
+- Provide post-incident review templates
+
+## Tools & Technologies
+- Velociraptor
+- Azure Sentinel
+- Ansible
+- Caldera
+- Slack bots
+
+## Architecture Notes
+Exercise lab isolated via virtualization; snapshot/restore enabled for repeatability and safety.
+
+## Process Walkthrough
+- Prepare lab images and data sets
+- Execute injects via automation scripts
+- Score responses and track timelines
+- Facilitate post-incident reviews
+
+## Outcomes & Metrics
+- Baseline MTTR benchmarks for ransomware cases
+- Standardized after-action reporting
+- Improved collaboration runbooks across teams
+
+## Evidence Links
+- exercises/p-bt-05/ir-playoff.md
+
+## Reproduction Steps
+- Spin up the lab with provided scripts
+- Run the inject automation
+- Record response times and compare to benchmarks
+
+## Interview Points
+- Designing safe yet realistic IR exercises
+- Metrics that matter beyond MTTR
+- Automating injects and resets

--- a/projects/p-cs-01/README.md
+++ b/projects/p-cs-01/README.md
@@ -1,0 +1,49 @@
+# Cloud Guardrails Blueprint
+
+- **Role Category:** Cloud Security
+- **Status:** Completed
+
+## Executive Summary
+Authored baseline guardrails for AWS, Azure, and GCP covering identity, networking, and data protection.
+
+## Scenario & Scope
+Greenfield multi-cloud foundation with centralized identity and logging.
+
+## Responsibilities
+- Mapped CIS benchmarks to cloud policies
+- Built landing zone guardrails
+- Published reusable policy-as-code modules
+
+## Tools & Technologies
+- Terraform
+- AWS Organizations
+- Azure Policy
+- GCP Organization Policy
+- OPA
+
+## Architecture Notes
+Guardrails enforced via org-level policies with exception workflows; logs aggregated into a security account.
+
+## Process Walkthrough
+- Defined baseline security controls
+- Implemented policies via Terraform modules
+- Tested enforcement with exception paths
+- Documented runbooks for tenant onboarding
+
+## Outcomes & Metrics
+- Achieved 95% policy coverage for new accounts
+- Reduced manual exceptions by introducing approvals
+- Centralized audit logging across clouds
+
+## Evidence Links
+- guardrails/p-cs-01/policies.md
+
+## Reproduction Steps
+- Deploy the org-level Terraform stack
+- Onboard a test account/subscription
+- Validate policy enforcement and logging
+
+## Interview Points
+- Balancing guardrails with developer velocity
+- Handling exceptions and drift
+- Cross-cloud identity alignment

--- a/projects/p-cs-02/README.md
+++ b/projects/p-cs-02/README.md
@@ -1,0 +1,49 @@
+# Kubernetes Runtime Hardening
+
+- **Role Category:** Cloud Security
+- **Status:** In Progress
+
+## Executive Summary
+Elevating cluster security with PSP replacements, runtime scanning, and managed identities.
+
+## Scenario & Scope
+EKS and AKS clusters running internal services with GitOps delivery.
+
+## Responsibilities
+- Defined baseline policies for pods and namespaces
+- Integrated admission controllers and image scanning
+- Enabled managed identities for service-to-service auth
+
+## Tools & Technologies
+- Kyverno
+- Trivy
+- OPA Gatekeeper
+- IRSA
+- Azure AD Workload Identity
+
+## Architecture Notes
+Policy bundles managed via GitOps; scanners run pre-deploy and at runtime; secrets offloaded to cloud KMS.
+
+## Process Walkthrough
+- Audited existing cluster settings
+- Implemented admission policies
+- Added runtime and supply chain scanning
+- Tested break-glass scenarios and RBAC controls
+
+## Outcomes & Metrics
+- Blocked privileged pod deployments
+- Achieved 100% image scanning coverage
+- Improved service identity posture without secrets in pods
+
+## Evidence Links
+- clusters/p-cs-02/k8s-hardening.md
+
+## Reproduction Steps
+- Apply Kyverno policies via Helm
+- Run Trivy scans on images pre-deploy
+- Validate IRSA/Workload Identity mappings
+
+## Interview Points
+- Admission control vs runtime controls
+- Identity handling for Kubernetes workloads
+- Testing policies without blocking deploys

--- a/projects/p-cs-03/README.md
+++ b/projects/p-cs-03/README.md
@@ -1,0 +1,49 @@
+# Data Loss Prevention Rollout
+
+- **Role Category:** Cloud Security
+- **Status:** Completed
+
+## Executive Summary
+Implemented DLP controls for SaaS and cloud storage with classification, alerting, and user education.
+
+## Scenario & Scope
+Microsoft 365, Google Workspace, and S3 buckets storing regulated data.
+
+## Responsibilities
+- Classified data with sensitivity labels
+- Defined DLP policies for email and storage
+- Built user-friendly justifications and overrides
+
+## Tools & Technologies
+- Microsoft Purview
+- Google DLP
+- Amazon Macie
+- KMS
+- Power Automate
+
+## Architecture Notes
+Centralized DLP events forwarded to SIEM; override workflows log justifications for audit.
+
+## Process Walkthrough
+- Mapped data types to labels
+- Deployed DLP policies in audit mode
+- Educated users and enabled enforcement
+- Monitored alerts and tuned policies
+
+## Outcomes & Metrics
+- Cut outbound sensitive emails by 70%
+- Tagged 90% of S3 objects with labels
+- Captured override justifications for audits
+
+## Evidence Links
+- policies/p-cs-03/dlp-rollout.md
+
+## Reproduction Steps
+- Enable labels in M365 and Workspace
+- Deploy DLP policies in audit then enforce
+- Review Macie findings and SIEM alerts
+
+## Interview Points
+- Balancing user productivity with DLP
+- Cross-platform labeling consistency
+- Handling false positives gracefully

--- a/projects/p-cs-04/README.md
+++ b/projects/p-cs-04/README.md
@@ -1,0 +1,49 @@
+# Secrets Management Unification
+
+- **Role Category:** Cloud Security
+- **Status:** In Progress
+
+## Executive Summary
+Consolidating secrets storage across clouds and CI/CD with automated rotation and least-privilege access.
+
+## Scenario & Scope
+AWS, Azure, and GitHub Actions workloads consuming shared secrets.
+
+## Responsibilities
+- Inventory existing secrets and owners
+- Migrated credentials into managed vaults
+- Automated rotation and audit logging
+
+## Tools & Technologies
+- HashiCorp Vault
+- AWS Secrets Manager
+- Azure Key Vault
+- GitHub OIDC
+- Terraform
+
+## Architecture Notes
+Federated OIDC access for CI; apps retrieve secrets via short-lived tokens with per-service namespaces.
+
+## Process Walkthrough
+- Mapped secrets to services and lifecycle
+- Provisioned vault namespaces and policies
+- Implemented rotation jobs and alerting
+- Removed plaintext secrets from repos
+
+## Outcomes & Metrics
+- Eliminated long-lived CI secrets
+- Rotated 100% of high-risk credentials
+- Added audit trails and owner metadata
+
+## Evidence Links
+- runbooks/p-cs-04/secrets-unification.md
+
+## Reproduction Steps
+- Deploy Vault with the provided helm chart
+- Configure GitHub OIDC roles for CI
+- Migrate application secrets and test rotation
+
+## Interview Points
+- Choosing between cloud-native and Vault
+- Designing least privilege for secrets
+- Automating rotation without downtime

--- a/projects/p-cs-05/README.md
+++ b/projects/p-cs-05/README.md
@@ -1,0 +1,49 @@
+# Cloud Security Monitoring Fabric
+
+- **Role Category:** Cloud Security
+- **Status:** Planned
+
+## Executive Summary
+Designing unified cloud monitoring with event hubs, schema normalization, and golden signals for security.
+
+## Scenario & Scope
+Multi-cloud log aggregation with detections for identity, network, and data access.
+
+## Responsibilities
+- Define canonical schemas for audit logs
+- Build ingestion pipelines with buffering
+- Publish golden signals dashboards
+
+## Tools & Technologies
+- Event Hub
+- Kinesis
+- Pub/Sub
+- Fluent Bit
+- BigQuery
+
+## Architecture Notes
+Hub-and-spoke log ingestion with buffering; normalization via stream processors; storage in data lake with tiered retention.
+
+## Process Walkthrough
+- Survey cloud audit sources
+- Implement streaming normalization
+- Publish metrics and dashboards
+- Pilot detections and alert routing
+
+## Outcomes & Metrics
+- Unified schema for 12 log types
+- Reduced ingestion failures via buffering
+- Published actionable golden signals
+
+## Evidence Links
+- designs/p-cs-05/monitoring-fabric.md
+
+## Reproduction Steps
+- Deploy the event hub stack
+- Connect cloud audit sources
+- Run sample normalization jobs
+
+## Interview Points
+- Why normalization matters for multi-cloud
+- Buffering strategies for log spikes
+- Golden signals for security telemetry

--- a/projects/p-devops-01/README.md
+++ b/projects/p-devops-01/README.md
@@ -1,0 +1,49 @@
+# GitOps Platform Build
+
+- **Role Category:** DevOps / SRE
+- **Status:** Completed
+
+## Executive Summary
+Built GitOps delivery for microservices with policy checks, progressive delivery, and secrets handling.
+
+## Scenario & Scope
+Kubernetes clusters with Argo CD and progressive delivery for internal APIs.
+
+## Responsibilities
+- Implemented repo layout and templates
+- Added policy checks and image attestations
+- Enabled blue/green and canary strategies
+
+## Tools & Technologies
+- Argo CD
+- Argo Rollouts
+- Kyverno
+- Cosign
+- Helm
+
+## Architecture Notes
+App-of-apps pattern with per-env overlays; admission policies enforce signed images; metrics drive rollout gates.
+
+## Process Walkthrough
+- Structured repos for apps and ops
+- Configured Argo CD projects and RBAC
+- Enabled rollout strategies with metrics
+- Documented secrets patterns with external vaults
+
+## Outcomes & Metrics
+- Reduced deployment lead time by 50%
+- Achieved 100% signed image enforcement
+- Improved rollback time via Git history
+
+## Evidence Links
+- platform/p-devops-01/gitops-build.md
+
+## Reproduction Steps
+- Install Argo CD and Rollouts via Helm
+- Apply the app-of-apps manifests
+- Trigger a canary and monitor metrics
+
+## Interview Points
+- Structuring GitOps repos
+- Progressive delivery patterns
+- Policy checks in the delivery pipeline

--- a/projects/p-devops-02/README.md
+++ b/projects/p-devops-02/README.md
@@ -1,0 +1,49 @@
+# Resilience Testing Program
+
+- **Role Category:** DevOps / SRE
+- **Status:** In Progress
+
+## Executive Summary
+Standing up a resilience testing program with chaos experiments, SLOs, and automated rollbacks.
+
+## Scenario & Scope
+Microservices on Kubernetes with stateful services in managed databases.
+
+## Responsibilities
+- Defined SLOs and error budgets
+- Authored chaos experiments for dependencies
+- Integrated rollback automation based on KPIs
+
+## Tools & Technologies
+- LitmusChaos
+- Grafana
+- Prometheus
+- Fluent Bit
+- Terraform
+
+## Architecture Notes
+Experiments executed in non-prod first; metrics exported to Grafana; alerting tied to error budgets.
+
+## Process Walkthrough
+- Capture service level indicators
+- Design chaos scenarios for dependencies
+- Automate rollbacks when SLOs breach
+- Review experiments in weekly ops council
+
+## Outcomes & Metrics
+- Established SLOs for five services
+- Reduced outage MTTR via automated rollbacks
+- Documented playbooks for repeatable chaos runs
+
+## Evidence Links
+- resilience/p-devops-02/chaos-program.md
+
+## Reproduction Steps
+- Deploy LitmusChaos and install CRDs
+- Run sample experiments against staging
+- Monitor SLO dashboards during tests
+
+## Interview Points
+- Running chaos safely
+- Choosing SLOs and SLIs
+- Automating rollback decisions

--- a/projects/p-devops-03/README.md
+++ b/projects/p-devops-03/README.md
@@ -1,0 +1,49 @@
+# Platform Observability Mesh
+
+- **Role Category:** DevOps / SRE
+- **Status:** Completed
+
+## Executive Summary
+Unified logs, metrics, and traces with opinionated defaults and developer self-service dashboards.
+
+## Scenario & Scope
+Multi-cluster setup with shared observability stack and tenant isolation.
+
+## Responsibilities
+- Deployed distributed tracing
+- Normalized logs and metrics schemas
+- Built golden signal dashboards
+
+## Tools & Technologies
+- OpenTelemetry
+- Tempo
+- Loki
+- Prometheus
+- Grafana
+
+## Architecture Notes
+Control plane cluster hosts observability stack; tenants onboard via Helm charts with scoped credentials.
+
+## Process Walkthrough
+- Set up OTel collectors and exporters
+- Enabled tracing libraries for services
+- Created reusable dashboard templates
+- Documented tenant onboarding steps
+
+## Outcomes & Metrics
+- Achieved trace coverage for 90% of services
+- Standardized log labels across clusters
+- Reduced triage time via golden dashboards
+
+## Evidence Links
+- observability/p-devops-03/mesh.md
+
+## Reproduction Steps
+- Deploy the observability stack via Helmfile
+- Install OTel collectors per cluster
+- Instrument sample services and verify dashboards
+
+## Interview Points
+- Multi-tenant observability design
+- Tradeoffs between push vs pull metrics
+- Rollout strategies for tracing

--- a/projects/p-devops-04/README.md
+++ b/projects/p-devops-04/README.md
@@ -1,0 +1,49 @@
+# Cost Optimization Lab
+
+- **Role Category:** DevOps / SRE
+- **Status:** Completed
+
+## Executive Summary
+Built a lab to evaluate autoscaling, rightsizing, and storage lifecycle policies with measurable savings.
+
+## Scenario & Scope
+Workloads across AWS and Azure with mixed batch and web services.
+
+## Responsibilities
+- Benchmarked autoscaling policies
+- Evaluated storage lifecycle rules
+- Modeled savings scenarios
+
+## Tools & Technologies
+- AWS Compute Optimizer
+- Azure Advisor
+- Grafana
+- Karpenter
+- FinOps dashboards
+
+## Architecture Notes
+Lab workloads tagged for cost tracking; dashboards aggregate costs by service and environment.
+
+## Process Walkthrough
+- Instrument workloads with cost tags
+- Run autoscaling experiments
+- Apply lifecycle rules to storage
+- Summarize savings and recommendations
+
+## Outcomes & Metrics
+- Identified 25% compute savings
+- Reduced storage spend via lifecycle rules
+- Produced FinOps-ready dashboards
+
+## Evidence Links
+- finops/p-devops-04/cost-lab.md
+
+## Reproduction Steps
+- Deploy sample workloads with tags
+- Run autoscaling scenarios
+- Review cost dashboards and recommendations
+
+## Interview Points
+- Balancing performance and cost
+- Autoscaling strategies across clouds
+- Building FinOps dashboards

--- a/projects/p-devops-05/README.md
+++ b/projects/p-devops-05/README.md
@@ -1,0 +1,49 @@
+# Reliability Runbooks
+
+- **Role Category:** DevOps / SRE
+- **Status:** Planned
+
+## Executive Summary
+Creating standardized runbooks for on-call with graphs, queries, and decision trees per service.
+
+## Scenario & Scope
+Critical services spanning APIs, queues, and databases across regions.
+
+## Responsibilities
+- Document service overviews and owners
+- Provide quick diagnostics and graphs
+- Define escalation and rollback paths
+
+## Tools & Technologies
+- Grafana
+- PagerDuty
+- RunWhen
+- Terraform
+- Markdown
+
+## Architecture Notes
+Runbooks stored with code; linked dashboards auto-open with relevant variables for incidents.
+
+## Process Walkthrough
+- Interview service owners
+- Document golden signals and alerts
+- Publish runbooks with decision trees
+- Pilot with on-call rotations
+
+## Outcomes & Metrics
+- Faster incident triage
+- Consistent escalation paths
+- Reduced toil via scripted diagnostics
+
+## Evidence Links
+- runbooks/p-devops-05/reliability-runbooks.md
+
+## Reproduction Steps
+- Clone the runbooks repo
+- Open service pages in Grafana
+- Test the diagnostic scripts
+
+## Interview Points
+- Designing actionable runbooks
+- Keeping runbooks versioned with code
+- Measuring runbook effectiveness

--- a/projects/p-grc-01/README.md
+++ b/projects/p-grc-01/README.md
@@ -1,0 +1,49 @@
+# ISO 27001 Readiness
+
+- **Role Category:** GRC
+- **Status:** Completed
+
+## Executive Summary
+Prepared an ISO 27001 readiness pack covering scope, controls, and evidence mapping.
+
+## Scenario & Scope
+SaaS platform with multi-tenant architecture across two regions.
+
+## Responsibilities
+- Defined ISMS scope
+- Mapped Annex A controls
+- Gathered evidence with owners
+
+## Tools & Technologies
+- Confluence
+- Jira
+- Drata
+- Excel
+- PowerPoint
+
+## Architecture Notes
+Evidence library stored in versioned folders; control owners tracked via ticketing with due dates.
+
+## Process Walkthrough
+- Kickoff with leadership
+- Run gap assessment
+- Assign control owners
+- Compile evidence and risk register
+
+## Outcomes & Metrics
+- Closed 75% of gaps ahead of audit
+- Documented clear scope statement
+- Streamlined evidence collection workflows
+
+## Evidence Links
+- grc/p-grc-01/iso-readiness.md
+
+## Reproduction Steps
+- Review the scope document
+- Follow the gap assessment checklist
+- Collect evidence using the templates
+
+## Interview Points
+- Scoping ISMS boundaries
+- Tracking control ownership
+- Common pitfalls before certification

--- a/projects/p-grc-02/README.md
+++ b/projects/p-grc-02/README.md
@@ -1,0 +1,49 @@
+# Risk Register Automation
+
+- **Role Category:** GRC
+- **Status:** In Progress
+
+## Executive Summary
+Automating risk register updates with workflows for scoring, approvals, and reporting dashboards.
+
+## Scenario & Scope
+Enterprise risk program spanning product, infra, and vendor risks.
+
+## Responsibilities
+- Defined risk scoring model
+- Built intake workflow
+- Published reporting dashboards
+
+## Tools & Technologies
+- Power Automate
+- Power BI
+- SharePoint
+- Python
+- SQL
+
+## Architecture Notes
+Risk data stored in SQL backend with API; workflows enforce approvals; dashboards pull nightly snapshots.
+
+## Process Walkthrough
+- Design intake forms
+- Implement scoring automation
+- Notify owners for reviews
+- Publish dashboards to leadership
+
+## Outcomes & Metrics
+- Reduced manual updates by 60%
+- Improved visibility into high risks
+- Automated reminders for reviews
+
+## Evidence Links
+- grc/p-grc-02/risk-automation.md
+
+## Reproduction Steps
+- Deploy the SQL schema
+- Set up Power Automate flows
+- Publish the Power BI dashboard
+
+## Interview Points
+- Designing usable risk workflows
+- Choosing scoring models
+- Reporting risk to leadership

--- a/projects/p-grc-03/README.md
+++ b/projects/p-grc-03/README.md
@@ -1,0 +1,49 @@
+# Vendor Security Review
+
+- **Role Category:** GRC
+- **Status:** Completed
+
+## Executive Summary
+Standardized vendor assessments with questionnaires, evidence collection, and remediation tracking.
+
+## Scenario & Scope
+Third-party SaaS providers handling customer data across regions.
+
+## Responsibilities
+- Authored questionnaire templates
+- Built scoring rubric
+- Tracked remediation tasks
+
+## Tools & Technologies
+- OneTrust
+- Jira
+- SharePoint
+- Excel
+- PowerPoint
+
+## Architecture Notes
+Assessments stored in central library; remediation tasks synced to Jira with due dates and owners.
+
+## Process Walkthrough
+- Collect vendor responses
+- Score controls and gaps
+- Assign remediation tasks
+- Provide summary to stakeholders
+
+## Outcomes & Metrics
+- Reduced assessment turnaround time
+- Improved consistency across vendors
+- Clear audit trail for decisions
+
+## Evidence Links
+- grc/p-grc-03/vendor-review.md
+
+## Reproduction Steps
+- Send the standard questionnaire
+- Score responses using the rubric
+- Track remediation in Jira
+
+## Interview Points
+- Balancing depth vs speed in assessments
+- Scoring approaches for vendor risk
+- Handling partial responses

--- a/projects/p-grc-04/README.md
+++ b/projects/p-grc-04/README.md
@@ -1,0 +1,49 @@
+# Policy Library Refresh
+
+- **Role Category:** GRC
+- **Status:** In Progress
+
+## Executive Summary
+Refreshing the security policy library with versioning, owner accountability, and crosswalks to frameworks.
+
+## Scenario & Scope
+Corporate policies covering data, access, change management, and incident response.
+
+## Responsibilities
+- Catalog policies and owners
+- Map policies to frameworks
+- Publish versioned updates
+
+## Tools & Technologies
+- Git
+- Markdown
+- Confluence
+- Lucidchart
+- Jira
+
+## Architecture Notes
+Policies stored in Git with semantic versioning; publication handled via static site for easy access.
+
+## Process Walkthrough
+- Inventory existing policies
+- Crosswalk to CIS/NIST
+- Update documents with owners
+- Publish and collect acknowledgments
+
+## Outcomes & Metrics
+- Clear ownership per policy
+- Crosswalks for auditors
+- Versioned history of changes
+
+## Evidence Links
+- policies/p-grc-04/policy-library.md
+
+## Reproduction Steps
+- Clone the policy repo
+- Review the crosswalk tables
+- Publish updates via static site generator
+
+## Interview Points
+- Version control for policies
+- Mapping to frameworks
+- Communicating policy changes

--- a/projects/p-grc-05/README.md
+++ b/projects/p-grc-05/README.md
@@ -1,0 +1,49 @@
+# BCP/DR Program
+
+- **Role Category:** GRC
+- **Status:** Planned
+
+## Executive Summary
+Building a business continuity and disaster recovery program with impact analysis and test cycles.
+
+## Scenario & Scope
+Critical customer-facing services with dependencies on cloud infrastructure and third parties.
+
+## Responsibilities
+- Conduct business impact analysis
+- Define RTO/RPO targets
+- Schedule tabletop and technical tests
+
+## Tools & Technologies
+- BIA templates
+- Runbooks
+- Tabletop playbooks
+- Terraform
+- AWS/Azure
+
+## Architecture Notes
+BCP artifacts stored centrally; DR tests follow standard scenarios with evidence capture for auditors.
+
+## Process Walkthrough
+- Interview service owners for BIA
+- Document dependencies and targets
+- Plan and execute DR tests
+- Capture findings and improvements
+
+## Outcomes & Metrics
+- Defined RTO/RPO per service
+- Scheduled quarterly DR tests
+- Improved readiness documentation
+
+## Evidence Links
+- dr/p-grc-05/bcp-program.md
+
+## Reproduction Steps
+- Run the BIA workshop
+- Document service dependencies
+- Execute the DR test plan
+
+## Interview Points
+- Structuring BCP/DR programs
+- Measuring readiness
+- Communicating with stakeholders

--- a/projects/p-rt-01/README.md
+++ b/projects/p-rt-01/README.md
@@ -1,0 +1,50 @@
+# Red Team Cloud Pivot
+
+- **Role Category:** Red Team
+- **Status:** Completed
+
+## Executive Summary
+Simulated a multi-stage intrusion from phishing to cloud pivoting to validate detection depth across SaaS and IaaS assets.
+
+## Scenario & Scope
+Assumed-compromise of a user mailbox with expansion into an Azure workload landing zone.
+
+## Responsibilities
+- Designed realistic phishing lure and payload chain
+- Abused OAuth token reuse to access cloud resources
+- Coordinated purple-team debrief with defenders
+
+## Tools & Technologies
+- Evilginx
+- Azure CLI
+- BloodHound
+- KQL
+- Burp Suite
+
+## Architecture Notes
+Isolated attack infrastructure in a throwaway VNet with rotating outbound IPs and strict logging to a separate SIEM tenant.
+
+## Process Walkthrough
+- Conducted controlled phishing campaign with time-boxed scope
+- Harvested tokens and validated MFA resilience
+- Pivoted into Azure via misconfigured app registrations
+- Documented detection opportunities and compensating controls
+
+## Outcomes & Metrics
+- Reduced risky OAuth app registrations by 80%
+- Implemented conditional access policies for legacy protocols
+- Added KQL detections for anomalous consent grants
+
+## Evidence Links
+- reports/p-rt-01/phishing-report.pdf
+- dashboards/kql-detections.md
+
+## Reproduction Steps
+- Deploy the throwaway VNet using the provided Terraform module
+- Run the phishing workflow with pre-approved targets
+- Review SIEM alerts generated during the exercise
+
+## Interview Points
+- Why token-based persistence is harder to detect than password reuse
+- How to scope red-team exercises to protect production tenants
+- Cloud-specific detections for OAuth consent abuse

--- a/projects/p-rt-02/README.md
+++ b/projects/p-rt-02/README.md
@@ -1,0 +1,49 @@
+# Adversary Emulation for OT Lab
+
+- **Role Category:** Red Team
+- **Status:** In Progress
+
+## Executive Summary
+Built an emulation plan for ICS/SCADA environments using MITRE ATT&CK for ICS to validate segmentation controls.
+
+## Scenario & Scope
+Targeted a lab with Modbus/TCP devices behind a jump host and engineering workstation.
+
+## Responsibilities
+- Mapped ATT&CK for ICS techniques to lab assets
+- Authored safe payloads to avoid process disruption
+- Ran purple-team tabletop with SOC and OT engineers
+
+## Tools & Technologies
+- Caldera
+- Atomic Red Team
+- Wireshark
+- GNS3
+- ModbusPal
+
+## Architecture Notes
+Segmentation enforced via dual-firewall zones; testing executed from a hardened Ubuntu jump box with strict egress rules.
+
+## Process Walkthrough
+- Cataloged OT assets and network flows
+- Selected low-impact techniques for the lab
+- Executed emulation steps with real-time monitoring
+- Captured packet traces and log artifacts for SOC tuning
+
+## Outcomes & Metrics
+- Documented 12 new OT detections
+- Validated firewall ACLs for engineering subnets
+- Provided evidence pack for compliance reviewers
+
+## Evidence Links
+- reports/p-rt-02/ot-emulation.pdf
+
+## Reproduction Steps
+- Start the OT lab VMs using the provided compose file
+- Launch Caldera with the ICS plugin
+- Replay the scripted ATT&CK sequences and capture logs
+
+## Interview Points
+- Balancing realism and safety in OT testing
+- Mapping ATT&CK for ICS to detection engineering
+- Coordinating with operations teams during emulation

--- a/projects/p-rt-03/README.md
+++ b/projects/p-rt-03/README.md
@@ -1,0 +1,49 @@
+# Wireless Intrusion Assessment
+
+- **Role Category:** Red Team
+- **Status:** Completed
+
+## Executive Summary
+Evaluated enterprise Wi-Fi security by performing rogue AP, evil-twin, and PMKID harvesting attacks.
+
+## Scenario & Scope
+Office SSIDs with WPA2-Enterprise and guest networks segmented via VLANs.
+
+## Responsibilities
+- Configured rogue AP with automatic credential capture
+- Performed controlled deauth and PMKID collection
+- Delivered hardening guidance for RADIUS and certificate validation
+
+## Tools & Technologies
+- Kali
+- hostapd-wpe
+- hcxdumptool
+- Wireshark
+- Aircrack-ng
+
+## Architecture Notes
+Used battery-powered rogue AP kit with 4G uplink; logs streamed to central syslog for chain-of-custody.
+
+## Process Walkthrough
+- Surveyed spectrum and SSIDs
+- Executed evil-twin and deauth scenarios
+- Captured PMKID handshakes and attempted offline crack
+- Validated 802.1X certificate pinning settings
+
+## Outcomes & Metrics
+- Enabled EAP-TLS enforcement for corporate devices
+- Blocked legacy TKIP negotiation
+- Added rogue AP detection alerts to NMS
+
+## Evidence Links
+- reports/p-rt-03/wifi-assessment.pdf
+
+## Reproduction Steps
+- Flash the rogue AP SD card with the provided image
+- Run the collection script and monitor syslog
+- Test 802.1X validation on sample devices
+
+## Interview Points
+- Defending against evil-twin attacks
+- Why certificate validation stops most credential theft
+- Coordinating wireless testing with facilities

--- a/projects/p-rt-04/README.md
+++ b/projects/p-rt-04/README.md
@@ -1,0 +1,49 @@
+# Web App Exploitation Playbook
+
+- **Role Category:** Red Team
+- **Status:** Planned
+
+## Executive Summary
+Curated repeatable exploit chains for a legacy Java web stack, focusing on deserialization and SSRF risks.
+
+## Scenario & Scope
+Internal bug bounty mirror environment with outdated app server and S3-compatible storage.
+
+## Responsibilities
+- Catalog CVE coverage and detection gaps
+- Develop SSRF-to-RCE chain with metadata abuse
+- Package exploits into safe, repeatable scripts
+
+## Tools & Technologies
+- Burp Suite
+- ysoserial
+- ffuf
+- Go
+- Docker
+
+## Architecture Notes
+Isolated testing network with replayable fixtures; S3 bucket emulated via MinIO to avoid production access.
+
+## Process Walkthrough
+- Set up vulnerable app via docker-compose
+- Enumerate endpoints and test deserialization gadgets
+- Craft SSRF payloads targeting instance metadata
+- Automate exploit chain with safety toggles
+
+## Outcomes & Metrics
+- Documented four exploit playbooks with mitigations
+- Provided developer-safe repro scripts
+- Enabled CI security gate for deserialization payload detection
+
+## Evidence Links
+- playbooks/p-rt-04/web-exploit-playbook.md
+
+## Reproduction Steps
+- Start the vulnerable stack with docker-compose
+- Run the exploit scripts with sandbox credentials
+- Capture logs for S3 access and metadata calls
+
+## Interview Points
+- Tradeoffs between patching and virtual patching
+- Safe exploitation practices in shared labs
+- How SSRF escalates in cloud environments

--- a/projects/p-rt-05/README.md
+++ b/projects/p-rt-05/README.md
@@ -1,0 +1,48 @@
+# Physical Security Bypass
+
+- **Role Category:** Red Team
+- **Status:** Completed
+
+## Executive Summary
+Tested badge cloning and tailgating controls for a regional office, including social engineering resilience.
+
+## Scenario & Scope
+Two-floor office with HID badges, visitor kiosks, and mantrap entry.
+
+## Responsibilities
+- Captured badge IDs using proximity readers
+- Attempted clone with reflashable cards
+- Conducted staff awareness checks and debriefs
+
+## Tools & Technologies
+- Proxmark3
+- Flipper Zero
+- GoPro
+- Kali
+
+## Architecture Notes
+Coordinated with facilities and security; all tests logged with timestamps and video capture for auditability.
+
+## Process Walkthrough
+- Surveyed entry points and badge readers
+- Captured card data and attempted clones
+- Validated door controller logging and alarms
+- Ran awareness recap with office leadership
+
+## Outcomes & Metrics
+- Upgraded to SEOS badges for cryptographic validation
+- Improved tailgating enforcement through policy updates
+- Added door event feeds into SOC dashboards
+
+## Evidence Links
+- reports/p-rt-05/physical-bypass.pdf
+
+## Reproduction Steps
+- Use lab-issued test badges with Proxmark3
+- Attempt clone and test against demo door controller
+- Review SOC alerts for unauthorized entries
+
+## Interview Points
+- Physical security integration with SOC
+- Badge technology differences (HID vs SEOS)
+- Coordinating red-team ops with facilities

--- a/tools/generate_readmes.py
+++ b/tools/generate_readmes.py
@@ -1,0 +1,132 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+TEMPLATE = """# {title}
+
+- **Role Category:** {role_category}
+- **Status:** {status}
+
+## Executive Summary
+{executive_summary}
+
+## Scenario & Scope
+{scenario_scope}
+
+## Responsibilities
+{responsibilities}
+
+## Tools & Technologies
+{tools_tech}
+
+## Architecture Notes
+{architecture_notes}
+
+## Process Walkthrough
+{process_walkthrough}
+
+## Outcomes & Metrics
+{outcomes_metrics}
+
+## Evidence Links
+{evidence_links}
+
+## Reproduction Steps
+{reproduction_steps}
+
+## Interview Points
+{interview_points}
+"""
+
+
+def format_value(value: Any) -> str:
+    """Convert a project field to markdown-friendly text with sensible defaults."""
+    if value is None:
+        return "TBD"
+
+    if isinstance(value, str):
+        text = value.strip()
+        return text if text else "TBD"
+
+    if isinstance(value, dict):
+        if not value:
+            return "TBD"
+        lines: Iterable[str] = (f"- {k}: {v}" for k, v in value.items())
+        return "\n".join(lines)
+
+    if isinstance(value, (list, tuple, set)):
+        if not value:
+            return "TBD"
+        return "\n".join(f"- {str(item).strip()}" if str(item).strip() else "- (blank)" for item in value)
+
+    return str(value)
+
+
+def render_readme(project: dict) -> str:
+    content = {
+        "title": format_value(project.get("title")),
+        "role_category": format_value(project.get("role_category")),
+        "status": format_value(project.get("status")),
+        "executive_summary": format_value(project.get("executive_summary")),
+        "scenario_scope": format_value(project.get("scenario_scope")),
+        "responsibilities": format_value(project.get("responsibilities")),
+        "tools_tech": format_value(project.get("tools_tech")),
+        "architecture_notes": format_value(project.get("architecture_notes")),
+        "process_walkthrough": format_value(project.get("process_walkthrough")),
+        "outcomes_metrics": format_value(project.get("outcomes_metrics")),
+        "evidence_links": format_value(project.get("evidence_links")),
+        "reproduction_steps": format_value(project.get("reproduction_steps")),
+        "interview_points": format_value(project.get("interview_points")),
+    }
+    return TEMPLATE.format(**content)
+
+
+def write_readme(project: dict, base_dir: Path) -> Path:
+    slug = project.get("slug")
+    if not slug:
+        raise ValueError("Project entry missing required 'slug' field")
+
+    target_dir = base_dir / slug
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    readme_path = target_dir / "README.md"
+    readme_path.write_text(render_readme(project), encoding="utf-8")
+    return readme_path
+
+
+def load_projects(json_path: Path) -> list[dict]:
+    with json_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("projects.json must contain a list of project objects")
+    return data
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate README.md files for portfolio projects")
+    parser.add_argument("--only", dest="only_slug", help="Generate README for a single project slug")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    project_root = Path(__file__).resolve().parent.parent / "projects"
+    projects_file = Path(__file__).resolve().parent.parent / "exports" / "projects.json"
+
+    projects = load_projects(projects_file)
+
+    if args.only_slug:
+        projects = [p for p in projects if p.get("slug") == args.only_slug]
+        if not projects:
+            raise SystemExit(f"No project found with slug '{args.only_slug}'")
+
+    generated_paths = [write_readme(project, project_root) for project in projects]
+
+    print(f"Generated {len(generated_paths)} README file(s)")
+    for path in generated_paths:
+        print(f"- {path.relative_to(Path.cwd())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add exports/projects.json and a README generator script to create project documentation from structured data
- scaffold MkDocs site content with category placeholders, project index, and generation factory prompt
- add docker-compose stack wiring Postgres, backend, and frontend services for local demos

## Testing
- python tools/generate_readmes.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c945935a88327be9fde0b73beb95a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Portfolio index created with 25 projects across five categories (Red Team, Blue Team, Cloud Security, DevOps/SRE, GRC).
  * Comprehensive project documentation added with consistent structure including overviews, responsibilities, tools, outcomes, and reproduction steps.
  * Documentation site configured and ready for deployment.

* **Chores**
  * Container orchestration configuration added for multi-service deployment.
  * Build automation tooling added to support documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->