### PR TITLE
Add master factory deliverables for P01 AWS infra

### DIFF
--- a/projects/p01-aws-infra/master-factory/README.md
+++ b/projects/p01-aws-infra/master-factory/README.md
@@ -1,0 +1,22 @@
+# P01 – AWS Infrastructure Automation Factory Output
+
+## Overview
+This package captures the master factory deliverables for the P01 AWS Infrastructure Automation track. It consolidates reference diagrams, implementation prompts, test strategy, operational playbooks, reporting, observability, security, risk, architecture decisions, and a concise business narrative aligned to the existing VPC + RDS stack and DR automation.
+
+## Deliverable Map
+- `diagrams.md`: System, CI/CD, and IaC diagrams (Mermaid + ASCII).
+- `code-prompts.md`: Structured prompts for infrastructure-as-code and automation updates.
+- `testing-suite.md`: Unit, integration, and DR drill validation coverage.
+- `operations.md`: Runbooks, deployment steps, and incident response.
+- `reporting.md`: KPIs and evidence capture guidelines.
+- `observability.md`: Metrics, logs, and tracing expectations.
+- `security.md`: Controls, guardrails, and validation hooks.
+- `risk.md`: Risk register with mitigations.
+- `adrs.md`: Key architecture decision records.
+- `business-narrative.md`: Executive summary tying outcomes to business value.
+
+## Usage
+1. Review `diagrams.md` to understand topology and automation flow.
+2. Apply changes using the scoped prompts in `code-prompts.md`.
+3. Validate with `testing-suite.md` before merging to main.
+4. Follow `operations.md` for deployments and DR drills.

--- a/projects/p01-aws-infra/master-factory/adrs.md
+++ b/projects/p01-aws-infra/master-factory/adrs.md
@@ -1,0 +1,16 @@
+# Architecture Decision Records
+
+## ADR-001: Terraform + CloudFormation Hybrid
+- **Context:** Existing VPC/RDS stack uses CloudFormation; new modules leverage Terraform.
+- **Decision:** Keep CloudFormation for stack stability but wrap with Terraform outputs and remote state to orchestrate dependencies.
+- **Consequences:** Mixed IaC requires consistent tagging and state documentation; CI must run both `terraform plan` and `cfn-lint`.
+
+## ADR-002: DR Failover Regions
+- **Context:** Need active/passive resilience.
+- **Decision:** Use primary region `us-east-1` with secondary `us-west-2` for Route53 failover and cross-region snapshots.
+- **Consequences:** Increased snapshot and data transfer cost; requires cross-region KMS keys and health check alarms.
+
+## ADR-003: Security Baseline Enforcement
+- **Context:** Compliance requires continuous guardrails.
+- **Decision:** Enable Config and GuardDuty in all deployed regions, enforce via CI checks and periodic reports.
+- **Consequences:** Additional per-account costs; ensures audit readiness and early drift detection.

--- a/projects/p01-aws-infra/master-factory/business-narrative.md
+++ b/projects/p01-aws-infra/master-factory/business-narrative.md
@@ -1,0 +1,3 @@
+# Business Narrative
+
+The P01 AWS Infrastructure Automation initiative delivers a hardened, repeatable stack for application teams. By codifying the VPC, ALB, and RDS footprint with Terraform + CloudFormation, we reduce provisioning time from weeks to hours while embedding guardrails (Config, GuardDuty, WAF). Quarterly DR drills validate business continuity with documented RPO/RTO targets and evidence artifacts, satisfying audit requirements and reducing downtime risk. Automated reporting and observability provide leadership with transparent uptime, cost, and resilience metrics tied directly to customer experience.

