### PR TITLE
Add ADRs for storage, topology, observability, and security

### DIFF
--- a/projects/p01-aws-infra/HANDBOOK.md
+++ b/projects/p01-aws-infra/HANDBOOK.md
@@ -50,8 +50,10 @@ This handbook defines how the infrastructure team collaborates on AWS environmen
 
 ### ADR Index
 - [ADR-0001: Initial Technical Direction](./docs/ADR/0001-initial-decision.md)
-- [ADR-0002: CloudFormation vs Terraform](./docs/ADR/0002-cfn-vs-terraform.md)
-- [ADR-0003: Multi-AZ RDS Design](./docs/ADR/0003-multi-az-rds.md)
+- [ADR-0002: Data Storage Choice](./docs/ADR/0002-data-storage-choice.md)
+- [ADR-0003: Deployment Topology](./docs/ADR/0003-deployment-topology.md)
+- [ADR-0004: Observability Stack](./docs/ADR/0004-observability-stack.md)
+- [ADR-0005: Security Posture](./docs/ADR/0005-security-posture.md)
 
 ## Onboarding Checklist
 

--- a/projects/p01-aws-infra/docs/ADR/0001-initial-decision.md
+++ b/projects/p01-aws-infra/docs/ADR/0001-initial-decision.md
@@ -30,7 +30,7 @@ Use **AWS CloudFormation** as primary IaC tool for AWS resource provisioning wit
 ### Mitigation
 - Use Python scripts for complex orchestration
 - Document rollback procedures in RUNBOOK.md
-- Evaluate Terraform for future multi-cloud requirements (see ADR-0002)
+- Evaluate Terraform for future multi-cloud requirements (future ADR)
 
 ## Alternatives Considered
 - **Terraform**: Better multi-cloud support, but requires state management (S3 + DynamoDB locking)

--- a/projects/p01-aws-infra/docs/ADR/0002-data-storage-choice.md
+++ b/projects/p01-aws-infra/docs/ADR/0002-data-storage-choice.md
@@ -1,0 +1,39 @@
+# ADR 0002 — Data Storage Choice
+
+**Status**: Accepted
+**Date**: 2024-11-08
+**Deciders**: Platform Team, Data Engineering Lead
+
+## Context
+The infrastructure stack requires a durable relational data store for application state, audit logs, and IaC outputs. The service portfolio needs HA across availability zones, support for native IAM authentication, and a managed backup/restore workflow with minimal operational overhead. The database should integrate cleanly with existing CloudFormation templates and support future read scaling without re-architecting the network.
+
+## Decision
+Adopt **Amazon RDS for PostgreSQL (Multi-AZ)** as the primary data store.
+
+### Rationale
+- Mature feature set (JSONB, extensions) that satisfies current application use cases.
+- Native integration with CloudFormation, Secrets Manager, and IAM authentication.
+- Automated backups with PITR and snapshot exports to S3 for compliance evidence.
+- Clear migration path to read replicas for analytics without impacting primaries.
+
+## Alternatives Considered
+- **Amazon Aurora PostgreSQL**: Higher performance and fast failover but higher cost and additional operational tuning not yet required.
+- **Amazon RDS for MySQL**: Familiar option, but lacks some PostgreSQL features (e.g., robust JSON operators) used by analytics workloads.
+- **Self-managed PostgreSQL on EC2**: Full control but increases patching/operational burden and weakens managed backup guarantees.
+
+## Consequences
+
+### Positive
+- Reduced operational toil via managed backups, monitoring, and maintenance windows.
+- Consistent IAM-based authentication and integration with existing CloudFormation stacks.
+- Future scalability via read replicas without major schema redesign.
+
+### Negative
+- Aurora’s lower-failover times are not leveraged; recovery is bounded by RDS Multi-AZ limits.
+- Vendor lock-in to AWS-managed database services.
+- Storage and IOPS costs scale with Multi-AZ; must monitor budgets.
+
+### Mitigation
+- Re-evaluate Aurora if latency/error budget trends degrade or read workloads spike.
+- Implement budget alarms on RDS storage/IOPS metrics.
+- Document snapshot/restore runbooks to maintain RTO/RPO confidence.

