### PR TITLE
Add AI agent portfolio templates and docs

### DIFF
--- a/ai-agent-portfolio/README.md
+++ b/ai-agent-portfolio/README.md
@@ -1,0 +1,25 @@
+# AI Agent Portfolio
+
+This portfolio packages a cohesive set of JSON-driven agents, Terraform usage examples, dashboard configuration, and Wiki.js import specs to accelerate AI-powered CI/CD and documentation workflows.
+
+## Contents
+- `build_agent.json` — Build automation template with platform-aware scripts.
+- `deploy_agent.json` — Deployment orchestrator template with configurable strategies.
+- `test_agent.json` — Testing automation template spanning unit through E2E.
+- `document_agent.json` — Documentation generation template with flexible outputs.
+- `terraform_examples.md` — Terraform snippets demonstrating agent invocation patterns.
+- `portfolio_dashboard.json` — Landing/dashboard configuration for portfolio status and quick-start guidance.
+- `wikijs_import_spec.json` — Import rules for Wiki.js to publish portfolio docs.
+- `codex_blueprint.json` — Master blueprint describing the ecosystem components and standards.
+
+## Usage
+1. Customize each agent JSON template to align with your toolchain and compliance requirements.
+2. Apply the Terraform examples to integrate the agents into your provisioning pipelines.
+3. Surface portfolio status by feeding `portfolio_dashboard.json` into your dashboard renderer.
+4. Import `wikijs_import_spec.json` into Wiki.js to bootstrap documentation.
+5. Reference `codex_blueprint.json` for governance, workflow phases, and integration expectations.
+
+## Notes
+- Keep parameter defaults conservative for production environments.
+- Align deployment strategies with your rollback and health verification policies.
+- Enable change tracking in Wiki.js imports to maintain auditability.

--- a/ai-agent-portfolio/build_agent.json
+++ b/ai-agent-portfolio/build_agent.json
@@ -1,0 +1,35 @@
+{
+  "agent_name": "terraform_builder",
+  "version": "2.1.0",
+  "description": "AI-powered Terraform infrastructure generator with validation",
+  "capabilities": [
+    "terraform_code_generation",
+    "syntax_validation",
+    "best_practices_enforcement",
+    "multi_cloud_support",
+    "dependency_management"
+  ],
+  "parameters": {
+    "cloud_provider": {
+      "type": "string",
+      "allowed_values": ["aws", "azure", "gcp", "multi_cloud"],
+      "default": "aws"
+    },
+    "complexity": {
+      "type": "string",
+      "allowed_values": ["basic", "standard", "enterprise"],
+      "default": "standard"
+    },
+    "security_level": {
+      "type": "string",
+      "allowed_values": ["default", "enhanced", "compliance"],
+      "default": "enhanced"
+    }
+  },
+  "workflow": {
+    "analysis_phase": "requirements_parsing",
+    "generation_phase": "modular_code_creation",
+    "validation_phase": "syntax_security_checks",
+    "output_phase": "documentation_bundling"
+  }
+}

