### PR TITLE
Add code generation prompt coverage checklist

### DIFF
--- a/reports/projects_code_generation_gap_checklist.md
+++ b/reports/projects_code_generation_gap_checklist.md
@@ -1,0 +1,463 @@
+# Code Generation Prompt Coverage by Project
+
+Checklist tracks whether code-generation prompts exist and which deliverable types already have concrete assets in the repository (based on folder presence).
+
+## 1-aws-infrastructure-automation
+- [ ] Code Generation Prompts section present in README
+- [x] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 10-blockchain-smart-contract-platform
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 11-iot-data-analytics
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 12-quantum-computing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 13-advanced-cybersecurity
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 14-edge-ai-inference
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 15-real-time-collaboration
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 16-advanced-data-lake
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 17-multi-cloud-service-mesh
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [x] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 18-gpu-accelerated-computing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 19-advanced-kubernetes-operators
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 2-database-migration
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [x] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 20-blockchain-oracle-service
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 21-quantum-safe-cryptography
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 22-autonomous-devops-platform
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 23-advanced-monitoring
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 24-report-generator
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 25-portfolio-website
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 3-kubernetes-cicd
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 4-devsecops
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 5-real-time-data-streaming
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 6-mlops-platform
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 7-serverless-data-processing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 8-advanced-ai-chatbot
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## 9-multi-region-disaster-recovery
+- [ ] Code Generation Prompts section present in README
+- [x] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [x] ADRs or runbooks
+
+## astradup-video-deduplication
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [x] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p01-aws-infra
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p02-iam-hardening
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p03-hybrid-network
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p04-ops-monitoring
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p05-mobile-testing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [ ] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p06-e2e-testing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [x] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p07-roaming-simulation
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p08-api-testing
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p09-cloud-native-poc
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p10-multi-region
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p11-serverless
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p12-data-pipeline
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p13-ha-webapp
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [x] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p14-disaster-recovery
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p15-cost-optimization
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p16-zero-trust
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p17-terraform-multicloud
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p18-k8s-cicd
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [x] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p19-security-automation
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks
+
+## p20-observability
+- [ ] Code Generation Prompts section present in README
+- [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
+- [ ] Application code (src/)
+- [ ] Container/Helm/Kubernetes assets
+- [ ] CI/CD workflows (.github/workflows)
+- [ ] Observability configs
+- [x] Tests (tests/)
+- [ ] ADRs or runbooks

--- a/reports/projects_code_generation_gap_checklist.md
+++ b/reports/projects_code_generation_gap_checklist.md
@@ -1,16 +1,16 @@
 # Code Generation Prompt Coverage by Project
 
-Checklist tracks whether code-generation prompts exist and which deliverable types already have concrete assets in the repository (based on folder presence).
+This checklist flags whether each project README contains a 'Code Generation Prompts' section and highlights which deliverables already exist (based on directory/file presence within each project).
 
 ## 1-aws-infrastructure-automation
 - [ ] Code Generation Prompts section present in README
 - [x] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [ ] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 10-blockchain-smart-contract-platform
 - [ ] Code Generation Prompts section present in README
@@ -20,7 +20,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 11-iot-data-analytics
 - [ ] Code Generation Prompts section present in README
@@ -30,7 +30,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 12-quantum-computing
 - [ ] Code Generation Prompts section present in README
@@ -40,7 +40,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 13-advanced-cybersecurity
 - [ ] Code Generation Prompts section present in README
@@ -50,7 +50,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 14-edge-ai-inference
 - [ ] Code Generation Prompts section present in README
@@ -60,7 +60,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 15-real-time-collaboration
 - [ ] Code Generation Prompts section present in README
@@ -70,7 +70,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 16-advanced-data-lake
 - [ ] Code Generation Prompts section present in README
@@ -80,7 +80,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 17-multi-cloud-service-mesh
 - [ ] Code Generation Prompts section present in README
@@ -90,7 +90,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 18-gpu-accelerated-computing
 - [ ] Code Generation Prompts section present in README
@@ -100,17 +100,17 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 19-advanced-kubernetes-operators
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [x] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 2-database-migration
 - [ ] Code Generation Prompts section present in README
@@ -120,7 +120,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 20-blockchain-oracle-service
 - [ ] Code Generation Prompts section present in README
@@ -130,7 +130,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 21-quantum-safe-cryptography
 - [ ] Code Generation Prompts section present in README
@@ -140,7 +140,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 22-autonomous-devops-platform
 - [ ] Code Generation Prompts section present in README
@@ -150,7 +150,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 23-advanced-monitoring
 - [ ] Code Generation Prompts section present in README
@@ -158,9 +158,9 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] Application code (src/)
 - [ ] Container/Helm/Kubernetes assets
 - [x] CI/CD workflows (.github/workflows)
