### PR TITLE
Add monitoring stack configs and homelab network documentation

### DIFF
--- a/projects/01-sde-devops/PRJ-SDE-002/.env.example
+++ b/projects/01-sde-devops/PRJ-SDE-002/.env.example
@@ -1,0 +1,23 @@
+# Grafana Configuration
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=ChangeThisSecurePassword123!
+GF_SERVER_ROOT_URL=http://localhost:3000
+GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-clock-panel
+
+# Prometheus Configuration
+PROMETHEUS_RETENTION=15d
+PROMETHEUS_STORAGE_PATH=/prometheus
+
+# Alertmanager Configuration
+ALERTMANAGER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/HERE
+ALERTMANAGER_SMTP_HOST=smtp.gmail.com:587
+ALERTMANAGER_SMTP_FROM=alerts@yourdomain.com
+ALERTMANAGER_SMTP_TO=monitoring-team@yourdomain.com
+ALERTMANAGER_SMTP_USERNAME=your-email@gmail.com
+ALERTMANAGER_SMTP_PASSWORD=your-app-specific-password
+PAGERDUTY_ROUTING_KEY=replace-me
+
+# General
+HOSTNAME=proxmox-monitoring-01
+ENVIRONMENT=homelab
+TZ=America/Los_Angeles

--- a/projects/01-sde-devops/PRJ-SDE-002/README.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/README.md
@@ -1,381 +1,57 @@
-# Observability & Backups Stack
-
-**Status:** 🟢 Done
-
-## Description
-
-Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.
-
-## Links
-
-- [Parent Documentation](../../../README.md)
-
-## Next Steps
-
-This is a placeholder README. Documentation and evidence will be added as the project progresses.
-
-## Contact
-
-For questions about this project, please reach out via [GitHub](https://github.com/sams-jackson) or [LinkedIn](https://www.linkedin.com/in/sams-jackson).
-
----
-*Placeholder — Documentation pending*
-# PRJ-SDE-002: Observability & Backups Stack
-
-**Status:** 🟢 Completed (Documentation Pending)
-**Category:** System Development Engineering / DevOps
-**Technologies:** Prometheus, Grafana, Loki, Alertmanager, Proxmox Backup Server
-
----
-
-## Overview
-
-Implemented a comprehensive monitoring, logging, and alerting stack to observe homelab infrastructure and ensure data resilience through automated backups.
-
-## Architecture
-
-### Monitoring (Prometheus)
-- Metrics collection from multiple targets
-- Node exporter for system metrics (CPU, memory, disk, network)
-- Proxmox exporter for hypervisor metrics
-- Service-specific exporters (PostgreSQL, Redis, etc.)
-- Retention and storage configuration
-
-### Visualization (Grafana)
-- Pre-built and custom dashboards
-- Golden signals: latency, traffic, errors, saturation
-- System health overview
-- Per-service detailed views
-- Annotations for deployments and incidents
-
-### Logging (Loki)
-- Centralized log aggregation
-- LogQL for querying and filtering logs
-- Integration with Grafana for unified interface
-- Log retention policies
-- Promtail agents for log shipping
-
-### Alerting (Alertmanager)
-- Alert routing and grouping
-- Notification channels (email, Slack, PagerDuty)
-- Silencing and inhibition rules
-- Alert templates and severity levels
-- On-call rotation support (if applicable)
-
-### Backup (Proxmox Backup Server)
-- Incremental backup of VMs and containers
-- Deduplication to save storage
-- Encryption at rest
-- Scheduled backup jobs
-- Retention policies and pruning
-
-## How It Works
-
-1. **Provision Prometheus and exporters** on the Proxmox host, followed by Node Exporter installation on all VMs and containers.
-2. **Deploy Grafana** once Prometheus is scraping data to verify dashboards render correctly.
-3. **Configure Loki and Promtail** to begin ingesting logs alongside metrics.
-4. **Set up Alertmanager** with notification channels and connect it to Prometheus.
-5. **Integrate PBS** nightly jobs and mount TrueNAS NFS shares for resilient storage.
-
-**Configuration Locations**
-- Prometheus: `/etc/prometheus/prometheus.yml`, alert rules in `/etc/prometheus/alerts/`
-- Grafana dashboards: `/etc/grafana/provisioning/dashboards/`
-- Loki: `/etc/loki/loki-config.yml`
-- Promtail: `/etc/promtail/promtail-config.yml`
-- Alertmanager: `/etc/alertmanager/alertmanager.yml`
-
-**Service Management**
-- `sudo systemctl enable --now prometheus`
-- `sudo systemctl enable --now grafana-server`
-- `sudo systemctl enable --now loki`
-- `sudo systemctl enable --now promtail`
-- `sudo systemctl enable --now alertmanager`
-- `sudo systemctl enable --now proxmox-backup`
-
-**Network Flow Architecture**
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Targets   │────▶│  Exporters  │────▶│ Prometheus  │
-│ (VMs/Hosts) │     │ (Port 9100+)│     │ (Port 9090) │
-└─────────────┘     └─────────────┘     └──────┬──────┘
-                                               │
-                    ┌──────────────────────────┼──────────────────────────┐
-                    │                          │                          │
-                    ▼                          ▼                          ▼
-            ┌───────────────┐         ┌──────────────┐         ┌─────────────┐
-            │ Alertmanager  │         │   Grafana    │         │    Loki     │
-            │  (Port 9093)  │         │ (Port 3000)  │         │ (Port 3100) │
-            └───────┬───────┘         └──────────────┘         └──────┬──────┘
-                    │                                                  │
-                    ▼                                                  ▼
-            ┌───────────────┐                                  ┌─────────────┐
-            │ Slack/Email   │                                  │  Promtail   │
-            │ Notifications │                                  │  (Logs)     │
-            └───────────────┘                                  └─────────────┘
-```
-
-**Data Flow Overview**
-1. **Metrics Collection**: Node Exporters (9100), Proxmox Exporter (9221), and application-specific exporters expose metrics
-2. **Log Shipping**: Promtail agents tail log files and push to Loki (port 3100)
-3. **Scraping**: Prometheus scrapes all exporters every 15 seconds, evaluates alert rules every 30 seconds
-4. **Storage**: Prometheus stores metrics locally with 30-day retention; Loki stores logs with 14-day retention
-5. **Alerting**: Alertmanager receives alerts from Prometheus, groups/routes them to Slack channel #homelab-alerts
-6. **Visualization**: Grafana queries Prometheus and Loki, renders dashboards on port 3000
-7. **Backup**: PBS runs nightly at 02:00, snapshots are stored on TrueNAS NFS share at 192.168.1.10:/mnt/tank/backups
-
-## Key Dashboards
-
-### Infrastructure Overview
-- Cluster resource utilization
-- Network throughput
-- Storage capacity and IOPS
-- Uptime tracking
-
-### Service Health
-- HTTP response times and error rates
-- Database query performance
-- Queue depths and processing rates
-- Cache hit ratios
-
-### Alerting Dashboard
-- Active alerts summary
-- Alert history and trends
-- Mean time to acknowledge (MTTA)
-- Mean time to resolve (MTTR)
-
-## Alert Examples
-
-### Critical Alerts
-- Host down or unreachable
-- Disk usage >90%
-- Memory usage >95%
-- Backup job failures
-- SSL certificate expiration <7 days
-
-### Warning Alerts
-- Disk usage >80%
-- High CPU sustained >80% for 15 minutes
-- Backup job duration increasing
-- Log error rate spike
-
-## Alert Examples and Responses
-
-| Alert Name | Trigger Condition | Severity | Response Time | Runbook |
-|------------|-------------------|----------|---------------|---------|
-| HostDown | `up == 0` for 2 minutes | Critical | 5 minutes | [HostDown](https://runbooks.homelab.local/HostDown) |
-| HighCPUUsage | CPU >80% for 15 minutes | Warning | 30 minutes | [HighCPUUsage](https://runbooks.homelab.local/HighCPUUsage) |
-| DiskSpaceLow | Free space <15% | Warning | 1 hour | [DiskSpaceLow](https://runbooks.homelab.local/DiskSpaceLow) |
-| BackupJobFailed | `proxmox_backup_job_last_status != 0` | Critical | 15 minutes | [BackupJobFailed](https://runbooks.homelab.local/BackupJobFailed) |
-| ServiceUnreachable | `probe_success == 0` for 5 minutes | Critical | 10 minutes | [ServiceUnreachable](https://runbooks.homelab.local/ServiceUnreachable) |
-
-**Example Slack Payload**
-```json
-{
-  "status": "firing",
-  "receiver": "critical-all",
-  "alerts": [
-    {
-      "labels": {
-        "alertname": "HostDown",
-        "instance": "192.168.1.21:9100",
-        "severity": "critical"
-      },
-      "annotations": {
-        "summary": "Host 192.168.1.21:9100 is unreachable",
-        "description": "Prometheus has not scraped 192.168.1.21:9100 for over two minutes. Investigate network connectivity or system health.",
-        "runbook": "https://runbooks.homelab.local/HostDown"
-      }
-    }
-  ],
-  "groupLabels": {
-    "alertname": "HostDown"
-  },
-  "commonLabels": {
-    "environment": "homelab",
-    "cluster": "main"
-  }
-}
-```
-
-## Backup Configuration
-
-### Schedule
-- **Daily:** All VMs and containers (incremental)
-- **Weekly:** Full backup verification
-- **Monthly:** Backup restore test
-
-### Retention Policy
-- **Daily backups:** Keep 7 days
-- **Weekly backups:** Keep 4 weeks
-- **Monthly backups:** Keep 3 months
-
-### Verification
-- Automated backup integrity checks
-- Monthly restore drills
-- Documentation of restore procedures
-
-## Backup and Recovery Procedures
-
-**Schedule**
-- Nightly backups at 02:00 via Proxmox Backup Server job schedule.
-- Weekly verification tasks run on Sundays to validate snapshot integrity.
-- Monthly restore rehearsals verify end-to-end recovery steps.
-
-**Scope of Backups**
-- VMs: 192.168.1.20-24 (Wiki.js, Home Assistant, Immich, database, utility).
-- Containers: 192.168.1.30-32 (supporting services).
-- Configuration directories exported from `/etc/` for Prometheus, Grafana, Loki, and Alertmanager.
-
-**Retention Policy**
-- 7 daily restore points, 4 weekly rollups, 3 monthly archives retained on PBS.
-
-**Recovery Steps**
-1. Log in to PBS web UI at `https://192.168.1.15:8007`.
-2. Select the desired snapshot for the VM or container.
-3. Restore to the original ID or clone to a staging ID for validation.
-4. Power on the restored workload and confirm service availability.
-5. Re-run Prometheus `ServiceUnreachable` probes to ensure monitoring reflects the recovered service.
-
-**Automation Support**
-- Backup verification script: [`verify-pbs-backups.sh`](./assets/scripts/verify-pbs-backups.sh).
-
-## Metrics Cheat Sheet
-
-### Essential PromQL Queries
-
-| Metric Goal | Prometheus Query | Expected Result |
-|-------------|------------------|-----------------|
-| CPU usage per host | `100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)` | Percentage utilization |
-| Memory available | `node_memory_MemAvailable_bytes / 1024 / 1024 / 1024` | GB available |
-| Memory utilization % | `100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))` | Percentage used |
-| Disk space used | `100 - ((node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"}) * 100)` | Percentage used |
-| Disk I/O rate | `rate(node_disk_read_bytes_total[5m]) + rate(node_disk_written_bytes_total[5m])` | Bytes per second |
-| Network traffic inbound | `rate(node_network_receive_bytes_total{device!~"lo|veth.*"}[5m])` | Bytes per second |
-| Network traffic outbound | `rate(node_network_transmit_bytes_total{device!~"lo|veth.*"}[5m])` | Bytes per second |
-| System load average | `node_load1 / count(node_cpu_seconds_total{mode="idle"})` | Load per CPU core |
-| Backup job status | `proxmox_backup_job_last_status` | 0 = OK, 1 = error |
-| HTTP request rate | `sum(rate(http_requests_total[5m])) by (service)` | Requests per second |
-| HTTP error rate | `sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))` | Error ratio (0-1) |
-| Service uptime | `time() - process_start_time_seconds` | Seconds since start |
-
-### Recording Rules (Pre-computed Metrics)
-
-```yaml
-# /etc/prometheus/recording_rules.yml
-groups:
-  - name: homelab_aggregations
-    interval: 60s
-    rules:
-      - record: instance:node_cpu_utilization:rate5m
-        expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
-      
-      - record: instance:node_memory_utilization:ratio
-        expr: 1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
-      
-      - record: instance:node_disk_utilization:ratio
-        expr: 1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"})
-      
-      - record: job:http_request_rate:rate5m
-        expr: sum(rate(http_requests_total[5m])) by (job)
-      
-      - record: job:http_error_rate:rate5m
-        expr: sum(rate(http_requests_total{status=~"5.."}[5m])) by (job) / sum(rate(http_requests_total[5m])) by (job)
-```
-
-**Usage Notes:**
-- Recording rules reduce dashboard load time by pre-computing complex queries
-- Stored with 5-minute granularity for 90 days
-- Used in high-traffic dashboards and alerting rules
-
-## Skills Demonstrated
-
-- Metrics collection and time-series databases
-- Dashboard design and visualization
-- Log aggregation and analysis
-- Alert design and tuning (reducing noise)
-- Backup automation and verification
-- Observability best practices (SLIs, SLOs, SLAs)
-
-## Observability Philosophy
-
-Following the **USE Method** (Utilization, Saturation, Errors):
-- **Utilization:** How busy is the resource?
-- **Saturation:** How much extra work is queued?
-- **Errors:** What errors are occurring?
-
-And the **RED Method** (Rate, Errors, Duration) for services:
-- **Rate:** Requests per second
-- **Errors:** Failed requests per second
-- **Duration:** Response time distribution
-
-## Documentation Status
-
-📝 **Pending:** Dashboard exports, Prometheus configurations, alert rule examples, and backup logs are being prepared and will be added to the `assets/` directory.
-
-## Lessons Learned
-
-### Technical Insights
-
-1. **Metrics Backend Selection**: Started with InfluxDB but migrated to Prometheus for richer querying (PromQL), better alerting integration, and stronger community support. The migration took 3 days but improved query performance by ~40%.
-
-2. **Scrape Interval Optimization**: Initial 5-second scrape interval filled disk quickly (80GB in 2 weeks). Settled on 15-second intervals which balanced granularity with 30-day retention, reducing storage to 12GB for the same period.
-
-3. **Alert Fatigue Mitigation**: Experienced 50+ alerts per day initially. Reduced to <5 daily by:
-   - Tuning thresholds based on historical data (e.g., disk alerts from 85% → 90%)
-   - Adding inhibition rules (e.g., HostDown suppresses all other alerts from that host)
-   - Implementing alert grouping windows (5 minutes) to batch related alerts
-   - Creating detailed runbooks for each alert to reduce investigation time
-
-4. **Backup Verification Critical**: The backup verification script (`verify-pbs-backups.sh`) discovered that PBS UI showed "OK" for 3 snapshots that were actually incomplete due to network timeouts. Now run verification within 1 hour of each backup completion.
-
-5. **Dashboard Standardization**: Created a dashboard template with consistent color schemes, panel layouts, and naming conventions. This reduced dashboard creation time from 2 hours to 20 minutes and accelerated onboarding for new homelab contributors.
-
-### Operational Insights
-
-6. **Log Volume Management**: Application logs initially consumed 200GB/month. Implemented selective logging (error/warn only in production) and reduced retention from 30 to 14 days, cutting storage to 40GB/month.
-
-7. **Cardinality Awareness**: Added a label for every container ID in metrics, causing cardinality explosion (>100k series). Removed unnecessary labels and now maintain <50k series, improving query performance dramatically.
-
-8. **Alertmanager Routing Complexity**: Single Slack channel became noisy. Now route: Critical → #incidents + PagerDuty, Warning → #monitoring, Info → #homelab-events. Clear separation improved response time by 60%.
-
-9. **Grafana Access Control**: Initially gave all homelab users Admin rights. After accidental dashboard deletions, implemented role-based access: Viewers for most users, Editors for infra team, Admin for ops lead only.
-
-10. **Backup Testing Discipline**: Implemented monthly restore drills. Discovered that recovering PostgreSQL required WAL replay knowledge that wasn't documented. Now maintain detailed restore runbooks for each service type (database, application, stateful services).
-
-## Future Enhancements
-
-- Distributed tracing with Tempo or Jaeger
-- Synthetic monitoring (uptime checks)
-- Anomaly detection with machine learning
-- Cost tracking dashboards
-- SLO tracking and error budgets
-
-## 📸 Screenshots and Evidence
-
-### Monitoring & Visualization
-
-![Infrastructure Overview Dashboard](./assets/screenshots/grafana-infrastructure-dashboard.png)
-*Grafana infrastructure dashboard showing CPU, memory, disk, and network metrics across all 9 homelab hosts (192.168.1.20-32). Displays real-time resource utilization with 15-second granularity, captured during normal operation with ~40% average CPU load.*
-
-![Active Alerts Panel](./assets/screenshots/grafana-alerts-panel.png)
-*Grafana alerting panel showing current firing alerts with severity levels (Critical/Warning/Info). Screenshot captured during maintenance window showing 2 intentional warnings: DiskSpaceLow on database VM and scheduled backup job in progress.*
-
-![Prometheus Targets Page](./assets/screenshots/prometheus-targets.png)
-*Prometheus targets page (http://192.168.1.11:9090/targets) showing all 15 scrape endpoints with UP status. Includes Node Exporters (9100), Proxmox Exporter (9221), PostgreSQL Exporter (9187), and custom application exporters. All targets healthy with <100ms scrape duration.*
-
-### Logging & Alerting
-
-![Loki Log Explorer](./assets/screenshots/loki-log-explorer.png)
-*Loki log aggregation interface in Grafana showing log streams from 12 sources. LogQL query `{job="systemd-journal"} |= "error"` filtered across last 24 hours, displaying centralized error tracking from all VMs. Demonstrates log correlation during incident investigation.*
-
-![Alertmanager UI](./assets/screenshots/alertmanager-ui.png)
-*Alertmanager web interface (http://192.168.1.11:9093) showing alert grouping, silences, and inhibition rules. Screenshot shows 3 active silences for planned maintenance and alert routing configuration with Slack integration status.*
-
-### Backup & Recovery
-
-![Proxmox Backup Server Dashboard](./assets/screenshots/pbs-dashboard.png)
-*Proxmox Backup Server (PBS) web UI at https://192.168.1.15:8007 showing backup summary. Displays 63 total snapshots across 7 VMs, 28.4TB total backup size with deduplication ratio of 3.2:1 (effective storage 8.9TB). Backup verification status showing 100% integrity for all snapshots with retention policy enforcement active.*
-
----
-
-**Last Updated:** October 28, 2025
+# Enterprise Monitoring & Observability Stack
+
+Production-ready monitoring solution for Proxmox and container workloads. The stack combines Prometheus, Grafana, Loki, Promtail, Alertmanager, node_exporter, and cAdvisor with hardened defaults, health checks, and operational runbooks.
+
+## Architecture Overview
+- **Prometheus** scrapes exporters and the Proxmox nodes every 15s and evaluates alerts shipped to Alertmanager.
+- **Grafana** renders prebuilt dashboards for infrastructure, hosts, containers, and logs.
+- **Loki + Promtail** aggregate container/system logs with low cardinality labeling.
+- **Alertmanager** routes critical/warning notifications to Slack, email, or PagerDuty with inhibition to avoid storms.
+- **Node Exporter & cAdvisor** expose host and container metrics.
+- Dual-network topology isolates exporter traffic from user-facing endpoints.
+
+## Features & Capabilities
+- Pinned container versions, explicit resource limits, and localhost binding for UI components.
+- Prebuilt alert rules covering infrastructure, containers, and monitoring-plane health.
+- Provisioned dashboards with variables for environment, instance, and container filtering.
+- Backup/restore scripts for all persistent volumes.
+- Health-check script that exercises metrics, logs, and alert pathways.
+
+## Quick Start
+1. Copy `.env.example` to `.env` and adjust credentials and retention parameters.
+2. Validate configuration: `./scripts/deploy.sh validate`.
+3. Start the stack: `./scripts/deploy.sh start`.
+4. Open Grafana via `http://127.0.0.1:3000` (admin credentials from `.env`).
+5. Confirm dashboards and alerts via the provided panels and send a test alert with `./scripts/health-check.sh`.
+
+## Configuration Guide
+- **Prometheus targets**: edit `prometheus/prometheus.yml` to add new exporters or Proxmox hosts; prefer file-based service discovery for larger fleets.
+- **Alert rules**: tune thresholds in `prometheus/alerts/rules.yml`; use `promtool check rules` before reload.
+- **Alertmanager routing**: configure Slack/email/PagerDuty secrets via `.env`; adjust routes and inhibition as needed.
+- **Loki retention**: controlled in `loki/loki-config.yml` (defaults to 7 days) and compactor settings.
+- **Promtail pipelines**: extend `promtail/promtail-config.yml` to parse structured logs and drop high-cardinality labels.
+
+## Dashboard Guide
+- `infrastructure-overview.json`: executive snapshot of fleet health, capacity, and firing alerts.
+- `host-details.json`: per-host CPU, memory, disk I/O, network traffic, and top processes with instance variable.
+- `container-monitoring.json`: per-container CPU/memory/network usage and restart tracking.
+- `logs-explorer.json`: LogQL-driven search with variables for container name and log level.
+
+## Alert Rule Reference
+Key alerts include instance down, CPU/memory saturation, disk capacity and growth prediction, container instability, and monitoring-plane failures (Prometheus/Grafana). All alerts include summaries, descriptions, and runbooks embedded in annotations.
+
+## Operations
+- **Backup**: `./scripts/deploy.sh backup` stores compressed copies of all volumes in `backups/`.
+- **Restore**: `./scripts/deploy.sh restore <archive>` stops the stack and restores data.
+- **Validate**: run validation prior to deploy to catch syntax issues.
+- **Health**: `./scripts/health-check.sh` checks endpoints, queries Prometheus, exercises Loki, and fires a test alert.
+
+## Security Considerations
+- UI ports bind to 127.0.0.1; publish externally only via reverse proxy with TLS.
+- Secrets and credentials are sourced from `.env`; avoid committing real secrets.
+- Resource limits prevent runaway processes from exhausting the host.
+
+## Performance Tuning
+- Increase Prometheus retention or scrape interval based on disk/CPU headroom.
+- Adjust Loki chunk size or retention for higher log throughput.
+- Scale node_exporter to remote Proxmox hosts and add recording rules for heavy dashboards.

--- a/projects/01-sde-devops/PRJ-SDE-002/alertmanager/alertmanager.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/alertmanager/alertmanager.yml
@@ -1,0 +1,66 @@
+# Alertmanager routing tree tuned for homelab with production-like behavior.
+route:
+  group_by: ['cluster', 'alertname', 'severity']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 12h
+  receiver: monitoring-default
+  routes:
+    - match:
+        severity: critical
+      receiver: pagerduty-critical
+      group_wait: 10s
+      group_interval: 5m
+      repeat_interval: 1h
+    - match:
+        severity: warning
+      receiver: slack-notifications
+      group_wait: 1m
+      group_interval: 5m
+      repeat_interval: 6h
+
+receivers:
+  - name: monitoring-default
+    slack_configs:
+      - api_url: ${ALERTMANAGER_SLACK_WEBHOOK_URL}
+        channel: '#monitoring'
+        send_resolved: true
+        title: '[Default] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}'
+
+  - name: pagerduty-critical
+    pagerduty_configs:
+      - routing_key: ${PAGERDUTY_ROUTING_KEY:-placeholder}
+        severity: 'critical'
+        send_resolved: true
+
+  - name: slack-notifications
+    slack_configs:
+      - api_url: ${ALERTMANAGER_SLACK_WEBHOOK_URL}
+        channel: '#monitoring-warnings'
+        title: '[Warning] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}'
+        send_resolved: true
+
+  - name: email-alerts
+    email_configs:
+      - to: ${ALERTMANAGER_SMTP_TO}
+        from: ${ALERTMANAGER_SMTP_FROM}
+        smarthost: ${ALERTMANAGER_SMTP_HOST}
+        auth_username: ${ALERTMANAGER_SMTP_USERNAME}
+        auth_password: ${ALERTMANAGER_SMTP_PASSWORD}
+        require_tls: true
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['instance', 'alertname']
+
+  - source_match:
+      alertname: 'InstanceDown'
+    target_match_re:
+      alertname: 'DiskSpace.*'
+    equal: ['instance']

--- a/projects/01-sde-devops/PRJ-SDE-002/docker-compose.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/docker-compose.yml
@@ -1,0 +1,216 @@
+version: "3.9"
+
+# Complete monitoring stack for homelab and Proxmox infrastructure
+# All services are pinned to explicit versions for reproducibility and security review.
+# The stack is split across frontend/backed networks to prevent exporter surfaces from being exposed to the host LAN.
+services:
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=${PROMETHEUS_STORAGE_PATH:-/prometheus}'
+      - '--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts:/etc/prometheus/alerts:ro
+      - prometheus_data:${PROMETHEUS_STORAGE_PATH:-/prometheus}
+    ports:
+      - "127.0.0.1:9090:9090"  # Bind to loopback to force tunnel/reverse-proxy access for security
+    networks:
+      - monitoring_frontend
+      - monitoring_backend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1.0"
+        reservations:
+          memory: 1G
+          cpus: "0.5"
+    depends_on:
+      alertmanager:
+        condition: service_healthy
+
+  grafana:
+    image: grafana/grafana:10.2.3
+    container_name: grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-http://localhost:3000}
+      GF_INSTALL_PLUGINS: ${GF_INSTALL_PLUGINS:-grafana-piechart-panel,grafana-clock-panel}
+    ports:
+      - "127.0.0.1:3000:3000"  # Localhost binding hardens surface area; use SSH tunnel for remote access
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    networks:
+      - monitoring_frontend
+      - monitoring_backend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "0.5"
+        reservations:
+          memory: 512M
+          cpus: "0.25"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+
+  loki:
+    image: grafana/loki:2.9.3
+    container_name: loki
+    command: ["-config.file=/etc/loki/loki-config.yml"]
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    ports:
+      - "127.0.0.1:3100:3100"  # Loki API exposed only locally
+    networks:
+      - monitoring_backend
+      - monitoring_frontend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "0.5"
+
+  promtail:
+    image: grafana/promtail:2.9.3
+    container_name: promtail
+    command: ["-config.file=/etc/promtail/promtail-config.yml"]
+    volumes:
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+    networks:
+      - monitoring_backend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9080/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+    depends_on:
+      loki:
+        condition: service_healthy
+
+  alertmanager:
+    image: prom/alertmanager:v0.26.0
+    container_name: alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    ports:
+      - "127.0.0.1:9093:9093"
+    networks:
+      - monitoring_backend
+      - monitoring_frontend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9093/-/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+
+  node-exporter:
+    image: prom/node-exporter:v1.7.0
+    container_name: node-exporter
+    pid: host
+    network_mode: host  # node-exporter must see host network interfaces; keep exporter on host while keeping other services isolated
+    command:
+      - '--path.rootfs=/host'
+    volumes:
+      - /:/host:ro,rslave
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9100/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.2"
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
+    container_name: cadvisor
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    ports:
+      - "127.0.0.1:8080:8080"
+    networks:
+      - monitoring_backend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+
+networks:
+  monitoring_frontend:
+    driver: bridge
+  monitoring_backend:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+  alertmanager_data:

--- a/projects/01-sde-devops/PRJ-SDE-002/docs/OPERATIONS.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/docs/OPERATIONS.md
@@ -1,0 +1,34 @@
+# Operations Runbook
+
+## Day 1: Initial Deployment
+1. Copy `.env.example` to `.env` and set secrets for Slack, SMTP, and PagerDuty.
+2. Run `./scripts/deploy.sh validate` to lint configurations with promtool and amtool.
+3. Deploy stack using `./scripts/deploy.sh start`; verify `docker compose ps` shows healthy containers.
+4. Import dashboards automatically provisioned in Grafana; confirm datasources are connected.
+
+## Day 2: Ongoing Maintenance
+- **Backups**: Execute `./scripts/deploy.sh backup` weekly; store archives off-host.
+- **Updates**: Pull latest images monthly (`docker compose pull`) after reviewing release notes; restart via deploy script.
+- **Capacity**: Track disk usage via infrastructure dashboard; adjust retention in Prometheus/Loki before reaching 70% disk.
+- **Certificate/TLS**: If fronting with reverse proxy, rotate certificates per corporate policy.
+
+## Incident Response Procedures
+- **Alert Storms**: Check Alertmanager inhibition rules; temporarily silence noisy alerts with expiration.
+- **Exporter Down**: Validate host connectivity, container status, and firewall rules; redeploy exporter if needed.
+- **Data Gaps**: Inspect Prometheus WAL for corruption; restart Prometheus after taking snapshot of data volume.
+- **Loki Ingestion Lag**: Reduce label cardinality in Promtail pipelines; increase chunk_target_size only if disk I/O allows.
+
+## Scaling Guidelines
+- Shard Prometheus or increase resources when scrape load exceeds 50k samples/sec; federate metrics for long-term storage.
+- Move Loki to object storage when retention exceeds 7 days or ingest rate grows; switch boltdb-shipper backend accordingly.
+- Use multiple Promtail clients on busy nodes to isolate log paths.
+
+## Disaster Recovery
+- Restore from latest backup archives using `./scripts/deploy.sh restore <archive>`.
+- Validate restored instance by running health-check script and comparing dashboard data with expected time ranges.
+- Store configuration files (prometheus.yml, alert rules, dashboards) in version control for reproducibility.
+
+## Upgrade Procedures
+- Test image updates in staging environment by swapping `.env` variables for alternate datasources.
+- Run validation commands after merging new rules/dashboards.
+- Use Grafana snapshots before upgrading plugins to recover quickly.

--- a/projects/01-sde-devops/PRJ-SDE-002/docs/TROUBLESHOOTING.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/docs/TROUBLESHOOTING.md
@@ -1,0 +1,36 @@
+# Troubleshooting Guide
+
+## Service Won't Start
+- Check docker compose logs: `docker compose -f docker-compose.yml logs <service>`.
+- Validate configuration syntax with `./scripts/deploy.sh validate`.
+- Ensure required ports (9090, 3000, 3100, 9093) are free or adjust mappings.
+
+## High Memory Usage
+- Review `HighMemoryUsage` alerts and `host-details` dashboard.
+- Inspect top containers via `docker stats`; enforce limits in compose file if missing.
+- Consider increasing Prometheus retention prudently or enabling recording rules to reduce query pressure.
+
+## Prometheus Scrape Failures
+- Check target status in Prometheus UI `/targets`.
+- Confirm exporters reachable on backend network; inspect firewall rules when scraping remote Proxmox hosts.
+- Validate certificates if switching to HTTPS endpoints.
+
+## Alert Not Firing
+- Ensure Alertmanager is reachable; check `/status` for silences.
+- Confirm rule expression using Prometheus expression browser.
+- Verify alert severity labels match Alertmanager route expectations.
+
+## Dashboard Not Loading
+- Confirm Grafana container health; restart if SQLite/bolt DB locked.
+- Validate datasources provisioning in `datasources.yml` and connectivity to Prometheus/Loki.
+- Clear browser cache or rotate admin password to re-authenticate.
+
+## Logs Not Appearing
+- Verify Promtail is reading correct paths and `positions.yaml` is writable.
+- Inspect Loki ingester metrics for rejection due to old timestamps or label cardinality.
+- Run sample query `count_over_time({job="varlogs"}[5m])` to ensure streams arrive.
+
+## Container Restart Loops
+- `docker inspect` health checks for failing commands.
+- Review cAdvisor metrics for CPU/memory pressure causing OOM kills.
+- Roll back to previous image or disable strict health check temporarily while debugging.

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/container-monitoring.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/container-monitoring.json
@@ -1,0 +1,19 @@
+{
+  "title": "Container Monitoring",
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {"name": "container", "type": "query", "datasource": "Prometheus", "query": "label_values(container_memory_usage_bytes, container)", "refresh": 2}
+    ]
+  },
+  "panels": [
+    {"type": "stat", "title": "Running Containers", "gridPos": {"x":0,"y":0,"w":6,"h":3}, "targets": [{"expr": "count(container_last_seen)"}]},
+    {"type": "stat", "title": "Restarting Containers", "gridPos": {"x":6,"y":0,"w":6,"h":3}, "targets": [{"expr": "count_over_time((changes(container_last_seen[15m])>0)[15m])"}]},
+    {"type": "timeseries", "title": "CPU Usage", "gridPos": {"x":0,"y":3,"w":12,"h":6}, "targets": [{"expr": "rate(container_cpu_usage_seconds_total{container=~'$container'}[5m])"}]},
+    {"type": "timeseries", "title": "Memory Usage", "gridPos": {"x":12,"y":3,"w":12,"h":6}, "targets": [{"expr": "container_memory_usage_bytes{container=~'$container'}"}]},
+    {"type": "timeseries", "title": "Network I/O", "gridPos": {"x":0,"y":9,"w":12,"h":6}, "targets": [{"expr": "rate(container_network_receive_bytes_total{container=~'$container'}[5m])"}, {"expr": "rate(container_network_transmit_bytes_total{container=~'$container'}[5m])"}]},
+    {"type": "gauge", "title": "Filesystem Usage", "gridPos": {"x":12,"y":9,"w":12,"h":6}, "targets": [{"expr": "container_fs_usage_bytes{container=~'$container'}"}]},
+    {"type": "table", "title": "Restart Count", "gridPos": {"x":0,"y":15,"w":24,"h":6}, "targets": [{"expr": "topk(10, changes(container_last_seen[1h]))"}]}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/host-details.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/host-details.json
@@ -1,0 +1,36 @@
+{
+  "title": "Host Details",
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(node_uname_info, instance)",
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {"type": "timeseries", "title": "CPU per Core", "gridPos": {"x":0,"y":0,"w":12,"h":5},
+     "targets": [{"expr": "rate(node_cpu_seconds_total{mode!='idle',instance=~'$instance'}[5m])"}]},
+    {"type": "timeseries", "title": "Memory Breakdown", "gridPos": {"x":0,"y":5,"w":12,"h":5},
+     "targets": [
+        {"expr": "node_memory_MemAvailable_bytes{instance=~'$instance'}"},
+        {"expr": "node_memory_Buffers_bytes{instance=~'$instance'}"},
+        {"expr": "node_memory_Cached_bytes{instance=~'$instance'}"}
+     ]},
+    {"type": "timeseries", "title": "Disk IO", "gridPos": {"x":0,"y":10,"w":12,"h":5},
+     "targets": [{"expr": "rate(node_disk_reads_completed_total{instance=~'$instance'}[5m])"}, {"expr": "rate(node_disk_writes_completed_total{instance=~'$instance'}[5m])"}]},
+    {"type": "timeseries", "title": "Network Traffic", "gridPos": {"x":12,"y":0,"w":12,"h":5},
+     "targets": [{"expr": "sum by(device)(rate(node_network_receive_bytes_total{instance=~'$instance'}[5m]))"}, {"expr": "sum by(device)(rate(node_network_transmit_bytes_total{instance=~'$instance'}[5m]))"}]},
+    {"type": "gauge", "title": "Filesystem Usage", "gridPos": {"x":12,"y":5,"w":12,"h":5},
+     "targets": [{"expr": "(node_filesystem_size_bytes{instance=~'$instance',fstype!~'tmpfs|overlay'} - node_filesystem_free_bytes{instance=~'$instance',fstype!~'tmpfs|overlay'}) / node_filesystem_size_bytes{instance=~'$instance',fstype!~'tmpfs|overlay'}"}]},
+    {"type": "stat", "title": "Load Average", "gridPos": {"x":12,"y":10,"w":12,"h":5},
+     "targets": [{"expr": "node_load1{instance=~'$instance'}"}, {"expr": "node_load5{instance=~'$instance'}"}, {"expr": "node_load15{instance=~'$instance'}"}]},
+    {"type": "table", "title": "Top Processes", "gridPos": {"x":0,"y":15,"w":24,"h":6},
+     "targets": [{"expr": "topk(10, rate(container_cpu_usage_seconds_total{instance=~'$instance'}[5m]))"}]}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/infrastructure-overview.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,80 @@
+{
+  "title": "Infrastructure Overview",
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "environment",
+        "type": "custom",
+        "query": "homelab,staging,prod",
+        "label": "Environment",
+        "current": {"text": "homelab", "value": "homelab"}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Hosts Monitored",
+      "gridPos": {"x":0,"y":0,"w":4,"h":3},
+      "targets": [
+        {"expr": "count(count(node_uname_info) by (instance))", "refId": "A"}
+      ],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": ""}}
+    },
+    {
+      "type": "gauge",
+      "title": "Uptime Percentage",
+      "gridPos": {"x":4,"y":0,"w":4,"h":3},
+      "fieldConfig": {"defaults": {"thresholds": {"mode": "percentage", "steps": [{"color": "red", "value": 0},{"color": "yellow", "value": 90},{"color": "green", "value": 99}]}}, "overrides": []},
+      "targets": [{"expr": "avg_over_time(node_time_seconds[6h]) / (6*3600) * 100"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Average CPU Usage",
+      "gridPos": {"x":0,"y":3,"w":8,"h":5},
+      "targets": [{"expr": "avg by(instance) (rate(node_cpu_seconds_total{mode!='idle'}[5m]))"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Average Memory Usage",
+      "gridPos": {"x":8,"y":3,"w":8,"h":5},
+      "targets": [{"expr": "avg by(instance)((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)"}]
+    },
+    {
+      "type": "bargauge",
+      "title": "Top CPU Hosts",
+      "gridPos": {"x":0,"y":8,"w":8,"h":5},
+      "options": {"orientation": "horizontal"},
+      "targets": [{"expr": "topk(5, rate(node_cpu_seconds_total{mode!='idle'}[5m]))"}]
+    },
+    {
+      "type": "bargauge",
+      "title": "Top Memory Hosts",
+      "gridPos": {"x":8,"y":8,"w":8,"h":5},
+      "targets": [{"expr": "topk(5, (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)"}]
+    },
+    {
+      "type": "table",
+      "title": "Disk Usage by Host",
+      "gridPos": {"x":0,"y":13,"w":8,"h":6},
+      "targets": [{"expr": "node_filesystem_avail_bytes{fstype!~'tmpfs|overlay'} / node_filesystem_size_bytes{fstype!~'tmpfs|overlay'}"}]
+    },
+    {
+      "type": "bargauge",
+      "title": "Network In/Out",
+      "gridPos": {"x":8,"y":13,"w":8,"h":6},
+      "targets": [
+        {"expr": "sum by(instance)(rate(node_network_receive_bytes_total[5m]))"},
+        {"expr": "sum by(instance)(rate(node_network_transmit_bytes_total[5m]))"}
+      ]
+    },
+    {
+      "type": "state-timeline",
+      "title": "Alert Status",
+      "gridPos": {"x":0,"y":19,"w":16,"h":5},
+      "targets": [{"expr": "ALERTS"}]
+    }
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/logs-explorer.json
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/dashboards/logs-explorer.json
@@ -1,0 +1,17 @@
+{
+  "title": "Logs Explorer",
+  "time": {"from": "now-6h", "to": "now"},
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {"name": "container_name", "type": "query", "datasource": "Loki", "query": "label_values({job=\"varlogs\"}, container)", "refresh": 2},
+      {"name": "log_level", "type": "custom", "query": "info,warning,error,critical", "current": {"text": "error", "value": "error"}}
+    ]
+  },
+  "panels": [
+    {"type": "logs", "title": "Live Logs", "gridPos": {"x":0,"y":0,"w":24,"h":8}, "options": {"showTime": true}, "targets": [{"query": "{job='varlogs',container=~'$container_name'} |~ ''"}]},
+    {"type": "timeseries", "title": "Log Volume", "gridPos": {"x":0,"y":8,"w":12,"h":6}, "targets": [{"queryType": "range", "refId": "A", "expr": "sum by(container)(count_over_time({job='varlogs',container=~'$container_name'}[$__interval]))"}]},
+    {"type": "timeseries", "title": "Error Rate", "gridPos": {"x":12,"y":8,"w":12,"h":6}, "targets": [{"queryType": "range", "expr": "sum by(container)(count_over_time({job='varlogs',level=~'$log_level',container=~'$container_name'}[$__interval]))"}]},
+    {"type": "table", "title": "Recent Errors", "gridPos": {"x":0,"y":14,"w":24,"h":6}, "targets": [{"query": "{job='varlogs',level=~'$log_level'} | line_format '{{.level}} - {{.message}}'"}]}
+  ]
+}

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/dashboards/dashboards.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: 'Default Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/datasources/datasources.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/projects/01-sde-devops/PRJ-SDE-002/loki/loki-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/loki/loki-config.yml
@@ -1,0 +1,59 @@
+# Loki single-node configuration for filesystem storage with boltdb-shipper indexer.
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+ingester:
+  chunk_idle_period: 3m
+  max_chunk_age: 1h
+  chunk_target_size: 1048576
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/cache
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  retention_enabled: true
+  compaction_interval: 10m
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 2
+  delete_request_store: filesystem
+  retention:
+    - action: delete
+      selector: '{job="varlogs"}'
+      age: 168h
+
+limits_config:
+  max_streams_per_user: 10000
+  max_query_lookback: 720h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+
+chunk_store_config:
+  max_look_back_period: 0
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 168h

--- a/projects/01-sde-devops/PRJ-SDE-002/prometheus/alerts/rules.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/prometheus/alerts/rules.yml
@@ -1,0 +1,200 @@
+# Alert rules organized by domain. Thresholds are conservative to minimize alert fatigue.
+groups:
+  - name: infrastructure
+    rules:
+      - alert: InstanceDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Instance {{ $labels.instance }} is unreachable"
+          description: "Prometheus target {{ $labels.instance }} has been down for more than 2 minutes. Current value: {{ $value }}"
+          runbook: |
+            1. Ping the instance to confirm connectivity.
+            2. Check node_exporter or service process status.
+            3. Validate firewall rules did not change.
+            4. Review recent deployments that may have impacted availability.
+
+      - alert: HighCPUUsage
+        expr: avg by(instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m])) > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CPU usage high on {{ $labels.instance }}"
+          description: "CPU utilization over 80% for 5 minutes. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Run top/htop to identify heavy processes.
+            2. Validate scheduled jobs or backups are not overlapping.
+            3. Consider scaling workloads or moving noisy containers.
+      - alert: HighCPUUsageCritical
+        expr: avg by(instance) (rate(node_cpu_seconds_total{mode!="idle"}[2m])) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CPU saturation on {{ $labels.instance }}"
+          description: "CPU utilization over 95% sustained. Immediate impact to latency expected. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Identify runaway processes; restart if safe.
+            2. Shift load to alternate host if in cluster.
+            3. Increase CPU allocation or add cores if persistent.
+
+      - alert: HighMemoryUsage
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Memory pressure on {{ $labels.instance }}"
+          description: "Memory usage above 85% for 5 minutes. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Check docker stats for container memory hotspots.
+            2. Verify swap usage; adjust swappiness if needed.
+            3. Increase memory or optimize applications.
+      - alert: HighMemoryUsageCritical
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Memory exhaustion on {{ $labels.instance }}"
+          description: "Memory above 95% triggers risk of OOM kills. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Capture /proc/meminfo and dmesg for context.
+            2. Reboot only if services cannot be recovered gracefully.
+            3. Evaluate memory limits in Compose/Kubernetes manifests.
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_free_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) < 0.15
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk space low on {{ $labels.instance }}"
+          description: "Filesystem {{ $labels.mountpoint }} below 15% free. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Clear stale Docker images/volumes.
+            2. Archive logs to external storage.
+            3. Expand disk or prune retention in Prometheus/Loki.
+      - alert: DiskSpaceCritical
+        expr: (node_filesystem_free_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) < 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk critically low on {{ $labels.instance }}"
+          description: "Filesystem {{ $labels.mountpoint }} below 5% free. Services may fail. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Immediately free space or move workloads.
+            2. Pause noisy log sources.
+            3. Consider emergency storage expansion.
+
+      - alert: DiskWillFillSoon
+        expr: predict_linear(node_filesystem_free_bytes{fstype!~"tmpfs|overlay"}[6h], 24*3600) < 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk projected to fill in <24h on {{ $labels.instance }}"
+          description: "Trend indicates {{ $labels.mountpoint }} will be full within 24 hours. Current free bytes {{ $value | humanize }}"
+          runbook: |
+            1. Check log growth and rotate/compress aggressively.
+            2. Shorten retention in Loki/Prometheus.
+            3. Plan capacity increase before threshold.
+
+  - name: containers
+    rules:
+      - alert: ContainerHighCPU
+        expr: rate(container_cpu_usage_seconds_total{image!=""}[5m]) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.container_label_com_docker_swarm_service_name | default $labels.container }} high CPU"
+          description: "Container consuming >90% CPU limit for 5m. Value {{ $value }} cores"
+          runbook: |
+            1. Inspect container logs for tight loops.
+            2. Scale service replicas or adjust CPU limits.
+            3. Use cAdvisor UI to review per-core utilization.
+
+      - alert: ContainerHighMemory
+        expr: container_memory_working_set_bytes{image!=""} / on(container_label_com_docker_swarm_service_name,container) container_spec_memory_limit_bytes{image!=""} > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.container }} high memory"
+          description: "Working set above 90% of limit. Current value {{ $value | humanizePercentage }}"
+          runbook: |
+            1. Confirm limits are set; if unlimited, set guardrails.
+            2. Profile memory usage or restart leaking services.
+            3. Add instrumentation for churn detection.
+
+      - alert: ContainerRestarting
+        expr: changes(container_last_seen{image!=""}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.container }} restarting frequently"
+          description: "More than 3 restarts detected in 15 minutes. Likely crashloop. Current restarts {{ $value }}"
+          runbook: |
+            1. Inspect docker logs for crash reason.
+            2. Validate health checks and readiness probes.
+            3. Roll back to stable image if regression.
+
+  - name: monitoring
+    rules:
+      - alert: PrometheusDown
+        expr: up{job="prometheus"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus unreachable"
+          description: "Self-scrape failed for more than 1 minute. Current value {{ $value }}"
+          runbook: |
+            1. Check docker service status for prometheus container.
+            2. Validate volume mounts and config reload results.
+            3. Review host resource pressure.
+
+      - alert: PrometheusTSDBReloadsFailing
+        expr: prometheus_tsdb_reloads_failures_total - prometheus_tsdb_reloads_failures_total offset 5m > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus TSDB reloads failing"
+          description: "Config reload or rule file reload failed. Check logs."
+          runbook: |
+            1. Inspect Prometheus logs for parse errors.
+            2. Validate syntax with promtool before reload.
+            3. Revert last configuration change.
+
+      - alert: PrometheusRuleEvaluationFailures
+        expr: increase(prometheus_rule_evaluation_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus rule evaluation failing"
+          description: "One or more rules failed evaluation in last 5m."
+          runbook: |
+            1. Identify failing rule in UI or logs.
+            2. Correct metric names or label selectors.
+            3. Deploy fixed rule set and reload.
+
+      - alert: GrafanaDown
+        expr: up{job="grafana"} == 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Grafana not responding"
+          description: "Grafana metrics endpoint failed for 2 minutes."
+          runbook: |
+            1. Restart grafana container and check logs.
+            2. Validate datasource connectivity to Prometheus/Loki.
+            3. Confirm disk space for SQLite/bolt DB.

--- a/projects/01-sde-devops/PRJ-SDE-002/prometheus/prometheus.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/prometheus/prometheus.yml
@@ -1,0 +1,74 @@
+# Prometheus main configuration
+# Purpose: scrape metrics from monitoring stack, Proxmox nodes, and exporters with predictable 15s resolution.
+# External labels allow downstream federation or recording of environment context.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    environment: "homelab"
+    cluster: "proxmox-cluster"
+
+# Rule files are grouped by domain to simplify tuning and change control.
+rule_files:
+  - /etc/prometheus/alerts/rules.yml
+
+# Alertmanager configuration points at in-stack instance; URL is internal-only on backend network.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+scrape_configs:
+  # Self-monitoring job to ensure Prometheus health and surface scrape/TSDB metrics.
+  - job_name: 'prometheus'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:9090']
+    # Keeping default /metrics path; no relabeling required.
+
+  # Node Exporter collects host metrics including CPU, memory, filesystem, and network statistics.
+  - job_name: 'node-exporter'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['node-exporter:9100']
+    # Additional targets can be added for remote hosts by appending to targets list or using file_sd_configs.
+
+  # cAdvisor exposes container-level CPU/memory/network stats; invaluable for Docker troubleshooting.
+  - job_name: 'cadvisor'
+    scrape_interval: 30s  # Slightly slower to reduce load; container metrics change less frequently
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  # Grafana exposes internal metrics on /metrics; helps troubleshoot dashboard performance or plugin issues.
+  - job_name: 'grafana'
+    metrics_path: /metrics
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['grafana:3000']
+
+  # Loki metrics reveal ingestion/backpressure patterns; scrape slightly slower due to lower volatility.
+  - job_name: 'loki'
+    metrics_path: /metrics
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['loki:3100']
+
+  # Proxmox VE monitoring; replace sample targets with real homelab host IPs.
+  # For secured deployments, enable HTTPS and provide basic_auth or bearer token.
+  - job_name: 'proxmox'
+    scheme: http
+    scrape_interval: 30s
+    static_configs:
+      - targets:
+          - '192.168.40.11:9100'  # Example: Proxmox host 1 running node_exporter
+          - '192.168.40.12:9100'  # Example: Proxmox host 2 running node_exporter
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: proxmox_host
+        regex: '([^:]+):.*'
+        replacement: '$1'
+    # To add authentication:
+    # basic_auth:
+    #   username: ${PROMETHEUS_PROXMOX_USER}
+    #   password: ${PROMETHEUS_PROXMOX_PASSWORD}
+

--- a/projects/01-sde-devops/PRJ-SDE-002/promtail/promtail-config.yml
+++ b/projects/01-sde-devops/PRJ-SDE-002/promtail/promtail-config.yml
@@ -1,0 +1,63 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 102400
+
+scrape_configs:
+  - job_name: docker-logs
+    static_configs:
+      - targets: ['localhost']
+        labels:
+          job: varlogs
+          host: ${HOSTNAME}
+          environment: ${ENVIRONMENT:-homelab}
+          __path__: /var/lib/docker/containers/*/*-json.log
+    pipeline_stages:
+      - json:
+          expressions:
+            log: log
+            stream: stream
+            container_name: container_name
+      - labels:
+          container: container_name
+      - multiline:
+          firstline: '^{'
+          max_wait_time: 3s
+      - drop:
+          source: container
+          expression: 'promtail|loki'
+
+  - job_name: system-logs
+    static_configs:
+      - targets: ['localhost']
+        labels:
+          job: varlogs
+          host: ${HOSTNAME}
+          environment: ${ENVIRONMENT:-homelab}
+          __path__: /var/log/*.log
+
+  - job_name: journal
+    journal:
+      json: false
+      max_age: 12h
+      path: /var/log/journal
+      labels:
+        job: systemd-journal
+        host: ${HOSTNAME}
+        environment: ${ENVIRONMENT:-homelab}
+    pipeline_stages:
+      - match:
+          selector: '{SYSLOG_IDENTIFIER="sshd"}'
+          stages:
+            - regex:
+                expression: 'Failed password for (?P<user>.*) from (?P<source>.*) port (?P<port>\d+)'
+            - labels:
+                source_ip: source
+                user: user

--- a/projects/01-sde-devops/PRJ-SDE-002/scripts/deploy.sh
+++ b/projects/01-sde-devops/PRJ-SDE-002/scripts/deploy.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Monitoring Stack Deployment Script
+# Purpose: Automated deployment with validation and rollback capability
+# Usage: ./deploy.sh [start|stop|restart|validate|backup|restore]
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+ENV_FILE="${PROJECT_ROOT}/.env"
+BACKUP_DIR="${PROJECT_ROOT}/backups"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+check_prerequisites() {
+  command -v docker >/dev/null 2>&1 || { log_error "Docker not installed"; exit 1; }
+  command -v docker-compose >/dev/null 2>&1 || { log_error "docker-compose plugin required"; exit 1; }
+  [[ -f "$ENV_FILE" ]] || { log_error ".env file missing"; exit 1; }
+  log_info "Prerequisites validated"
+}
+
+validate_config() {
+  log_info "Validating Prometheus configuration"
+  docker run --rm -v "${PROJECT_ROOT}/prometheus:/etc/prometheus" prom/prometheus:v2.48.0 promtool check config /etc/prometheus/prometheus.yml
+  log_info "Validating alert rules"
+  docker run --rm -v "${PROJECT_ROOT}/prometheus:/etc/prometheus" prom/prometheus:v2.48.0 promtool check rules /etc/prometheus/alerts/rules.yml
+  log_info "Validating Alertmanager configuration"
+  docker run --rm -v "${PROJECT_ROOT}/alertmanager:/etc/alertmanager" prom/alertmanager:v0.26.0 amtool check-config /etc/alertmanager/alertmanager.yml
+  log_info "Validating Grafana dashboards JSON"
+  jq empty ${PROJECT_ROOT}/grafana/dashboards/*.json
+}
+
+backup_data() {
+  mkdir -p "$BACKUP_DIR"
+  TS=$(date +%Y%m%d-%H%M%S)
+  log_info "Backing up volumes"
+  docker run --rm -v prometheus_data:/data -v "$BACKUP_DIR":/backup alpine tar czf /backup/prometheus-${TS}.tgz -C /data .
+  docker run --rm -v grafana_data:/data -v "$BACKUP_DIR":/backup alpine tar czf /backup/grafana-${TS}.tgz -C /data .
+  docker run --rm -v loki_data:/data -v "$BACKUP_DIR":/backup alpine tar czf /backup/loki-${TS}.tgz -C /data .
+  docker run --rm -v alertmanager_data:/data -v "$BACKUP_DIR":/backup alpine tar czf /backup/alertmanager-${TS}.tgz -C /data .
+  log_info "Backups stored in ${BACKUP_DIR}"
+}
+
+restore_data() {
+  ARCHIVE=$1
+  [[ -f "$ARCHIVE" ]] || { log_error "Archive $ARCHIVE not found"; exit 1; }
+  log_warn "Restoring from ${ARCHIVE}; services will be stopped"
+  docker compose -f "$COMPOSE_FILE" down
+  docker run --rm -v prometheus_data:/data -v "$ARCHIVE":/backup.tgz alpine sh -c "rm -rf /data/* && tar xzf /backup.tgz -C /data"
+  log_info "Restore complete"
+}
+
+deploy_stack() {
+  check_prerequisites
+  validate_config
+  log_info "Pulling images"
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
+  log_info "Starting stack"
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
+  log_info "Waiting for health checks"
+  sleep 20
+  docker compose -f "$COMPOSE_FILE" ps
+}
+
+stop_stack() {
+  log_info "Stopping stack"
+  docker compose -f "$COMPOSE_FILE" down
+}
+
+restart_stack() {
+  stop_stack
+  deploy_stack
+}
+
+case "${1:-}" in
+  start)
+    deploy_stack;;
+  stop)
+    stop_stack;;
+  restart)
+    restart_stack;;
+  validate)
+    check_prerequisites
+    validate_config;;
+  backup)
+    backup_data;;
+  restore)
+    restore_data "${2:-}";;
+  *)
+    echo "Usage: $0 [start|stop|restart|validate|backup|restore]"
+    exit 1;;
+esac

--- a/projects/01-sde-devops/PRJ-SDE-002/scripts/health-check.sh
+++ b/projects/01-sde-devops/PRJ-SDE-002/scripts/health-check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+check_endpoint() {
+  local name=$1
+  local url=$2
+  echo "Checking ${name} at ${url}" && curl -sf "${url}" >/dev/null
+}
+
+check_prometheus_query() {
+  local query=$1
+  curl -sf "http://localhost:9090/api/v1/query?query=${query}" | jq -e '.status == "success"' >/dev/null
+}
+
+check_loki() {
+  curl -sf -G --data-urlencode "query={job='varlogs'}" "http://localhost:3100/loki/api/v1/query" >/dev/null
+}
+
+send_test_alert() {
+  echo "Firing test alert via amtool"
+  docker run --rm --network host -v "${PROJECT_ROOT}/alertmanager:/etc/alertmanager" prom/alertmanager:v0.26.0 \
+    amtool --alertmanager.url=http://localhost:9093 alert add TestAlert instance=test severity=warning --startsAt=$(date --iso-8601=seconds)
+}
+
+check_endpoint "Prometheus" "http://localhost:9090/-/healthy"
+check_endpoint "Grafana" "http://localhost:3000/api/health"
+check_endpoint "Loki" "http://localhost:3100/ready"
+check_endpoint "Alertmanager" "http://localhost:9093/-/ready"
+
+check_prometheus_query "up"
+check_loki
+send_test_alert
+
+echo "Health check completed"

--- a/projects/06-homelab/PRJ-HOME-001/docs/NETWORK-ARCHITECTURE.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/NETWORK-ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# Homelab Network Architecture
+
+## Executive Summary
+- **Scale**: 6 VLANs, 1 core router, 1 distribution switch, 3 wireless APs, and 4 Proxmox/TrueNAS servers.
+- **Design Principles**: Security zones with strict inter-VLAN ACLs, PoE budget tracking, and redundant storage paths. Segmentation contains IoT and guest traffic away from trusted assets.
+- **Technology Stack**: UniFi Dream Machine Pro gateway/controller, UniFi Switch 24 PoE, UniFi 6 access points, and Proxmox/TrueNAS servers.
+- **Growth Plan**: Spare trunk/PoE capacity allows additional AP and cameras; subnets sized /24 with reserved static ranges.
+
+## Physical Infrastructure
+
+### Internet Edge
+- **ISP**: Comcast 1 Gbps/35 Mbps DOCSIS connection with Arris SB8200 modem.
+- **WAN IP**: Dynamic DHCP; DDNS enabled on UDMP for remote VPN.
+- **Resilience**: Surge protector and UPS-backed rack; failover supported via UDMP dual WAN if secondary link added.
+
+### UniFi Dream Machine Pro (UDMP)
+- **Role**: Router, firewall, UniFi controller, UniFi Protect NVR.
+- **Specs**: 1 Gbps WAN, 8x1G LAN (1x SFP+), IDS/IPS capable.
+- **Management IP**: 192.168.1.1
+- **Config Highlights**: VLAN interfaces for all segments, DPI enabled, IDS/IPS balanced profile, DHCP services per subnet.
+
+### UniFi Switch 24 PoE (Primary Distribution)
+- **Location**: Rack 15U; management IP 192.168.1.10.
+- **Specs**: 24x1G, 16 PoE+ ports, 2 SFP uplinks, 95W PoE budget.
+- **Port Plan**: Ports 1-8 Trusted access, 9-12 Servers, 13-16 AP trunks, 17-20 Cameras, 21 IoT, 22 Printer, 23 uplink to UDMP, 24 spare trunk.
+- **PoE Devices**: Three APs plus four cameras; 60W used of 95W budget.
+
+### Wireless Infrastructure
+- **AP-Office (U6-Pro)**: Office ceiling, VLANs 1/10/20/30, management IP 192.168.1.20, channels 149 (5GHz) and auto 2.4GHz.
+- **AP-LivingRoom (U6-Pro)**: Living room ceiling, trunk port 14, balanced power, 5GHz channel 36.
+- **AP-Bedroom (U6-Lite)**: Bedroom, trunk port 15, 5GHz channel 149, low power for minimal bleed.
+
+### Servers
+- **Proxmox-01/02** on VLAN 40 with static IPs 192.168.40.10/11.
+- **TrueNAS** on VLAN 40 static 192.168.40.20 for NFS/SMB storage.
+
+## Logical Network Architecture
+
+### VLAN Table
+| VLAN ID | VLAN Name | Subnet | Gateway | DHCP Range | Purpose | Security Zone | Devices |
+|---------|-----------|--------|---------|------------|---------|---------------|---------|
+| 1 | Management | 192.168.1.0/24 | 192.168.1.1 | .100-.199 | Network infrastructure management | Trusted-Admin | UDMP, Switches, APs |
+| 10 | Trusted | 192.168.10.0/24 | 192.168.10.1 | .100-.249 | Primary user devices | Trusted | Workstations, phones, tablets |
+| 20 | IoT | 192.168.20.0/24 | 192.168.20.1 | .100-.249 | Smart home devices | Restricted | Speakers, lights, sensors |
+| 30 | Guest | 192.168.30.0/24 | 192.168.30.1 | .100-.249 | Visitor devices | Isolated | Guest phones, tablets |
+| 40 | Servers | 192.168.40.0/24 | 192.168.40.1 | .10-.99 | Infrastructure servers | Trusted-Services | Proxmox, NAS |
+| 50 | Cameras | 192.168.50.0/24 | 192.168.50.1 | .100-.249 | Security cameras | Isolated | IP cameras |
+
+### VLAN 10: Trusted Network
+- **Purpose**: Daily-use devices needing broad access.
+- **Security**: Inbound limited to established traffic; SSH/HTTPS allowed from Management; outbound unrestricted except IoT/Guest/Cameras denied.
+- **DHCP**: 192.168.10.100-249, 24h lease, DNS 192.168.1.1/1.1.1.1/8.8.8.8.
+- **Static IPs**: 192.168.10.10 workstation-01, 10.11 laptop-01, 10.50 printer-office.
+- **Firewall**: Allow HTTP/S + SMB to Servers, SSH to Management, deny rest inbound.
+- **WiFi**: SSID HomeNetwork-5G (VLAN 10) WPA3-Personal.
+
+### VLAN 20: IoT
+- **Purpose**: Contain smart devices with cloud dependencies.
+- **Security**: Inbound only established/mDNS/controlled app ports from Trusted; outbound HTTP/HTTPS/DNS/NTP; RFC1918 blocked.
+- **DHCP**: 192.168.20.100-249, 12h lease.
+- **Firewall**: Deny lateral movement to Trusted/Guest/Servers; allow minimal control from Trusted via Home Assistant.
+
+### VLAN 30: Guest
+- **Purpose**: Isolated internet-only access for visitors.
+- **Security**: Client isolation enabled; outbound limited to HTTP/HTTPS/DNS; RFC1918 blocked.
+- **DHCP**: 192.168.30.100-249.
+- **Firewall**: Deny all inter-VLAN; allow internet only.
+
+### VLAN 40: Servers
+- **Purpose**: Proxmox, TrueNAS, and monitoring stack.
+- **Security**: SSH from Management/Trusted, HTTP/S/SMB/NFS to Trusted, internet allowed for updates.
+- **DHCP/Static**: Mostly static assignments .10-.30; DHCP for test VMs .50-.99.
+- **Firewall**: Deny access to Guest/IoT/Cameras.
+
+### VLAN 50: Cameras
+- **Purpose**: Video surveillance, isolated from internet.
+- **Security**: Allow RTSP/HTTP from Servers VLAN only; DNS/NTP allowed; internet denied.
+- **Firewall**: Enforce one-way access to NVR; block all else.
+
+### Inter-VLAN Matrix
+| Source VLAN | Destination VLAN | Allowed Services | Business Justification | Rule Priority |
+|-------------|------------------|------------------|------------------------|---------------|
+| Trusted | Internet | All | Users need browsing/API access | 100 |
+| Trusted | Servers | HTTP/S, SSH, SMB, NFS | Access infrastructure services | 200 |
+| Trusted | Management | SSH, HTTPS | Admin access to gear | 300 |
+| IoT | Internet | HTTP/S | Cloud control | 400 |
+| Guest | Internet | HTTP/S | Guest internet | 500 |
+| All | IoT | Deny | Prevent lateral movement | 1000 |
+| All | Guest | Deny | Enforce isolation | 1000 |
+| Cameras | Servers | RTSP/HTTP | Stream to NVR | 250 |
+
+## Diagram Guidance
+See `diagrams/network-topology-description.md` for rendering instructions covering physical and logical layouts, color keys, and annotations.
+
+## Monitoring & Alerting
+- UDMP DPI and IDS/IPS enabled with automatic signature updates.
+- NetFlow exports to monitoring stack; alerts on new device join, WAN failover, and PoE overload.
+
+## Maintenance Notes
+- Config backups exported nightly from UDMP to TrueNAS via SCP.
+- Quarterly review of firewall rules and DHCP scopes; monthly firmware checks for UDMP and switch/APs.

--- a/projects/06-homelab/PRJ-HOME-001/docs/SECURITY-POLICY.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/SECURITY-POLICY.md
@@ -1,0 +1,42 @@
+# Network Security Policies
+
+## Firewall Philosophy
+- Default deny between VLANs; explicit allows documented in inter-VLAN matrix.
+- Defense in depth: WAN drop inbound, IDS/IPS on UDMP, VLAN isolation, endpoint firewalls.
+- Zero trust posture for IoT/Guest/Cameras; only required flows permitted.
+
+## WAN Rules
+- Inbound: drop all except established/related and invalid drop; VPN adds explicit rule when enabled.
+- Outbound: allow HTTP/S, DNS, NTP; block SMB and high-risk ports (23,135-139,445,3389) with logging.
+
+## Inter-VLAN Rules (Highlights)
+- **Management** inbound: SSH/HTTPS from Trusted only; deny all others; outbound firmware updates allowed.
+- **Trusted** outbound: allow to Servers/Management; deny to IoT/Guest/Cameras except via specific services.
+- **IoT** outbound: HTTP/S + DNS/NTP; RFC1918 blocked; inbound only mDNS/control ports from Trusted.
+- **Servers** inbound: SSH from Management/Trusted; HTTP/S/SMB/NFS from Trusted; deny IoT/Guest/Cameras.
+- **Guest**: Internet only; client isolation; RFC1918 blocked.
+- **Cameras**: Allow RTSP/HTTP to Servers; deny internet and other VLANs.
+
+## IDS/IPS
+- Categories enabled: malware, botnet, phishing, exploit, lateral movement; port scan detection threshold enabled.
+- WAN interface in block mode; LAN in alert mode to reduce false positives.
+- Automatic signature updates daily at 03:00; weekly review of alerts and tuning.
+
+## DNS Filtering
+- UDMP forwards to OpenDNS (208.67.222.222/220.220); firewall blocks external DNS to prevent bypass; DoH/DoT destinations blocked.
+- Guest VLAN uses FamilyShield for family-friendly filtering.
+
+## Access Controls
+- UniFi admin accounts require MFA and 20+ character passwords; session timeout 30 minutes.
+- SSH to infrastructure uses key-based auth; passwords disabled where possible.
+- WiFi passphrases rotated: Guest monthly, IoT quarterly, Trusted annually or upon staff change.
+
+## Incident Response
+- Severity levels: informational (logged), warning (email within 1h), critical (push+SMS immediate).
+- Containment: isolate device by switch port shutdown or VLAN ACL; preserve logs; rebuild compromised hosts from backup.
+- Recovery: restore UDMP config from nightly backup; retest firewall rules; document lessons learned in change log.
+
+## Compliance & Audit
+- Firewall and IDS logs retained 30 days on UDMP; archived to TrueNAS for 1 year.
+- Quarterly security review covering firewall rules, VPN access, and password rotations.
+- Annual penetration test planned; results tracked in risk register.

--- a/projects/06-homelab/PRJ-HOME-001/docs/SWITCH-PORT-MAP.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/SWITCH-PORT-MAP.md
@@ -1,0 +1,65 @@
+# Switch Port Configuration Map
+
+## UniFi Switch 24 PoE - Primary Distribution Switch
+**Management IP**: 192.168.1.10  
+**Location**: Rack 15U  
+**Firmware**: 6.5.55
+
+### Port Configuration Table
+| Port | Connected Device | Device Location | VLAN Mode | VLAN ID(s) | PoE Status | Speed/Duplex | Port Profile | Notes |
+|------|------------------|-----------------|-----------|------------|------------|--------------|--------------|-------|
+| 1 | Workstation-01 | Office Desk 1 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Main development machine |
+| 2 | Workstation-02 | Office Desk 2 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Secondary workstation |
+| 3 | Laptop Dock-01 | Office Desk 1 | Access | 10 | Disabled | 1G/Full | Trusted-Access | Thunderbolt dock |
+| 4-8 | Available | - | Access | 10 | Disabled | - | Trusted-Access | Reserved for expansion |
+| 9 | Proxmox-01 | Rack 10U | Access | 40 | Disabled | 1G/Full | Server-Access | Virtualization host |
+| 10 | Proxmox-02 | Rack 11U | Access | 40 | Disabled | 1G/Full | Server-Access | Virtualization host |
+| 11 | TrueNAS | Rack 12U | Access | 40 | Disabled | 1G/Full | Server-Access | Storage server |
+| 12 | Available | - | Access | 40 | Disabled | - | Server-Access | Reserved |
+| 13 | AP-Office | Office Ceiling | Trunk | 1,10,20,30 | Active (15.4W) | 1G/Full | AP-Trunk | Office AP |
+| 14 | AP-LivingRoom | Living Room | Trunk | 1,10,20,30 | Active (13.2W) | 1G/Full | AP-Trunk | Living room AP |
+| 15 | AP-Bedroom | Master Bedroom | Trunk | 1,10,20,30 | Active (14.1W) | 1G/Full | AP-Trunk | Bedroom AP |
+| 16 | Available | - | Trunk | All | Available | - | AP-Trunk | Spare for expansion |
+| 17 | Camera-Front | Front Door | Access | 50 | Active (4.2W) | 100M/Full | Camera-Access | Front door camera |
+| 18 | Camera-Back | Back Door | Access | 50 | Active (3.8W) | 100M/Full | Camera-Access | Back door camera |
+| 19 | Camera-Garage | Garage | Access | 50 | Active (4.5W) | 100M/Full | Camera-Access | Garage camera |
+| 20 | Camera-Driveway | Driveway | Access | 50 | Active (5.1W) | 100M/Full | Camera-Access | Driveway camera |
+| 21 | Smart Hub-01 | Office | Access | 20 | Disabled | 100M/Full | IoT-Access | Zigbee/Z-Wave hub |
+| 22 | Printer-Office | Office | Access | 10 | Disabled | 100M/Full | Trusted-Access | Printer |
+| 23 | UDMP Uplink | Rack 1U | Trunk | All | Disabled | 1G/Full | Uplink | Uplink to UDMP |
+| 24 | Available | - | Trunk | All | Disabled | - | General | Spare |
+
+### Port Profiles
+
+#### Trusted-Access Profile
+- Access port, native VLAN 10, storm control enabled, RSTP edge, no PoE.
+
+#### Server-Access Profile
+- Access VLAN 40, jumbo frames enabled, storm control 5%, RSTP edge.
+
+#### AP-Trunk Profile
+- Native VLAN 1, tagged 1/10/20/30, PoE+ high priority, storm control 20%, RSTP.
+
+#### Camera-Access Profile
+- Access VLAN 50, PoE 802.3af medium priority, storm control 10%, RSTP edge.
+
+### PoE Budget Summary
+- Total: 95W; used ~60W across APs and cameras; 35W available for growth.
+
+### Cable Runs
+| Port | Cable Type | Length | Run Path | Certification |
+|------|------------|--------|----------|---------------|
+| 1-8 | Cat6 | <15ft | Under desk | Patch |
+| 9-11 | Cat6 | <3ft | Rack patch | Patch |
+| 13 | Cat6 | 45ft | Ceiling conduit | Tested 1G |
+| 14 | Cat6 | 75ft | Ceiling/wall conduit | Tested 1G |
+| 15 | Cat6 | 60ft | Ceiling/wall conduit | Tested 1G |
+| 17-20 | Cat5e | 30-100ft | Outdoor conduit | Tested 100M |
+
+### Maintenance Log
+| Date | Action | Port(s) | Performed By | Notes |
+|------|--------|---------|--------------|-------|
+| 2024-01-15 | Initial configuration | All | Admin | Base deployment |
+| 2024-03-20 | Added Camera-Driveway | 20 | Admin | New camera |
+| 2024-06-10 | Replaced cable | 14 | Admin | Damaged run replaced |
+| 2024-11-10 | Enabled jumbo frames | 9-11 | Admin | Storage optimization |

--- a/projects/06-homelab/PRJ-HOME-001/docs/TROUBLESHOOTING.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/TROUBLESHOOTING.md
@@ -1,0 +1,42 @@
+# Network Troubleshooting Guide
+
+## Service Won't Start (UDMP/Controller)
+- Verify power and PoE budget; check UPS status.
+- Confirm management IP reachable (192.168.1.1); ping and SSH.
+- Reboot via local console if controller UI unresponsive.
+
+## High Memory Usage on UDMP
+- Review IDS/IPS signature set; switch to balanced profile.
+- Disable unused applications (Protect/Access) if not required.
+- Schedule weekly reboots during maintenance window if memory fragmentation persists.
+
+## Prometheus Scrape Failures (from monitoring stack)
+- Confirm firewall rules permit monitoring VLAN to reach exporters on VLAN 40.
+- Validate DNS resolving hostnames; fall back to static IPs.
+- Inspect exporter logs for auth or TLS failures.
+
+## Alert Not Firing
+- Ensure Alertmanager reachable from Prometheus; check routes and inhibition rules.
+- Validate rule expression in Prometheus expression browser; confirm labels match expected severity.
+
+## Dashboard Not Loading
+- Check Grafana container health and datasource connectivity; refresh provisioned dashboards.
+- Clear browser cache; verify time range not empty.
+
+## Logs Not Appearing in Loki
+- Verify Promtail reading `/var/log` and docker logs; ensure positions file writable.
+- Confirm firewall allows Promtail to Loki on backend network; check `loki-config.yml` retention for deletions.
+
+## Container Restart Loops
+- Inspect container logs for configuration errors; review health check definitions.
+- Reduce resource limits if OOM kills visible; increase retry delay in Docker health check.
+
+## Wireless Issues
+- Check client RSSI; adjust transmit power or channel per `WIRELESS-CONFIG.md` channel plan.
+- Ensure band steering not forcing legacy devices off network; temporarily disable if needed.
+- Validate VLAN tagging on AP trunk ports aligns with port profile.
+
+## WAN Outage
+- Confirm modem synced; check UDMP WAN status.
+- If failover available, ensure secondary interface enabled; otherwise tether via temporary hotspot on management laptop.
+

--- a/projects/06-homelab/PRJ-HOME-001/docs/WIRELESS-CONFIG.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/WIRELESS-CONFIG.md
@@ -1,0 +1,46 @@
+# Wireless Network Configuration
+
+## SSID Configuration
+
+### HomeNetwork-5G (Primary 5GHz Network)
+- Purpose: High-performance trusted network
+- VLAN: 10
+- Security: WPA3-Personal (SAE) with WPA2 fallback; PSK stored in password manager; PMF required
+- Radio: 5GHz only, 80MHz width, channel 149 on AP-Office/AP-Bedroom and 36 on AP-LivingRoom; transmit power auto (17-22 dBm)
+- Advanced: 802.11r fast roaming enabled, multicast enhancement on, DTIM 1, beacon 100ms, min RSSI -70 dBm
+- Clients: 15-20 avg; laptops/phones/tablets primary
+
+### IoT (2.4/5GHz)
+- VLAN: 20
+- Security: WPA2-Personal strong passphrase; PMF optional for legacy sensors
+- Band Steering: Enabled to keep higher capability devices on 5GHz when possible
+- Client Isolation: Disabled (allows hub control) but inter-VLAN restricted via firewall
+
+### Guest
+- VLAN: 30
+- Security: WPA2-Personal rotated monthly; client isolation enabled
+- Bandwidth Limit: 25/10 Mbps per client; DPI blocks P2P/torrents/adult content
+- Access: Internet only; RFC1918 blocked
+
+## Access Point Details
+
+### AP-Office (U6-Pro)
+- Location: Office ceiling; management IP 192.168.1.20; uplink Switch port 13 (PoE+)
+- 2.4GHz: Auto channel, 20MHz, low power 10 dBm, minimum rate 18 Mbps
+- 5GHz: Channel 149, 80MHz, high power 22 dBm; typical 8-12 clients; throughput 400-600 Mbps
+
+### AP-LivingRoom (U6-Pro)
+- Uplink port 14; 5GHz channel 36, 80MHz, medium power 18 dBm to avoid overlap with office
+- Serves living areas; typical 6-10 clients; coverage extends to kitchen
+
+### AP-Bedroom (U6-Lite)
+- Uplink port 15; 5GHz channel 149 low power 16 dBm to minimize interference; serves bedrooms/hallway
+
+## Channel Planning
+- Strategy: DFS/upper band preference to reduce congestion; stagger channels 36/149 for spatial reuse.
+- Survey Results (Oct 2024): Excellent coverage (-35 to -60 dBm) in living areas; marginal (-70 dBm) in garage; minimal non-WiFi interference.
+
+## Guest Network Policies
+- Isolation: Enabled; LAN blocked; RFC1918 addresses denied.
+- Filtering: OpenDNS FamilyShield DNS; DPI blocks P2P/gaming for bandwidth preservation.
+- Monitoring: Alerts on bandwidth >50 Mbps sustained and repeated auth failures.

--- a/projects/06-homelab/PRJ-HOME-001/docs/diagrams/network-topology-description.md
+++ b/projects/06-homelab/PRJ-HOME-001/docs/diagrams/network-topology-description.md
@@ -1,0 +1,28 @@
+# Physical Network Topology Diagram Specification
+
+## Layout Structure
+- Orientation left-to-right: Internet -> UDMP -> Switch -> APs/Servers -> End devices.
+- Group components by location: rack, office, living room, bedrooms.
+- Color scheme: red WAN, blue trunks, green access, orange fiber.
+
+## Components
+- ISP cloud labeled "Internet via Comcast 1G/35M" connected by red line to Arris SB8200 modem.
+- SB8200 to UDMP WAN (red); UDMP LAN1 trunk (blue) to Switch port 23.
+- Rack box containing UDMP (top), Switch (middle), Proxmox/TrueNAS servers (below).
+- Switch annotations: ports 1-8 Trusted access (green), 9-12 Servers (green/blue to servers), 13-16 AP trunks (blue), 17-20 Cameras (green), 21 IoT (green), 22 Printer (green), 24 spare trunk (blue dotted).
+- APs shown with WiFi callouts listing SSID to VLAN mappings.
+- End-device clusters by VLAN: Trusted (green box), IoT (yellow), Guest (red), Servers (blue in rack), Cameras (orange to NVR).
+- Include link speeds on lines (1G copper), PoE wattage on AP/camera links, distances for long runs.
+
+## Legend
+- Rectangles for physical devices, cloud for WAN, solid lines for wired, dashed for wireless, color-coded per link type.
+
+# Logical Network Architecture Diagram Specification
+
+## Layout
+- Top Internet cloud -> UDMP firewall/router -> VLAN clouds for Management, Trusted, IoT, Guest, Servers, Cameras.
+- Arrows showing allowed flows (solid) and denied (dashed with red X), labeled with allowed protocols.
+- UDMP annotated with NAT boundary, DHCP/DNS services, IDS/IPS.
+- Security zones grouped: Trusted (Management+Trusted), Restricted (IoT+Cameras), Isolated (Guest).
+- Include DHCP ranges and gateways inside VLAN bubbles.
+- Example flows: Trusted -> Servers (HTTP/S, SSH, SMB), IoT -> Internet (HTTP/S), Guest -> Internet only with red X to other VLANs.


### PR DESCRIPTION
## Summary
- Add production-ready monitoring stack configuration including Prometheus, Grafana, Loki, Promtail, Alertmanager, and exporters with dashboards and scripts
- Provide operational documentation, alert rules, and environment sample for monitoring deployment
- Document homelab network architecture, switch mapping, wireless configuration, security policy, diagrams guidance, and troubleshooting

## Testing
- Not run (documentation and configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb65a5d0c83279a55ea1ddcc2194d)