### PR TITLE
Add phase diagram helper and link assets in READMEs

### DIFF
--- a/projects/01-sde-devops/PRJ-SDE-001/README.md
+++ b/projects/01-sde-devops/PRJ-SDE-001/README.md
@@ -6,6 +6,11 @@
 
 ---
 
+## Diagrams
+
+- [Database infrastructure (Mermaid)](assets/diagrams/database-infrastructure.mermaid)
+- [Database infrastructure (PNG/Markdown export)](assets/diagrams/database-infrastructure.md)
+
 ## Overview
 
 Complete production-ready infrastructure-as-code solution deploying a full application stack on AWS with:

--- a/projects/01-sde-devops/PRJ-SDE-002/README.md
+++ b/projects/01-sde-devops/PRJ-SDE-002/README.md
@@ -2,6 +2,11 @@
 
 **Status:** 🟢 Done
 
+## Diagrams
+
+- [Observability architecture (Mermaid)](assets/diagrams/observability-architecture.mermaid)
+- [Observability architecture (PNG/Markdown export)](assets/diagrams/observability-architecture.md)
+
 ## Description
 
 Monitoring/alerting stack using Prometheus, Grafana, Loki, and Alertmanager, integrated with Proxmox Backup Server.

--- a/projects/06-homelab/PRJ-HOME-001/README.md
+++ b/projects/06-homelab/PRJ-HOME-001/README.md
@@ -2,6 +2,13 @@
 
 **Status:** 🟢 Done
 
+## Diagrams
+
+- [Logical VLAN map (Mermaid)](assets/diagrams/logical-vlan-map.mermaid)
+- [Logical VLAN map (PNG/Markdown export)](assets/diagrams/logical-vlan-map.md)
+- [Physical topology (Mermaid)](assets/diagrams/physical-topology.mermaid)
+- [Physical topology (PNG/Markdown export)](assets/diagrams/physical-topology.md)
+
 ## Description
 
 Designed and wired a home network from scratch: rack-mounted gear, VLAN segmentation, and secure Wi-Fi for isolated IoT, guest, and trusted networks.

--- a/projects/06-homelab/PRJ-HOME-002/README.md
+++ b/projects/06-homelab/PRJ-HOME-002/README.md
@@ -2,6 +2,23 @@
 
 **Status:** 🟢 Done
 
+## Diagrams
+
+- [Network topology (Mermaid)](assets/diagrams/network-topology.mmd)
+- [Network topology (PNG/Markdown export)](assets/diagrams/network-topology.md)
+- [Service architecture (Mermaid)](assets/diagrams/service-architecture.mmd)
+- [Service architecture (PNG/Markdown export)](assets/diagrams/service-architecture.md)
+- [Virtualization architecture (Mermaid)](assets/diagrams/virtualization-architecture.mermaid)
+- [Virtualization architecture (PNG/Markdown export)](assets/diagrams/virtualization-architecture.md)
+- [Monitoring architecture (Mermaid)](assets/diagrams/monitoring-architecture.mmd)
+- [Monitoring architecture (PNG/Markdown export)](assets/diagrams/monitoring-architecture.md)
+- [Disaster recovery flow (Mermaid)](assets/diagrams/disaster-recovery-flow.mmd)
+- [Disaster recovery flow (PNG/Markdown export)](assets/diagrams/disaster-recovery-flow.md)
+- [Backup & recovery plan (Mermaid)](assets/diagrams/backup-recovery.mmd)
+- [Backup & recovery plan (PNG/Markdown export)](assets/diagrams/backup-recovery.md)
+- [Data flow (Mermaid)](assets/diagrams/data-flow.mmd)
+- [Data flow (PNG/Markdown export)](assets/diagrams/data-flow.md)
+
 ## Description
 
 Proxmox/TrueNAS host running Wiki.js, Home Assistant, and Immich behind a reverse proxy with TLS.

--- a/projects/06-homelab/PRJ-HOME-004/README.md
+++ b/projects/06-homelab/PRJ-HOME-004/README.md
@@ -5,6 +5,14 @@
 **Technologies:** Proxmox VE, TrueNAS, UniFi, WireGuard, Nginx Proxy Manager, Prometheus, Grafana, Loki, Immich
 **Complexity:** Expert
 
+## Diagrams
+
+- [Architecture overview](assets/diagrams/architecture-overview.mermaid)
+- [Firewall policy](assets/diagrams/firewall-policy.mermaid)
+- [Implementation timeline](assets/diagrams/implementation-timeline.mermaid)
+- [Backup strategy](assets/diagrams/backup-strategy.mermaid)
+- [Risk assessment matrix](assets/diagrams/risk-assessment-matrix.mermaid)
+
 **Owner:** Samuel Jackson
 **Sponsor:** Andrew Vongsady
 **Version:** 6.0 (Final Comprehensive)