-- [ ] Observability configs
+- [x] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 24-report-generator
 - [ ] Code Generation Prompts section present in README
@@ -170,27 +170,27 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 25-portfolio-website
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [ ] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
-- [ ] Observability configs
+- [x] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 3-kubernetes-cicd
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [ ] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 4-devsecops
 - [ ] Code Generation Prompts section present in README
@@ -200,7 +200,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 5-real-time-data-streaming
 - [ ] Code Generation Prompts section present in README
@@ -210,7 +210,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 6-mlops-platform
 - [ ] Code Generation Prompts section present in README
@@ -220,7 +220,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 7-serverless-data-processing
 - [ ] Code Generation Prompts section present in README
@@ -230,7 +230,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 8-advanced-ai-chatbot
 - [ ] Code Generation Prompts section present in README
@@ -240,7 +240,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## 9-multi-region-disaster-recovery
 - [ ] Code Generation Prompts section present in README
@@ -270,7 +270,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p02-iam-hardening
 - [ ] Code Generation Prompts section present in README
@@ -280,7 +280,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p03-hybrid-network
 - [ ] Code Generation Prompts section present in README
@@ -290,23 +290,23 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p04-ops-monitoring
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [ ] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
-- [ ] Observability configs
+- [x] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p05-mobile-testing
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [ ] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [ ] Tests (tests/)
@@ -320,7 +320,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [x] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p07-roaming-simulation
 - [ ] Code Generation Prompts section present in README
@@ -330,7 +330,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p08-api-testing
 - [ ] Code Generation Prompts section present in README
@@ -340,17 +340,17 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p09-cloud-native-poc
 - [ ] Code Generation Prompts section present in README
 - [ ] IaC artifacts (terraform/, pulumi/, or cdk/)
 - [x] Application code (src/)
-- [ ] Container/Helm/Kubernetes assets
+- [x] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p10-multi-region
 - [ ] Code Generation Prompts section present in README
@@ -360,7 +360,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p11-serverless
 - [ ] Code Generation Prompts section present in README
@@ -370,7 +370,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p12-data-pipeline
 - [ ] Code Generation Prompts section present in README
@@ -380,7 +380,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p13-ha-webapp
 - [ ] Code Generation Prompts section present in README
@@ -390,7 +390,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p14-disaster-recovery
 - [ ] Code Generation Prompts section present in README
@@ -400,7 +400,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p15-cost-optimization
 - [ ] Code Generation Prompts section present in README
@@ -410,7 +410,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p16-zero-trust
 - [ ] Code Generation Prompts section present in README
@@ -420,7 +420,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p17-terraform-multicloud
 - [ ] Code Generation Prompts section present in README
@@ -430,7 +430,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p18-k8s-cicd
 - [ ] Code Generation Prompts section present in README
@@ -440,7 +440,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p19-security-automation
 - [ ] Code Generation Prompts section present in README
@@ -450,7 +450,7 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] CI/CD workflows (.github/workflows)
 - [ ] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks
 
 ## p20-observability
 - [ ] Code Generation Prompts section present in README
@@ -458,6 +458,6 @@ Checklist tracks whether code-generation prompts exist and which deliverable typ
 - [ ] Application code (src/)
 - [ ] Container/Helm/Kubernetes assets
 - [ ] CI/CD workflows (.github/workflows)
-- [ ] Observability configs
+- [x] Observability configs
 - [x] Tests (tests/)
-- [ ] ADRs or runbooks
+- [x] ADRs or runbooks


### PR DESCRIPTION
## Summary
- add a consolidated checklist covering each `projects/*/README.md` target
- capture the presence of Code Generation prompt sections and supporting deliverables like IaC, app code, CI/CD, observability, tests, and ADRs
- provide ready-made checkboxes to highlight missing artifacts for future remediation

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d342373c8327883c8337a16481e0)