### PR TITLE
Add completion summaries for projects 5-25

### DIFF
--- a/PORTFOLIO_COMPLETION_PROGRESS.md
+++ b/PORTFOLIO_COMPLETION_PROGRESS.md
@@ -206,31 +206,261 @@ This report documents the substantial progress made in completing the 25-project
 
 ---
 
-#### Project 23: Advanced Monitoring & Observability ✅
+#### Project 5: Real-time Data Streaming ⚠️
 
-**Status**: Enhanced with deployment automation
+**Status**: Minimal baseline with initial stream processor
 
 **What Was Added**:
-- ✅ **Monitoring stack deployment** (`monitoring.yml` - 160+ lines)
-  - Prometheus configuration validation
-  - Grafana dashboard linting
-  - Prometheus Operator deployment via Helm
-  - Custom alert rules deployment
-  - Grafana dashboard provisioning
-  - Loki log aggregation setup
-  - OpenTelemetry Collector deployment
-  - Health checks for all components
+- ✅ Sample stream processing script (`process_events.py`) to aggregate event counts and demonstrate ingestion flow.【F:projects/5-real-time-data-streaming/src/process_events.py†L1-L15】
+- ✅ README and runbook placeholders describing streaming goals and next steps.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L115-L123】
 
-**Monitoring Features**:
-- **Prometheus**: 30-day retention, 50Gi storage
-- **Grafana**: Automated dashboard loading
-- **Loki**: Log aggregation with Promtail
-- **OpenTelemetry**: Distributed tracing
-- **Health Checks**: Automated verification of all components
+**Key Metrics**:
+- Repository size: 9KB across 3 files; 15 lines of Python application code in place.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L111-L123】
 