--- a/projects/p01-aws-infra/docs/ADR/0003-deployment-topology.md
+++ b/projects/p01-aws-infra/docs/ADR/0003-deployment-topology.md
@@ -1,0 +1,37 @@
+# ADR 0003 — Deployment Topology
+
+**Status**: Accepted
+**Date**: 2024-11-09
+**Deciders**: Platform Team, SRE Lead
+
+## Context
+We must deploy infrastructure across multiple environments (dev, stage, prod) with clear separation of blast radius, predictable promotion paths, and minimal cross-environment coupling. Compliance requires isolated accounts for prod data, and the networking model must support public edge services while keeping databases private. The topology should align with CloudFormation StackSets and CI/CD workflows already in use.
+
+## Decision
+Use a **multi-account, multi-AZ topology**:
+- Dedicated AWS accounts per environment (dev, stage, prod) managed via AWS Organizations.
+- Single region (us-east-1) with **three Availability Zones** for high availability.
+- VPC per account with public and private subnets; RDS and application services reside in private subnets only.
+- Shared CI/CD account assumes cross-account roles to deploy stacks via CloudFormation StackSets.
+
+## Alternatives Considered
+- **Single-account with multiple VPCs**: Simpler to manage but higher blast radius and weaker compliance isolation for production data.
+- **Multi-region active/active**: Improves resilience but increases cost/complexity beyond current requirements; revisit after traffic growth milestones.
+- **Hybrid on-prem + AWS**: Not required for current workloads and would add VPN/Direct Connect dependencies.
+
+## Consequences
+
+### Positive
+- Clear environment isolation for compliance and incident containment.
+- High availability via three AZs without multi-region complexity.
+- CI/CD can reuse templates across accounts using StackSets, reducing drift risk.
+
+### Negative
+- Cross-account role management adds IAM complexity and onboarding overhead.
+- Single-region strategy still concentrates risk from regional outages.
+- Additional NAT Gateway costs per account.
+
+### Mitigation
+- Automate IAM role provisioning with CloudFormation and periodic `aws iam` audits.
+- Document regional evacuation playbooks and run annual failover drills.
+- Use centralized cost dashboards to monitor NAT/data transfer spend across accounts.

--- a/projects/p01-aws-infra/docs/ADR/0004-observability-stack.md
+++ b/projects/p01-aws-infra/docs/ADR/0004-observability-stack.md
@@ -1,0 +1,38 @@
+# ADR 0004 — Observability Stack
+
+**Status**: Accepted
+**Date**: 2024-11-10
+**Deciders**: SRE Lead, Platform Observability Engineer
+
+## Context
+The platform needs consistent logging, metrics, and tracing to detect drift, performance regressions, and incidents across environments. Tooling must integrate with AWS-native services, support infrastructure-as-code deployment, and provide long-term retention for audit events. Observability should minimize vendor lock-in while enabling alert routing to PagerDuty and collaboration channels.
+
+## Decision
+Adopt an **AWS-native observability stack** complemented by lightweight open-source components:
+- **CloudWatch Logs** for centralized log ingestion with subscription filters to **Kinesis Firehose → S3** for archival.
+- **CloudWatch Metrics** with **AWS Distro for OpenTelemetry (ADOT)** collectors for application metrics.
+- **X-Ray** for distributed tracing of service calls within the VPC.
+- **CloudTrail** enabled across all accounts with organization-wide trail and 365-day retention in S3.
+- Alerting via **CloudWatch Alarms → SNS → PagerDuty** and **Ops Slack** webhooks.
+
+## Alternatives Considered
+- **Datadog**: Rich features and unified UI but adds licensing costs and agent overhead; deferred until scale demands.
+- **ELK/Opensearch self-managed**: Flexible querying but increases operational toil (scaling clusters, patching, storage tuning).
+- **Prometheus + Grafana Cloud**: Strong metrics/tracing support but introduces multi-vendor management and cross-account networking complexity.
+
+## Consequences
+
+### Positive
+- Rapid adoption with minimal new tooling; uses managed AWS services already approved for compliance.
+- Unified alerting path to PagerDuty and Slack; no separate alerting stack to maintain.
+- Long-term auditability via CloudTrail and S3 archives.
+
+### Negative
+- CloudWatch query experience is less user-friendly than dedicated observability vendors.
+- X-Ray sampling may obscure low-volume traces unless tuned carefully.
+- Kinesis/S3 archival adds incremental costs.
+
+### Mitigation
+- Provide ready-made CloudWatch Logs Insights queries in RUNBOOK.md for common investigations.
+- Tune ADOT and X-Ray sampling per environment and document defaults.
+- Set lifecycle policies on S3 archives and Kinesis delivery streams to manage storage spend.