--- a/projects/p01-aws-infra/master-factory/code-prompts.md
+++ b/projects/p01-aws-infra/master-factory/code-prompts.md
@@ -1,0 +1,28 @@
+# Code Prompts
+
+## Terraform Module Enhancements
+- Add Config/GuardDuty outputs and wiring for existing `infra/vpc-rds.yaml` stack.
+- Introduce Terraform module variables for ALB access logs bucket, WAF ACL ID, and RDS performance insights toggle.
+- Ensure state backend references `terraform/backend.hcl` with DynamoDB table for locking.
+
+### Prompt
+"""
+Update Terraform modules to expose outputs for AWS Config recorder ARN, GuardDuty detector ID, and S3 access logs bucket. Wire outputs into CloudFormation stack parameters for VPC/RDS. Enforce state backend stored in S3 with DynamoDB locking and add pre-commit hooks for `terraform fmt` and `terraform validate`.
+"""
+
+## CloudFormation Adjustments
+- Parameterize subnet CIDRs and DB instance class for DR drill flexibility.
+- Add SNS notification topics for backup failures and DR drill status.
+
+### Prompt
+"""
+Modify `infra/vpc-rds.yaml` to accept CIDR and DB instance class parameters, create SNS topics for backup failures and DR drill status, and publish stack outputs for topic ARNs. Ensure resources are tagged with `Project=P01` and `Environment` variables.
+"""
+
+## Automation Scripts
+- Extend `scripts/dr-drill.sh` to capture Route53 failover metrics and upload to S3 evidence bucket.
+
+### Prompt
+"""
+Enhance `scripts/dr-drill.sh` to run Route53 health checks pre/post failover, record latency metrics, push JSON results to `evidence/` in S3, and exit non-zero on threshold breaches.
+"""

--- a/projects/p01-aws-infra/master-factory/diagrams.md
+++ b/projects/p01-aws-infra/master-factory/diagrams.md
@@ -1,0 +1,57 @@
+# P01 – Diagrams
+
+## System Topology (Mermaid)
+```mermaid
+flowchart LR
+  User[User] -->|HTTPS| ALB[Application Load Balancer]
+  ALB --> ASG[Auto Scaling Group]
+  ASG --> App[App Instances]
+  App --> RDS[(Amazon RDS)]
+  App --> Redis[(ElastiCache Redis)]
+  ALB -->|Health Checks| Route53[Route 53]
+  CloudWatch[CloudWatch Alarms] -->|Notify| SNS[PagerDuty/Webhook]
+```
+
+## System Topology (ASCII)
+```
+User --> Route53 --> ALB ==> ASG -> App Nodes -> RDS
+                          \--> CloudWatch Alarms -> SNS/PagerDuty
+                          \--> Redis Cache
+```
+
+## CI/CD Flow (Mermaid)
+```mermaid
+flowchart LR
+  Dev[Developer Commit] --> GH[GitHub Actions]
+  GH -->|Lint/Test| QA[Quality Gate]
+  QA -->|Build| AMI[AMI/Container Build]
+  AMI -->|Deploy| CD[CD Stage]
+  CD -->|Apply| Terraform[Terraform Plan/Apply]
+  CD -->|Run| Ansible[Ansible Playbooks]
+  QA -->|Scan| Sec[Security Scans]
+  Sec -->|Report| GH
+```
+
+## CI/CD Flow (ASCII)
+```
+Dev commit -> GitHub Actions -> Lint/Test -> Security Scan -> Build Artifact -> CD Stage
+        -> Terraform plan/apply -> Ansible config -> Notify
+```
+
+## IaC Layering (Mermaid)
+```mermaid
+flowchart TB
+  TF[Terraform Modules]
+  CF[CloudFormation Templates]
+  DSC[Desired State Config]
+  TF --> CF --> DSC
+  TF --> RemoteState[(S3 + DynamoDB State)]
+  CF --> Hooks[Lambda Hooks]
+```
+
+## IaC Layering (ASCII)
+```
+Terraform modules -> CloudFormation stack -> Desired state configs
+         |-> Remote state (S3/DynamoDB)
+         |-> Lambda hooks
+```