-**Code Statistics**:
-- CI/CD: 160+ lines (GitHub Actions)
-- Existing dashboards and alert configs
+---
+
+#### Project 6: MLOps Platform ⚠️
+
+**Status**: Partial implementation with full training pipeline skeleton
+
+**What Was Added**:
+- ✅ Comprehensive ML pipeline with experiment tracking, hyperparameter tuning, and model registration in `mlops_pipeline.py`.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L135-L143】【F:projects/6-mlops-platform/src/mlops_pipeline.py†L1-L80】
+- ✅ Supporting configs (requirements, YAML experiments) and runbook to drive training workflows.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L135-L148】
+
+**Key Metrics**:
+- Repository size: 28KB across 6 files; 187 lines of Python, but no CI/CD or tests yet.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L135-L150】
+
+---
+
+#### Project 7: Serverless Data Processing ⚠️
+
+**Status**: Partial Lambda/SAM foundation
+
+**What Was Added**:
+- ✅ Lambda ingestion and analytics handlers with DynamoDB/S3/Step Functions integrations (`lambda_pipeline.py`).【F:projects/7-serverless-data-processing/src/lambda_pipeline.py†L1-L80】【F:PORTFOLIO_ASSESSMENT_REPORT.md†L161-L169】
+- ✅ Infrastructure templates and deployment scripts with requirements for AWS SAM/Terraform workflows.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L161-L169】
+
+**Key Metrics**:
+- Repository size: 25KB across 6 files; 102 lines of Python application code, but no tests or CI/CD yet.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L161-L176】
+
+---
+
+#### Project 8: Advanced AI Chatbot ⚠️
+
+**Status**: Partial RAG/FastAPI service
+
+**What Was Added**:
+- ✅ 120 lines of Python implementing RAG, vector search, and FastAPI endpoints with supporting requirements.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L186-L194】
+- ✅ Deployment scripts and architecture-focused README to guide future infrastructure work.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L186-L200】
+
+**Key Metrics**:
+- Repository size: 20KB across 5 files; application code present but lacking Docker, tests, and CI/CD.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L186-L201】
+
+---
+
+#### Project 9: Multi-Region Disaster Recovery ⚠️
+
+**Status**: Partial Terraform-driven DR foundation
+
+**What Was Added**:
+- ✅ 151 lines of Terraform covering VPC, RDS, and Route53 failover plus automation scripts for drills.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L211-L218】
+- ✅ Runbooks detailing DR procedures and automation entrypoints.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L211-L218】
+
+**Key Metrics**:
+- Repository size: 26KB across 6 files; infrastructure code present but no tests, CI/CD, or monitoring yet.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L211-L224】
+
+---
+
+#### Project 10: Blockchain Smart Contract Platform ⚠️
+
+**Status**: Partial Hardhat-based contract suite
+
+**What Was Added**:
+- ✅ Solidity contracts and Hardhat test harness with deploy scripts and config (`hardhat.config.ts`).【F:PORTFOLIO_ASSESSMENT_REPORT.md†L235-L243】
+- ✅ README documenting security considerations and workflow entrypoints.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L235-L244】
+
+**Key Metrics**:
+- Repository size: 29KB across 9 files; 52 lines of Solidity with initial tests but missing CI/CD and coverage depth.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L235-L250】
+
+---
+
+#### Project 11: IoT Data Analytics ⚠️
+
+**Status**: Minimal device simulator foundation
+
+**What Was Added**:
+- ✅ 52-line Python device simulator with lightweight requirements file and README guidance.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L260-L267】
+
+**Key Metrics**:
+- Repository size: 12KB across 4 files; lacks infrastructure, tests, CI/CD, and monitoring pipelines.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L260-L274】
+
+---
+
+#### Project 12: Quantum Computing Integration ⚠️
+
+**Status**: Minimal VQE prototype
+
+**What Was Added**:
+- ✅ 58 lines of Python implementing a VQE workflow with dependency pinning and documentation.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L284-L291】
+
+**Key Metrics**:
+- Repository size: 12KB across 4 files; no infrastructure, tests, CI/CD, or observability yet.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L284-L298】
+
+---
+
+#### Project 13: Advanced Cybersecurity Platform ⚠️
+
+**Status**: Minimal SOAR engine stub
+
+**What Was Added**:
+- ✅ 77-line Python SOAR engine with sample alert data and concise README overview.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L308-L315】
+
+**Key Metrics**:
+- Repository size: 16KB across 4 files; missing requirements, infrastructure, tests, and CI/CD pipelines.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L308-L321】
+
+---
+
+#### Project 14: Edge AI Inference Platform ⚠️
+
+**Status**: Minimal ONNX inference starter
+
+**What Was Added**:
+- ✅ 31-line Python ONNX inference script with dependency list and README guidance.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L332-L339】
+
+**Key Metrics**:
+- Repository size: 11KB across 4 files; needs edge deployment manifests, tests, and CI/CD support.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L332-L346】
+
+---
+
+#### Project 15: Real-time Collaboration Platform ⚠️
+
+**Status**: Minimal OT/CRDT service outline
+
+**What Was Added**:
+- ✅ 56-line Python collaboration server prototype with dependencies and documentation starter.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L356-L363】
+
+**Key Metrics**:
+- Repository size: 11KB across 4 files; lacks frontend, infra, tests, and CI/CD automation.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L356-L369】
+
+---
+
+#### Project 16: Advanced Data Lake ⚠️
+
+**Status**: Minimal medallion pipeline seed
+
+**What Was Added**:
+- ✅ Bronze-to-silver transformation script with sample data, requirements, and README.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L380-L388】
+
+**Key Metrics**:
+- Repository size: 15KB across 5 files; no dbt models, infra, tests, or CI/CD yet.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L380-L395】
+
+---
+
+#### Project 17: Multi-Cloud Service Mesh ⚠️
+
+**Status**: Minimal Istio operator bootstrap
+
+**What Was Added**:
+- ✅ Istio operator YAML and bootstrap script with accompanying README for mesh setup.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L405-L412】
+
+**Key Metrics**:
+- Repository size: 14KB across 3 files; lacks demo services, multi-cluster automation, tests, and CI/CD.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L405-L418】
+
+---
+
+#### Project 18: GPU-Accelerated Computing ⚠️
+
+**Status**: Minimal Monte Carlo GPU starter
+
+**What Was Added**:
+- ✅ 19-line Python Monte Carlo simulation with requirements and README instructions.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L429-L436】
+
+**Key Metrics**:
+- Repository size: 10KB across 4 files; no CUDA kernels, infra, tests, or CI/CD present.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L429-L443】
+
+---
+
+#### Project 19: Advanced Kubernetes Operators ⚠️
+
+**Status**: Minimal Kopf operator stub
+
+**What Was Added**:
+- ✅ 29-line Python operator stub with requirements and README setup notes.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L453-L460】
+
+**Key Metrics**:
+- Repository size: 11KB across 4 files; CRDs, tests, CI/CD, and webhooks still needed.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L453-L467】
+
+---
+
+#### Project 20: Blockchain Oracle Service ⚠️
+
+**Status**: Minimal adapter and contract starter
+
+**What Was Added**:
+- ✅ JavaScript adapter plus Solidity contract with deployment scripts and package configuration.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L477-L484】
+
+**Key Metrics**:
+- Repository size: 15KB across 4 files; missing infrastructure, tests, CI/CD, and Chainlink node setup.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L477-L491】
+
+---
+
+#### Project 21: Quantum-Safe Cryptography ⚠️
+
+**Status**: Minimal hybrid key exchange demo
+
+**What Was Added**:
+- ✅ 55-line Python example combining Kyber and ECDH with dependencies and README instructions.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L502-L509】
+
+**Key Metrics**:
+- Repository size: 11KB across 4 files; lacks infra, tests, CI/CD, and benchmarking tooling.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L502-L515】
+
+---
+
+#### Project 22: Autonomous DevOps Platform ⚠️
+
+**Status**: Minimal automation engine stub
+
+**What Was Added**:
+- ✅ 55-line Python autonomous remediation engine scaffold with initial documentation.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L526-L532】
+
+**Key Metrics**:
+- Repository size: 10KB across 3 files; missing requirements, infra, tests, CI/CD, and runbook automation.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L526-L539】
+
+---
+
+#### Project 23: Advanced Monitoring & Observability ⚠️
+
+**Status**: Minimal monitoring configuration seeds
+
+**What Was Added**:
+- ✅ Alerting and Prometheus rule YAML plus Grafana dashboard definitions with README pointers.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L550-L556】
+
+**Key Metrics**:
+- Repository size: 14KB across 3 files; lacks collectors, infra deployment, tests, and CI/CD automation.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L550-L564】
+
+---
+
+#### Project 24: Report Generator ⚠️
+
+**Status**: Minimal reporting stub
+
+**What Was Added**:
+- ✅ 29-line Python report generator scaffold with requirements and template directory structure plus README.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L574-L581】
+
+**Key Metrics**:
+- Repository size: 15KB across 5 files; missing templates, tests, CI/CD, and automation pipelines.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L574-L588】
+
+---
+
+#### Project 25: Portfolio Website & Documentation Hub ⚠️
+
+**Status**: Partial VitePress documentation site
+
+**What Was Added**:
+- ✅ VitePress configuration and docs directory with package scripts and README for local development; basic integration tests included.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L598-L606】
+
+**Key Metrics**:
+- Repository size: 20KB across 7 files; needs deployment manifests, CI/CD, monitoring, and containerization.【F:PORTFOLIO_ASSESSMENT_REPORT.md†L598-L613】
 
 ---
 


### PR DESCRIPTION
## Summary
- add status blocks for projects 5–25 to extend the portfolio completion tracker
- reference code and documentation artifacts with metrics drawn from the assessment report
- align remaining projects with the format used for the foundation projects

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c174322083278409abfced7fc75a)