### PR TITLE
Extend completion tracker to projects 5-25

### DIFF
--- a/PORTFOLIO_COMPLETION_PROGRESS.md
+++ b/PORTFOLIO_COMPLETION_PROGRESS.md
@@ -206,6 +206,276 @@ This report documents the substantial progress made in completing the 25-project
 
 ---
 
+#### Project 5: Real-time Data Streaming ⏳
+
+**Status**: Minimal baseline with docs and Flink/Kafka scaffold
+
+**What Was Added**:
+- ✅ Service overview and quickstart (`projects/5-real-time-data-streaming/README.md`)
+- ✅ Operations handbook (`projects/5-real-time-data-streaming/RUNBOOK.md`)
+- ✅ Initial processing pipeline stub (`projects/5-real-time-data-streaming/src/`)
+
+**Key Metrics**:
+- Files: 3 (9K) with README and runbook coverage【F:PORTFOLIO_SUMMARY_TABLE.txt†L11-L12】
+- Status: Minimal implementation, priority High【F:PORTFOLIO_SUMMARY_TABLE.txt†L11-L12】
+
+---
+
+#### Project 6: MLOps Platform ⏳
+
+**Status**: Partial scaffold with configs, scripts, and wiki notes
+
+**What Was Added**:
+- ✅ Platform README plus operational runbook (`projects/6-mlops-platform/README.md`, `projects/6-mlops-platform/RUNBOOK.md`)
+- ✅ Configuration and automation stubs (`projects/6-mlops-platform/configs/`, `projects/6-mlops-platform/scripts/`)
+- ✅ Source skeleton and wiki for design notes (`projects/6-mlops-platform/src/`, `projects/6-mlops-platform/wiki/`)
+
+**Key Metrics**:
+- Files: 6 (28K) with partial implementation coverage【F:PORTFOLIO_SUMMARY_TABLE.txt†L12-L13】
+- Status: Partial build-out, priority High【F:PORTFOLIO_SUMMARY_TABLE.txt†L12-L13】
+
+---
+
+#### Project 7: Serverless Data Processing ⏳
+
+**Status**: Partial Lambda/dataflow blueprint with docs and configs
+
+**What Was Added**:
+- ✅ README and runbook for serverless workflows (`projects/7-serverless-data-processing/README.md`, `projects/7-serverless-data-processing/RUNBOOK.md`)
+- ✅ Configuration and scripts directories for deployments (`projects/7-serverless-data-processing/configs/`, `projects/7-serverless-data-processing/scripts/`)
+- ✅ Source and wiki scaffolds for pipeline logic (`projects/7-serverless-data-processing/src/`, `projects/7-serverless-data-processing/wiki/`)
+
+**Key Metrics**:
+- Files: 6 (25K) reflecting partial implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L13-L14】
+- Status: Partial, priority High【F:PORTFOLIO_SUMMARY_TABLE.txt†L13-L14】
+
+---
+
+#### Project 8: Advanced AI Chatbot ⏳
+
+**Status**: Partial chatbot platform with docs and starter code
+
+**What Was Added**:
+- ✅ Product README and operational runbook (`projects/8-advanced-ai-chatbot/README.md`, `projects/8-advanced-ai-chatbot/RUNBOOK.md`)
+- ✅ Source scaffolding for conversational flows (`projects/8-advanced-ai-chatbot/src/`)
+- ✅ Wiki content for architecture and prompts (`projects/8-advanced-ai-chatbot/wiki/`)
+
+**Key Metrics**:
+- Files: 5 (20K) representing partial coverage【F:PORTFOLIO_SUMMARY_TABLE.txt†L14-L15】
+- Status: Partial, priority High【F:PORTFOLIO_SUMMARY_TABLE.txt†L14-L15】
+
+---
+
+#### Project 9: Multi-Region Disaster Recovery ⏳
+
+**Status**: Partial IaC/runbook set for DR strategy
+
+**What Was Added**:
+- ✅ README and DR playbook (`projects/9-multi-region-disaster-recovery/README.md`, `projects/9-multi-region-disaster-recovery/RUNBOOK.md`)
+- ✅ Infrastructure stubs and scripts (`projects/9-multi-region-disaster-recovery/terraform/`, `projects/9-multi-region-disaster-recovery/scripts/`)
+- ✅ Wiki for recovery procedures (`projects/9-multi-region-disaster-recovery/wiki/`)
+
+**Key Metrics**:
+- Files: 6 (26K) indicating partial implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L15-L16】
+- Status: Partial, priority High【F:PORTFOLIO_SUMMARY_TABLE.txt†L15-L16】
+
+---
+
+#### Project 10: Blockchain Smart Contract Platform ⏳
+
+**Status**: Partial Hardhat/solidity workspace with docs and tests scaffold
+
+**What Was Added**:
+- ✅ README and runbook for contract workflows (`projects/10-blockchain-smart-contract-platform/README.md`, `projects/10-blockchain-smart-contract-platform/RUNBOOK.md`)
+- ✅ Contract, test, and script directories (`projects/10-blockchain-smart-contract-platform/contracts/`, `projects/10-blockchain-smart-contract-platform/test/`, `projects/10-blockchain-smart-contract-platform/scripts/`)
+- ✅ Tooling configs (Hardhat/TypeScript) for builds (`projects/10-blockchain-smart-contract-platform/hardhat.config.ts`, `projects/10-blockchain-smart-contract-platform/tsconfig.json`)
+
+**Key Metrics**:
+- Files: 9 (29K) demonstrating partial implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L16-L17】
+- Status: Partial, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L16-L17】
+
+---
+
+#### Project 11: IoT Data Analytics ⏳
+
+**Status**: Minimal analytics pipeline starter with docs
+
+**What Was Added**:
+- ✅ README and runbook for IoT ingestion (`projects/11-iot-data-analytics/README.md`, `projects/11-iot-data-analytics/RUNBOOK.md`)
+- ✅ Source scaffold for data processing (`projects/11-iot-data-analytics/src/`)
+- ✅ Wiki for architecture considerations (`projects/11-iot-data-analytics/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (12K) marked minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L17-L18】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L17-L18】
+
+---
+
+#### Project 12: Quantum Computing Integration ⏳
+
+**Status**: Minimal baseline for quantum workflow integration
+
+**What Was Added**:
+- ✅ README and operational runbook (`projects/12-quantum-computing/README.md`, `projects/12-quantum-computing/RUNBOOK.md`)
+- ✅ Source folder for quantum experiments (`projects/12-quantum-computing/src/`)
+- ✅ Wiki for algorithm notes (`projects/12-quantum-computing/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (12K) with minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L18-L19】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L18-L19】
+
+---
+
+#### Project 13: Advanced Cybersecurity Platform ⏳
+
+**Status**: Minimal security platform starter with docs
+
+**What Was Added**:
+- ✅ README and security operations runbook (`projects/13-advanced-cybersecurity/README.md`, `projects/13-advanced-cybersecurity/RUNBOOK.md`)
+- ✅ Source skeleton for detection/response (`projects/13-advanced-cybersecurity/src/`)
+- ✅ Wiki for playbooks and threat models (`projects/13-advanced-cybersecurity/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (16K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L19-L20】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L19-L20】
+
+---
+
+#### Project 14: Edge AI Inference Platform ⏳
+
+**Status**: Minimal edge inference baseline with docs and code stub
+
+**What Was Added**:
+- ✅ README and runbook for edge deployments (`projects/14-edge-ai-inference/README.md`, `projects/14-edge-ai-inference/RUNBOOK.md`)
+- ✅ Source folder for inference services (`projects/14-edge-ai-inference/src/`)
+- ✅ Wiki for hardware/latency guidance (`projects/14-edge-ai-inference/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (11K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L20-L21】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L20-L21】
+
+---
+
+#### Project 15: Real-time Collaboration Platform ⏳
+
+**Status**: Minimal collaboration stack foundation with docs
+
+**What Was Added**:
+- ✅ README and reliability runbook (`projects/15-real-time-collaboration/README.md`, `projects/15-real-time-collaboration/RUNBOOK.md`)
+- ✅ Source scaffold for collaboration services (`projects/15-real-time-collaboration/src/`)
+- ✅ Wiki capturing architecture notes (`projects/15-real-time-collaboration/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (11K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L21-L22】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L21-L22】
+
+---
+
+#### Project 16: Advanced Data Lake ⏳
+
+**Status**: Minimal data lake scaffold with docs and configs
+
+**What Was Added**:
+- ✅ README and runbook for ingestion/retention (`projects/16-advanced-data-lake/README.md`, `projects/16-advanced-data-lake/RUNBOOK.md`)
+- ✅ Configuration and source stubs (`projects/16-advanced-data-lake/configs/`, `projects/16-advanced-data-lake/src/`)
+- ✅ Wiki for governance and schema strategy (`projects/16-advanced-data-lake/wiki/`)
+
+**Key Metrics**:
+- Files: 5 (15K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L22-L23】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L22-L23】
+
+---
+
+#### Project 17: Multi-Cloud Service Mesh ⏳
+
+**Status**: Minimal mesh baseline with docs and IaC placeholder
+
+**What Was Added**:
+- ✅ README and runbook for cross-cloud traffic management (`projects/17-multi-cloud-service-mesh/README.md`, `projects/17-multi-cloud-service-mesh/RUNBOOK.md`)
+- ✅ Infrastructure and config stubs (`projects/17-multi-cloud-service-mesh/terraform/`, `projects/17-multi-cloud-service-mesh/configs/`)
+- ✅ Wiki for topology guidance (`projects/17-multi-cloud-service-mesh/wiki/`)
+
+**Key Metrics**:
+- Files: 3 (14K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L23-L24】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L23-L24】
+
+---
+
+#### Project 18: GPU-Accelerated Computing ⏳
+
+**Status**: Minimal GPU workload scaffold with docs
+
+**What Was Added**:
+- ✅ README and runbook for GPU nodes (`projects/18-gpu-accelerated-computing/README.md`, `projects/18-gpu-accelerated-computing/RUNBOOK.md`)
+- ✅ Source and script placeholders (`projects/18-gpu-accelerated-computing/src/`, `projects/18-gpu-accelerated-computing/scripts/`)
+- ✅ Wiki for performance tuning notes (`projects/18-gpu-accelerated-computing/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (10K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L24-L25】
+- Status: Minimal, priority Low【F:PORTFOLIO_SUMMARY_TABLE.txt†L24-L25】
+
+---
+
+#### Project 19: Advanced Kubernetes Operators ⏳
+
+**Status**: Minimal operator framework scaffold with docs
+
+**What Was Added**:
+- ✅ README and runbook for operator lifecycle (`projects/19-advanced-kubernetes-operators/README.md`, `projects/19-advanced-kubernetes-operators/RUNBOOK.md`)
+- ✅ Source and config stubs (`projects/19-advanced-kubernetes-operators/src/`, `projects/19-advanced-kubernetes-operators/configs/`)
+- ✅ Wiki for CRD design notes (`projects/19-advanced-kubernetes-operators/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (11K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L25-L26】
+- Status: Minimal, priority Low【F:PORTFOLIO_SUMMARY_TABLE.txt†L25-L26】
+
+---
+
+#### Project 20: Blockchain Oracle Service ⏳
+
+**Status**: Minimal oracle service baseline with docs and scripts
+
+**What Was Added**:
+- ✅ README and runbook for oracle lifecycle (`projects/20-blockchain-oracle-service/README.md`, `projects/20-blockchain-oracle-service/RUNBOOK.md`)
+- ✅ Source and deployment scripts (`projects/20-blockchain-oracle-service/src/`, `projects/20-blockchain-oracle-service/scripts/`)
+- ✅ Wiki for network/chain integration notes (`projects/20-blockchain-oracle-service/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (15K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L26-L27】
+- Status: Minimal, priority Low【F:PORTFOLIO_SUMMARY_TABLE.txt†L26-L27】
+
+---
+
+#### Project 21: Quantum-Safe Cryptography ⏳
+
+**Status**: Minimal cryptography pilot with docs
+
+**What Was Added**:
+- ✅ README and runbook for PQC rollout (`projects/21-quantum-safe-cryptography/README.md`, `projects/21-quantum-safe-cryptography/RUNBOOK.md`)
+- ✅ Source and config placeholders (`projects/21-quantum-safe-cryptography/src/`, `projects/21-quantum-safe-cryptography/configs/`)
+- ✅ Wiki for algorithm selection notes (`projects/21-quantum-safe-cryptography/wiki/`)
+
+**Key Metrics**:
+- Files: 4 (11K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L27-L28】
+- Status: Minimal, priority Low【F:PORTFOLIO_SUMMARY_TABLE.txt†L27-L28】
+
+---
+
+#### Project 22: Autonomous DevOps Platform ⏳
+
+**Status**: Minimal automation engine scaffold with docs
+
+**What Was Added**:
+- ✅ README and runbook for autonomous workflows (`projects/22-autonomous-devops-platform/README.md`, `projects/22-autonomous-devops-platform/RUNBOOK.md`)
+- ✅ Source and config stubs (`projects/22-autonomous-devops-platform/src/`, `projects/22-autonomous-devops-platform/configs/`)
+- ✅ Wiki capturing self-healing patterns (`projects/22-autonomous-devops-platform/wiki/`)
+
+**Key Metrics**:
+- Files: 3 (10K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L28-L29】
+- Status: Minimal, priority Critical【F:PORTFOLIO_SUMMARY_TABLE.txt†L28-L29】
+
+---
+
 #### Project 23: Advanced Monitoring & Observability ✅
 
 **Status**: Enhanced with deployment automation
@@ -231,6 +501,36 @@ This report documents the substantial progress made in completing the 25-project
 **Code Statistics**:
 - CI/CD: 160+ lines (GitHub Actions)
 - Existing dashboards and alert configs
+
+---
+
+#### Project 24: Report Generator ⏳
+
+**Status**: Minimal reporting engine scaffold with docs and templates
+
+**What Was Added**:
+- ✅ README and runbook for report workflows (`projects/24-report-generator/README.md`, `projects/24-report-generator/RUNBOOK.md`)
+- ✅ Source, templates, and scripts for generation flows (`projects/24-report-generator/src/`, `projects/24-report-generator/templates/`, `projects/24-report-generator/scripts/`)
+- ✅ Wiki for data model and formatting guidance (`projects/24-report-generator/wiki/`)
+
+**Key Metrics**:
+- Files: 5 (15K) minimal implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L29-L30】
+- Status: Minimal, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L29-L30】
+
+---
+
+#### Project 25: Portfolio Website ⏳
+
+**Status**: Partial VitePress/portal setup with docs and assets
+
+**What Was Added**:
+- ✅ README and runbook for site operations (`projects/25-portfolio-website/README.md`, `projects/25-portfolio-website/RUNBOOK.md`)
+- ✅ Documentation site scaffolding and config (`projects/25-portfolio-website/docs/`, `projects/25-portfolio-website/.vitepress/`)
+- ✅ Assets and scripts for publishing (`projects/25-portfolio-website/assets/`, `projects/25-portfolio-website/scripts/`)
+
+**Key Metrics**:
+- Files: 7 (20K) reflecting partial implementation【F:PORTFOLIO_SUMMARY_TABLE.txt†L30-L31】
+- Status: Partial, priority Medium【F:PORTFOLIO_SUMMARY_TABLE.txt†L30-L31】
 
 ---
 


### PR DESCRIPTION
## Summary
- extend `PORTFOLIO_COMPLETION_PROGRESS.md` with status coverage for projects 5–25
- capture key artifacts, priorities, and metrics for each project using the summary table

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dc0803fc8327aec0333a477debcf)