--- a/reports/diagram_phase_branching_notes.md
+++ b/reports/diagram_phase_branching_notes.md
@@ -1,0 +1,16 @@
+# Diagram Phase Branching Notes
+
+The phase-scoped diagram helper now lives at `tools/generate_phase1_diagrams.py`. It groups projects into four phases with explicit diagram expectations and validates that required Mermaid/Markdown artifacts exist alongside README references. Use it to scope work per branch and to confirm assets before opening PRs.
+
+## Phase Coverage
+- **Phase 1:** PRJ-SDE-001 (Database infrastructure), PRJ-SDE-002 (Observability architecture)
+- **Phase 2:** PRJ-HOME-001 (Logical VLAN map, physical topology)
+- **Phase 3:** PRJ-HOME-002 (Network topology, service architecture, virtualization, monitoring, DR, backup, data flow)
+- **Phase 4:** PRJ-HOME-004 (Architecture overview, firewall policy, implementation timeline, backup strategy, risk matrix)
+
+## How to Use
+- **List expectations:** `python tools/generate_phase1_diagrams.py --list phase1 phase2`
+- **Validate assets + README links:** `python tools/generate_phase1_diagrams.py --check phase3`
+- **All phases:** omit phase arguments (e.g., `--list` or `--check` alone) to operate on every phase.
+
+Validation will fail if an expected diagram is missing or if the project README does not mention the corresponding asset file. This keeps phase-specific branches focused on complete diagram sets with documented links.