--- a/projects/p01-aws-infra/docs/ADR/0005-security-posture.md
+++ b/projects/p01-aws-infra/docs/ADR/0005-security-posture.md
@@ -1,0 +1,38 @@
+# ADR 0005 — Security Posture
+
+**Status**: Accepted
+**Date**: 2024-11-11
+**Deciders**: Security Lead, Platform Team
+
+## Context
+Our AWS environments must comply with least-privilege principles, protect sensitive data, and provide auditable controls for deployments and runtime operations. The security posture needs to balance developer velocity with guardrails that prevent misconfigurations, while integrating with existing CI/CD pipelines and AWS Organizations governance.
+
+## Decision
+Adopt a **defense-in-depth security posture** anchored on AWS-native controls:
+- Enforce **least privilege IAM** with role-based access; CloudFormation execution roles scoped to required services only.
+- Use **private subnets** for RDS and application services; restrict inbound traffic to load balancers and bastion hosts only.
+- Standardize **Secrets Manager** for credentials with 90-day rotation and customer-managed KMS keys.
+- Enable **Config + Security Hub** across accounts with mandatory conformance packs (CIS AWS Foundations) and automated drift alerts.
+- Require **CI/CD signing** of CloudFormation change sets with peer review before promotion to prod.
+
+## Alternatives Considered
+- **Third-party CSPM tooling only**: Offers richer dashboards but duplicates Security Hub signals and increases vendor footprint.
+- **Self-managed Vault**: Powerful secret workflow, but adds operational complexity and overlapping capabilities with Secrets Manager/KMS.
+- **Flat network with NACL-only controls**: Simpler, but fails to meet segmentation requirements and increases blast radius.
+
+## Consequences
+
+### Positive
+- Strong alignment with AWS governance services; minimal new infrastructure to secure or patch.
+- Clear audit trail via Config, CloudTrail, and signed change sets.
+- Reduced credential sprawl through centralized Secrets Manager usage.
+
+### Negative
+- Increased IAM policy management overhead; requires linting and review discipline.
+- Additional Config/Security Hub costs across multiple accounts.
+- Rotation policies may cause short-lived credential disruptions if not coordinated with app teams.
+
+### Mitigation
+- Automate IAM linting in CI (cfn-lint + custom policy checks) and provide policy templates.
+- Apply cost controls via Security Hub/Config scope and periodic review of unused checks.
+- Document rotation playbooks and provide integration examples for common runtimes.

--- a/projects/p01-aws-infra/docs/wiki/p01-aws-infra.md
+++ b/projects/p01-aws-infra/docs/wiki/p01-aws-infra.md
@@ -144,7 +144,7 @@ aws secretsmanager rotate-secret --secret-id /myapp/prod/db-password
 
 ### Future Phases
 - [ ] Multi-region replication (us-west-2 Read Replicas)
-- [ ] Terraform migration for multi-cloud support (see ADR-0002)
+- [ ] Terraform migration for multi-cloud support (future ADR)
 - [ ] Automated cost optimization (right-sizing recommendations)
 
 ## Links
@@ -155,5 +155,9 @@ aws secretsmanager rotate-secret --secret-id /myapp/prod/db-password
   - [RUNBOOK](../RUNBOOK.md) — Operational procedures
   - [PLAYBOOK](../PLAYBOOK.md) — Deployment and DR plays
   - [HANDBOOK](../HANDBOOK.md) — Team collaboration guide
-  - [ADR-0001](../docs/ADR/0001-initial-decision.md) — Architecture decisions
+  - [ADR-0001](../docs/ADR/0001-initial-decision.md) — Initial technical direction
+  - [ADR-0002](../docs/ADR/0002-data-storage-choice.md) — Data storage choice
+  - [ADR-0003](../docs/ADR/0003-deployment-topology.md) — Deployment topology
+  - [ADR-0004](../docs/ADR/0004-observability-stack.md) — Observability stack
+  - [ADR-0005](../docs/ADR/0005-security-posture.md) — Security posture
 - **Diagrams**: [Architecture](../docs/diagrams/architecture.mmd) | [Data Flow](../docs/diagrams/dataflow.mmd)


### PR DESCRIPTION
## Summary
- add ADRs for data storage selection, deployment topology, observability stack, and security posture
- update handbook and wiki ADR indexes to reference the expanded decision set
- align initial decision ADR mitigation to reference future Terraform evaluation without broken links

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb668e9c88327a0d06547bbabd174)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded architectural guidance with new decision records: RDS PostgreSQL Multi-AZ for data storage, multi-account multi-AZ topology across dev/stage/prod environments, CloudWatch-based observability with X-Ray and CloudTrail logging, and defense-in-depth security approach featuring least-privilege IAM, secrets rotation, and compliance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->