--- a/ai-agent-portfolio/codex_blueprint.json
+++ b/ai-agent-portfolio/codex_blueprint.json
@@ -1,0 +1,126 @@
+{
+  "ai_agent_builder_kit": {
+    "version": "2.1.0",
+    "schema_version": "2024.1",
+    "description": "Master blueprint for AI Agent development ecosystem",
+    "core_components": {
+      "agent_framework": {
+        "name": "AgentOS",
+        "version": "1.3.0",
+        "capabilities": [
+          "distributed_execution",
+          "fault_tolerance",
+          "auto_scaling",
+          "inter_agent_communication"
+        ]
+      },
+      "knowledge_base": {
+        "name": "KnowledgeMesh",
+        "version": "1.2.0",
+        "features": [
+          "vector_embeddings",
+          "semantic_search",
+          "knowledge_graphs",
+          "continuous_learning"
+        ]
+      },
+      "orchestration": {
+        "name": "OrchestratorX",
+        "version": "1.5.0",
+        "workflow_types": [
+          "sequential",
+          "parallel",
+          "conditional",
+          "event_driven"
+        ]
+      }
+    },
+    "development_workflow": {
+      "phase_1": {
+        "name": "Agent Design",
+        "activities": [
+          "requirement_analysis",
+          "capability_mapping",
+          "interface_design",
+          "protocol_selection"
+        ],
+        "outputs": [
+          "agent_spec.json",
+          "interface_contracts",
+          "test_scenarios"
+        ]
+      },
+      "phase_2": {
+        "name": "Implementation",
+        "activities": [
+          "code_generation",
+          "dependency_management",
+          "configuration_setup",
+          "integration_points"
+        ],
+        "outputs": [
+          "source_code",
+          "config_files",
+          "dependency_manifest"
+        ]
+      },
+      "phase_3": {
+        "name": "Validation",
+        "activities": [
+          "unit_testing",
+          "integration_testing",
+          "security_scanning",
+          "performance_benchmarking"
+        ],
+        "outputs": [
+          "test_reports",
+          "security_certificates",
+          "performance_metrics"
+        ]
+      },
+      "phase_4": {
+        "name": "Deployment",
+        "activities": [
+          "environment_provisioning",
+          "agent_registration",
+          "health_checks",
+          "monitoring_setup"
+        ],
+        "outputs": [
+          "deployment_manifest",
+          "monitoring_dashboard",
+          "documentation"
+        ]
+      }
+    },
+    "quality_standards": {
+      "code_quality": {
+        "test_coverage": ">=90%",
+        "static_analysis": "zero_critical",
+        "complexity": "cyclomatic<10"
+      },
+      "security": {
+        "vulnerability_scan": "zero_high_risk",
+        "secret_management": "encrypted_at_rest",
+        "access_control": "rbac_enforced"
+      },
+      "performance": {
+        "response_time": "<100ms",
+        "throughput": ">1000rps",
+        "availability": "99.95%"
+      }
+    },
+    "integration_ecosystem": {
+      "cloud_platforms": ["aws", "azure", "gcp", "oracle", "ibm"],
+      "ci_cd_systems": ["github_actions", "gitlab_ci", "jenkins", "circleci"],
+      "monitoring_tools": ["prometheus", "grafana", "datadog", "newrelic"],
+      "communication": ["slack", "teams", "discord", "webhooks"]
+    },
+    "compliance_framework": {
+      "standards": ["SOC2", "ISO27001", "GDPR", "HIPAA"],
+      "audit_trail": "immutable_logging",
+      "data_governance": "encryption_always",
+      "access_logging": "comprehensive_tracking"
+    }
+  }
+}

--- a/ai-agent-portfolio/deploy_agent.json
+++ b/ai-agent-portfolio/deploy_agent.json
@@ -1,0 +1,25 @@
+{
+  "agent_name": "cicd_deployer",
+  "version": "1.4.0",
+  "description": "Automated deployment pipeline orchestrator",
+  "capabilities": [
+    "pipeline_generation",
+    "environment_management",
+    "rollback_automation",
+    "health_verification",
+    "secret_management"
+  ],
+  "deployment_targets": [
+    "kubernetes",
+    "serverless",
+    "container_registry",
+    "cloud_functions",
+    "static_hosting"
+  ],
+  "pipeline_templates": {
+    "github_actions": "templates/github/workflows/",
+    "gitlab_ci": "templates/gitlab/.gitlab-ci.yml",
+    "jenkins": "templates/jenkins/Jenkinsfile",
+    "argo_cd": "templates/argo/applications/"
+  }
+}