--- a/tools/generate_phase1_diagrams.py
+++ b/tools/generate_phase1_diagrams.py
@@ -1,0 +1,280 @@
+"""Phase-aware diagram inventory and validation helper.
+
+This script groups projects into four phases for diagram-focused work. Use it to
+list the diagram assets expected in each phase and to verify that both the
+Mermaid sources and rendered artifacts are present alongside README references.
+
+Example usage:
+
+    python tools/generate_phase1_diagrams.py --list phase1
+    python tools/generate_phase1_diagrams.py --check phase2 phase3
+
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class DiagramExpectation:
+    """Represents the expected diagram artifacts for a project."""
+
+    name: str
+    relative_files: tuple[str, ...]
+
+    def existing_files(self, base_dir: Path) -> list[Path]:
+        return [base_dir / rel for rel in self.relative_files if (base_dir / rel).exists()]
+
+    def missing_files(self, base_dir: Path) -> list[Path]:
+        return [base_dir / rel for rel in self.relative_files if not (base_dir / rel).exists()]
+
+
+@dataclass(frozen=True)
+class PhaseProject:
+    slug: str
+    base_dir: Path
+    readme: str
+    diagrams: tuple[DiagramExpectation, ...]
+
+    def diagram_summary(self) -> list[str]:
+        summary: list[str] = []
+        for diagram in self.diagrams:
+            summary.append(f"- {diagram.name}: {', '.join(diagram.relative_files)}")
+        return summary
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        for diagram in self.diagrams:
+            missing = diagram.missing_files(self.base_dir)
+            if missing:
+                errors.append(
+                    f"{self.slug} missing files for {diagram.name}: "
+                    + ", ".join(str(path.relative_to(REPO_ROOT)) for path in missing)
+                )
+
+        readme_path = self.base_dir / self.readme
+        if not readme_path.exists():
+            errors.append(f"{self.slug} missing README at {readme_path.relative_to(REPO_ROOT)}")
+        else:
+            content = readme_path.read_text(encoding="utf-8")
+            for diagram in self.diagrams:
+                if not any(rel in content for rel in diagram.relative_files):
+                    errors.append(
+                        f"{self.slug} README missing reference to {diagram.name} diagrams"
+                    )
+        return errors
+
+
+PHASES: dict[str, list[PhaseProject]] = {
+    "phase1": [
+        PhaseProject(
+            slug="PRJ-SDE-001",
+            base_dir=REPO_ROOT / "projects/01-sde-devops/PRJ-SDE-001",
+            readme="README.md",
+            diagrams=(
+                DiagramExpectation(
+                    name="Database infrastructure",
+                    relative_files=(
+                        "assets/diagrams/database-infrastructure.mermaid",
+                        "assets/diagrams/database-infrastructure.md",
+                    ),
+                ),
+            ),
+        ),
+        PhaseProject(
+            slug="PRJ-SDE-002",
+            base_dir=REPO_ROOT / "projects/01-sde-devops/PRJ-SDE-002",
+            readme="README.md",
+            diagrams=(
+                DiagramExpectation(
+                    name="Observability architecture",
+                    relative_files=(
+                        "assets/diagrams/observability-architecture.mermaid",
+                        "assets/diagrams/observability-architecture.md",
+                    ),
+                ),
+            ),
+        ),
+    ],
+    "phase2": [
+        PhaseProject(
+            slug="PRJ-HOME-001",
+            base_dir=REPO_ROOT / "projects/06-homelab/PRJ-HOME-001",
+            readme="README.md",
+            diagrams=(
+                DiagramExpectation(
+                    name="Homelab logical VLAN map",
+                    relative_files=(
+                        "assets/diagrams/logical-vlan-map.mermaid",
+                        "assets/diagrams/logical-vlan-map.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Physical topology",
+                    relative_files=(
+                        "assets/diagrams/physical-topology.mermaid",
+                        "assets/diagrams/physical-topology.md",
+                    ),
+                ),
+            ),
+        ),
+    ],
+    "phase3": [
+        PhaseProject(
+            slug="PRJ-HOME-002",
+            base_dir=REPO_ROOT / "projects/06-homelab/PRJ-HOME-002",
+            readme="README.md",
+            diagrams=(
+                DiagramExpectation(
+                    name="Network topology",
+                    relative_files=(
+                        "assets/diagrams/network-topology.mmd",
+                        "assets/diagrams/network-topology.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Service architecture",
+                    relative_files=(
+                        "assets/diagrams/service-architecture.mmd",
+                        "assets/diagrams/service-architecture.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Virtualization architecture",
+                    relative_files=(
+                        "assets/diagrams/virtualization-architecture.mermaid",
+                        "assets/diagrams/virtualization-architecture.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Monitoring architecture",
+                    relative_files=(
+                        "assets/diagrams/monitoring-architecture.mmd",
+                        "assets/diagrams/monitoring-architecture.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Disaster recovery flow",
+                    relative_files=(
+                        "assets/diagrams/disaster-recovery-flow.mmd",
+                        "assets/diagrams/disaster-recovery-flow.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Backup & recovery",
+                    relative_files=(
+                        "assets/diagrams/backup-recovery.mmd",
+                        "assets/diagrams/backup-recovery.md",
+                    ),
+                ),
+                DiagramExpectation(
+                    name="Data flow",
+                    relative_files=(
+                        "assets/diagrams/data-flow.mmd",
+                        "assets/diagrams/data-flow.md",
+                    ),
+                ),
+            ),
+        ),
+    ],
+    "phase4": [
+        PhaseProject(
+            slug="PRJ-HOME-004",
+            base_dir=REPO_ROOT / "projects/06-homelab/PRJ-HOME-004",
+            readme="README.md",
+            diagrams=(
+                DiagramExpectation(
+                    name="Architecture overview",
+                    relative_files=("assets/diagrams/architecture-overview.mermaid",),
+                ),
+                DiagramExpectation(
+                    name="Firewall policy",
+                    relative_files=("assets/diagrams/firewall-policy.mermaid",),
+                ),
+                DiagramExpectation(
+                    name="Implementation timeline",
+                    relative_files=("assets/diagrams/implementation-timeline.mermaid",),
+                ),
+                DiagramExpectation(
+                    name="Backup strategy",
+                    relative_files=("assets/diagrams/backup-strategy.mermaid",),
+                ),
+                DiagramExpectation(
+                    name="Risk assessment matrix",
+                    relative_files=("assets/diagrams/risk-assessment-matrix.mermaid",),
+                ),
+            ),
+        ),
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        nargs="*",
+        metavar="PHASE",
+        help="List expected diagrams for the given phases (default: all phases)",
+    )
+    parser.add_argument(
+        "--check",
+        nargs="*",
+        metavar="PHASE",
+        help="Validate files and README references for the given phases (default: all phases)",
+    )
+    return parser.parse_args()
+
+
+def _phases_from_args(selected: Iterable[str] | None) -> list[str]:
+    if selected:
+        unknown = sorted(set(selected) - set(PHASES))
+        if unknown:
+            raise SystemExit(f"Unknown phase(s): {', '.join(unknown)}")
+        return list(dict.fromkeys(selected))
+    return list(PHASES)
+
+
+def list_phase(phase: str) -> None:
+    print(f"\n{phase.upper()} — {len(PHASES[phase])} project(s)")
+    for project in PHASES[phase]:
+        print(f"  {project.slug} ({project.base_dir.relative_to(REPO_ROOT)})")
+        for line in project.diagram_summary():
+            print(f"    {line}")
+
+
+def check_phase(phase: str) -> int:
+    failures = 0
+    for project in PHASES[phase]:
+        for error in project.validate():
+            failures += 1
+            print(f"[FAIL] {error}")
+    if failures == 0:
+        print(f"[OK] {phase} diagrams and README references validated")
+    return failures
+
+
+def main() -> None:
+    args = parse_args()
+    list_phases = _phases_from_args(args.list)
+    check_phases = _phases_from_args(args.check)
+
+    if args.list is not None:
+        for phase in list_phases:
+            list_phase(phase)
+
+    if args.check is not None:
+        failures = 0
+        for phase in check_phases:
+            failures += check_phase(phase)
+        if failures:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a phase-scoped diagram inventory/validation script covering phases 1–4
- link each phase project README to its Mermaid and Markdown diagram assets
- refresh the diagram branching notes with phase coverage and helper usage

## Testing
- python tools/generate_phase1_diagrams.py --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dbe7e2a4832781b9e1516dd2e159)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual diagrams to project documentation including infrastructure, observability, topology, and architecture diagrams.
  * Introduced automated diagram validation tool to verify diagram completeness and documentation consistency.

* **Documentation**
  * Added guidance on diagram inventory and validation procedures across project phases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->