--- a/projects/p01-aws-infra/master-factory/governance.md
+++ b/projects/p01-aws-infra/master-factory/governance.md
@@ -1,0 +1,18 @@
+# Governance
+
+## Roles & RACI
+- **Product Owner:** Approves scope, prioritizes backlog.
+- **Tech Lead:** Owns architecture decisions and CI/CD quality gates.
+- **DevOps:** Maintains Terraform/CloudFormation pipelines and state hygiene.
+- **Security:** Reviews guardrails, scans, and incident response readiness.
+- **Ops/DBA:** Oversees RDS performance, backups, and DR drill execution.
+
+## Change Control
+- All infrastructure changes via PR with linked issue and risk rating.
+- Mandatory reviewers: Tech Lead + Security for high/critical changes.
+- Emergency changes require postmortem within 48 hours.
+
+## Compliance
+- Align with CIS AWS Foundations; document evidence quarterly.
+- Track open findings in `reports/p01/findings.csv` with due dates and owners.
+- Require tagging standards: `Project=P01`, `Environment`, `Owner`, `CostCenter`.

--- a/projects/p01-aws-infra/master-factory/observability.md
+++ b/projects/p01-aws-infra/master-factory/observability.md
@@ -1,0 +1,19 @@
+# Observability
+
+## Metrics
+- ALB: request count, 4xx/5xx rates, target response time.
+- RDS: CPU, connections, read/write latency, replica lag.
+- Route53: health check status, failover switch time.
+- Backup: snapshot duration and failures.
+
+## Logs
+- ALB access logs to S3 with 30-day retention.
+- RDS audit logs shipped to CloudWatch Logs.
+- DR drill script logs stored in `artifacts/drills/<date>.log`.
+
+## Tracing
+- Enable X-Ray sampling on app instances (if present) to capture DB and external call traces.
+
+## Alerting
+- CloudWatch alarms for ALB 5xx, RDS latency > 50 ms, Route53 health check failure, backup failure, and GuardDuty high-severity findings.
+- Alerts route to SNS with PagerDuty/webhook integration.

--- a/projects/p01-aws-infra/master-factory/operations.md
+++ b/projects/p01-aws-infra/master-factory/operations.md
@@ -1,0 +1,24 @@
+# Operations
+
+## Deployment Runbook
+1. `make lint && make test`.
+2. `make plan` (Terraform) and capture plan output.
+3. Change advisory approval.
+4. `make apply` targeting env (`ENV=dev|prod`).
+5. Verify ALB health checks and RDS connectivity via `scripts/verify_rds.sh`.
+
+## Change Management
+- Use GitHub PR templates with checklist for Config/GuardDuty outputs.
+- Tag releases `p01-vX.Y.Z` and upload plan/apply logs to `artifacts/releases/`.
+
+## Incident Response
+- Primary alarms: ALB 5xx rate, RDS latency, Route53 health check failure, DR drill failure.
+- On alarm: engage on-call, run `scripts/dr-drill.sh --verify-only`, collect CloudWatch metrics, and document in incident record.
+
+## Backup & Restore
+- Daily RDS snapshots with 7-day retention.
+- Weekly cross-region snapshot copy; test restore monthly using `scripts/restore_rds.sh` (dry-run available).
+
+## DR Drills
+- Quarterly failover to secondary region with documented RPO/RTO.
+- Capture evidence: Route53 status, RDS promotion time, app smoke test results.

--- a/projects/p01-aws-infra/master-factory/reporting.md
+++ b/projects/p01-aws-infra/master-factory/reporting.md
@@ -1,0 +1,19 @@
+# Reporting
+
+## KPIs
+- ALB 5xx error rate < 1% per 5 minutes.
+- RDS average latency < 20 ms.
+- DR drill RTO ≤ 30 minutes; RPO ≤ 5 minutes.
+- IaC drift: zero unmanaged resources per weekly drift check.
+
+## Dashboard Outputs
+- CloudWatch: ALB/RDS metrics, Route53 health, Config compliance.
+- Grafana (if connected): RDS performance insights, application latency.
+
+## Evidence Package
+- Include Terraform plan/apply logs, `dr-drill.sh` JSON metrics, Config/GuardDuty status reports, and alarm screenshots.
+- Store quarterly in `reports/p01/<year>-Q<qtr>/`.
+
+## Executive Rollup
+- Monthly summary of uptime, cost deltas, and completed drills.
+- Highlight security scan findings and remediation closure dates.