--- a/ai-agent-portfolio/document_agent.json
+++ b/ai-agent-portfolio/document_agent.json
@@ -1,0 +1,23 @@
+{
+  "agent_name": "knowledge_curator",
+  "version": "1.5.0",
+  "description": "Automated documentation generation and maintenance",
+  "documentation_types": [
+    "architecture_diagrams",
+    "api_reference",
+    "runbooks",
+    "troubleshooting_guides",
+    "compliance_docs"
+  ],
+  "output_formats": {
+    "technical": ["terraform_docs", "archimate", "plantuml"],
+    "user_focused": ["mkdocs", "gitbook", "confluence"],
+    "compliance": ["pdf_reports", "audit_trails", "change_logs"]
+  },
+  "auto_update": {
+    "code_changes": true,
+    "version_updates": true,
+    "dependency_updates": true,
+    "security_advisories": true
+  }
+}

--- a/ai-agent-portfolio/portfolio_dashboard.json
+++ b/ai-agent-portfolio/portfolio_dashboard.json
@@ -1,0 +1,69 @@
+{
+  "portfolio_config": {
+    "project_name": "AI Agent Builder Kit",
+    "version": "2.1.0",
+    "description": "Enterprise-grade AI agent development platform",
+    "status_badges": {
+      "build": "https://img.shields.io/badge/build-passing-brightgreen",
+      "coverage": "https://img.shields.io/badge/coverage-95%25-green",
+      "license": "https://img.shields.io/badge/license-MIT-blue",
+      "release": "https://img.shields.io/badge/release-v2.1.0-orange"
+    }
+  },
+  "quick_start": {
+    "prerequisites": [
+      "Terraform >= 1.0",
+      "Node.js >= 18",
+      "Python >= 3.9",
+      "Docker >= 20.0"
+    ],
+    "installation": [
+      "git clone https://github.com/your-org/ai-agent-builder-kit",
+      "cd ai-agent-builder-kit",
+      "make init",
+      "make configure",
+      "make deploy-staging"
+    ],
+    "verification": [
+      "make test-all",
+      "make validate-security",
+      "make generate-docs"
+    ]
+  },
+  "agent_showcase": {
+    "featured_agents": [
+      {
+        "name": "Infrastructure Architect",
+        "description": "Designs and validates cloud infrastructure",
+        "status": "production",
+        "capabilities": 15
+      },
+      {
+        "name": "Security Sentinel",
+        "description": "Continuous security validation and compliance",
+        "status": "production",
+        "capabilities": 12
+      },
+      {
+        "name": "Documentation Curator",
+        "description": "Auto-generates and maintains documentation",
+        "status": "beta",
+        "capabilities": 8
+      }
+    ]
+  },
+  "metrics_dashboard": {
+    "deployment_stats": {
+      "agents_deployed": 47,
+      "success_rate": "99.2%",
+      "avg_deployment_time": "3.2min",
+      "active_environments": 12
+    },
+    "quality_metrics": {
+      "test_coverage": "95%",
+      "security_score": "A+",
+      "documentation_completeness": "98%",
+      "customer_satisfaction": "4.8/5.0"
+    }
+  }
+}

--- a/ai-agent-portfolio/terraform_examples.md
+++ b/ai-agent-portfolio/terraform_examples.md
@@ -1,0 +1,63 @@
+# Terraform Call Usage Examples
+
+## Basic Module Instantiation
+```hcl
+module "web_app" {
+  source = "github.com/your-org/terraform-aws-webapp"
+
+  environment = "production"
+  vpc_id      = "vpc-123456"
+
+  # Auto-scaling configuration
+  min_size     = 2
+  max_size     = 10
+  desired_size = 3
+
+  # Feature flags
+  enable_cdn        = true
+  enable_monitoring = true
+  enable_backups    = true
+}
+```
+
+## Multi-Cloud Deployment
+```hcl
+module "multi_cloud_app" {
+  source = "github.com/your-org/terraform-multi-cloud"
+
+  providers = {
+    aws   = aws.primary
+    azure = azurerm.secondary
+    gcp   = google.tertiary
+  }
+
+  regions = ["us-east-1", "eu-west-1", "asia-southeast1"]
+
+  traffic_distribution = {
+    primary   = 60
+    secondary = 30
+    tertiary  = 10
+  }
+}
+```
+
+## Kubernetes Cluster with AI-Optimized Config
+```hcl
+module "ai_ready_k8s" {
+  source = "github.com/your-org/terraform-k8s-ai"
+
+  cluster_name = "ml-platform"
+  node_count   = 5
+
+  gpu_enabled   = true
+  ml_frameworks = ["pytorch", "tensorflow", "jupyter"]
+  storage_class = "high-performance"
+
+  auto_scaling = {
+    enabled      = true
+    min_replicas = 3
+    max_replicas = 50
+    metrics_type = "custom/ml-workload"
+  }
+}
+```