--- a/projects/p01-aws-infra/master-factory/risk.md
+++ b/projects/p01-aws-infra/master-factory/risk.md
@@ -1,0 +1,9 @@
+# Risk Register
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+| --- | --- | --- | --- | --- |
+| Misconfigured Route53 failover causing downtime | Medium | High | Automated health checks + DR drill validation with thresholds; manual approval for DNS changes. | Ops Lead |
+| Terraform state corruption | Low | High | S3 versioning + DynamoDB locking; restricted IAM on state bucket; periodic state backups. | DevOps |
+| RDS backup failure | Medium | High | CloudWatch alarm on snapshot failures; monthly restore tests; SNS alerts. | DBA |
+| Security drift (Config/GuardDuty disabled) | Medium | High | Config rules to enforce enablement; CI checks; weekly drift reports. | Security |
+| Cost overrun from idle resources | Medium | Medium | Scheduled shutdown for non-prod, tagging, and cost anomaly detection alerts. | FinOps |

--- a/projects/p01-aws-infra/master-factory/security.md
+++ b/projects/p01-aws-infra/master-factory/security.md
@@ -1,0 +1,19 @@
+# Security
+
+## Controls
+- Enforce AWS Config recorder and GuardDuty in all regions used by the stack.
+- ALB behind AWS WAF with managed rules: SQLi, XSS, IP reputation.
+- RDS encryption at rest with KMS; enforce TLS in transit.
+- IAM: least privilege for CI/CD roles; use IAM roles for service access (no static creds).
+
+## Scanning
+- `checkov` and `tfsec` in CI to block insecure resources.
+- AWS Inspector/Config conformance packs for CIS foundations.
+
+## Secrets Management
+- Store database credentials in Secrets Manager; rotate every 30 days.
+- CI/CD pulls secrets via OIDC + scoped IAM role.
+
+## Audit
+- Enable CloudTrail with log integrity validation.
+- Ship WAF/ALB logs to centralized S3 with lifecycle + access logging.

--- a/projects/p01-aws-infra/master-factory/testing-suite.md
+++ b/projects/p01-aws-infra/master-factory/testing-suite.md
@@ -1,0 +1,23 @@
+# Testing Suite
+
+## Unit Tests
+- Terraform: `terraform validate`, `tflint`, and `checkov` on modules.
+- Shell scripts: `shellcheck scripts/*.sh` focusing on `dr-drill.sh`.
+
+## Integration Tests
+- `pytest tests/integration/test_rds_connectivity.py` to verify RDS connectivity from app instances via bastion.
+- `pytest tests/integration/test_route53_failover.py` to confirm health check failover toggles.
+- `pytest tests/integration/test_config_guardduty.py` to validate AWS Config and GuardDuty detectors are enabled.
+
+## Disaster Recovery Drills
+- Execute `scripts/dr-drill.sh --region <primary> --failover-region <secondary>`.
+- Validate RPO/RTO targets: RPO ≤ 5 minutes, RTO ≤ 30 minutes.
+- Capture CloudWatch metrics and Route53 health check outputs as artifacts.
+
+## CI Pipeline Gates
+- Pre-merge: `make lint` -> `make test` -> `make plan` (Terraform plan).
+- Release: `make apply` gated on manual approval + security scan pass.
+
+## Evidence Collection
+- Store test outputs in `artifacts/<date>/` with JSON summaries for Config, GuardDuty, and DR drills.
+- Attach screenshots/logs to pull requests for audit readiness.


### PR DESCRIPTION
## Summary
- add master factory deliverable set for P01 AWS infrastructure automation
- include mermaid/ASCII diagrams, governance, risk, security, and business narrative artifacts
- provide prompts, testing suite, operations, observability, and reporting guidance for CI/CD and IaC flows

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca2659ab08327a698ce8f7bc4d4aa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released comprehensive documentation suite for AWS infrastructure automation including architecture diagrams and system topology, operational runbooks for deployment and incident response, security baseline controls and compliance frameworks, disaster recovery procedures with quarterly failover testing, governance roles and change control workflows, risk register, observability metrics and alerting strategies, integrated testing suite, reporting KPIs and dashboards, and executive-level business narrative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->