--- a/ai-agent-portfolio/test_agent.json
+++ b/ai-agent-portfolio/test_agent.json
@@ -1,0 +1,30 @@
+{
+  "agent_name": "quality_validator",
+  "version": "1.2.0",
+  "description": "Comprehensive testing and validation framework",
+  "test_types": [
+    "unit_tests",
+    "integration_tests",
+    "security_scans",
+    "performance_benchmarks",
+    "compliance_checks"
+  ],
+  "validation_rules": {
+    "terraform_validation": [
+      "terraform validate",
+      "tflint",
+      "tfsec",
+      "checkov"
+    ],
+    "security_validation": [
+      "vulnerability_scanning",
+      "secret_detection",
+      "policy_compliance",
+      "license_checks"
+    ]
+  },
+  "reporting": {
+    "formats": ["junit_xml", "html", "json", "markdown"],
+    "destinations": ["github_pr", "slack", "email", "dashboard"]
+  }
+}

--- a/ai-agent-portfolio/wikijs_import_spec.json
+++ b/ai-agent-portfolio/wikijs_import_spec.json
@@ -1,0 +1,75 @@
+{
+  "wiki_config": {
+    "name": "AI Agent Builder Documentation",
+    "description": "Complete documentation for AI Agent development lifecycle",
+    "auto_sync": {
+      "enabled": true,
+      "sync_interval": "30m",
+      "trigger_sources": ["github", "agent_registry", "documentation_updates"]
+    }
+  },
+  "content_structure": {
+    "path": "docs/",
+    "auto_categories": [
+      {
+        "name": "Getting Started",
+        "path": "getting-started/",
+        "priority": 1,
+        "content_sources": ["README.md", "QUICKSTART.md"]
+      },
+      {
+        "name": "Agent Development",
+        "path": "agent-development/",
+        "priority": 2,
+        "content_sources": ["agents/**/README.md", "templates/"]
+      },
+      {
+        "name": "API Reference",
+        "path": "api-reference/",
+        "priority": 3,
+        "content_sources": ["openapi/", "api-docs/"]
+      },
+      {
+        "name": "Best Practices",
+        "path": "best-practices/",
+        "priority": 4,
+        "content_sources": ["guidelines/", "examples/"]
+      }
+    ]
+  },
+  "import_rules": {
+    "markdown_processing": {
+      "frontmatter_extraction": true,
+      "link_rewriting": true,
+      "image_optimization": true,
+      "code_syntax_highlighting": true
+    },
+    "version_control": {
+      "branch_based_staging": true,
+      "change_tracking": true,
+      "rollback_support": true
+    },
+    "access_control": {
+      "role_based_permissions": true,
+      "page_level_security": true,
+      "audit_logging": true
+    }
+  },
+  "integration_webhooks": {
+    "github_events": [
+      "push",
+      "pull_request",
+      "release"
+    ],
+    "agent_registry_events": [
+      "agent_created",
+      "agent_updated",
+      "agent_deployed"
+    ],
+    "monitoring_events": [
+      "health_check_failed",
+      "performance_alert",
+      "security_incident"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add AI agent JSON templates for build, deploy, test, and documentation workflows
- provide Terraform usage examples plus dashboard and Wiki.js configuration assets
- include codex blueprint and README to describe portfolio contents and usage

## Testing
- not run (documentation and configuration updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c32b29b883278ea64c2acf128f41)