### PR TITLE
Add Terratest integration and policy validation suites

### DIFF
--- a/terraform/scripts/validate.sh
+++ b/terraform/scripts/validate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${TERRAFORM_DIR}/.." && pwd)"
+
+print_step() {
+  echo "==> $1"
+}
+
+print_step "Terraform init/validate"
+terraform -chdir="$TERRAFORM_DIR" init -backend=false -input=false
+terraform -chdir="$TERRAFORM_DIR" validate
+
+tfsec_path=$(command -v tfsec || true)
+if [[ -n "$tfsec_path" ]]; then
+  print_step "tfsec scan"
+  tfsec "$TERRAFORM_DIR" --no-color --minimum-severity LOW
+else
+  echo "[warn] tfsec not installed; skipping security scan"
+fi
+
+checkov_path=$(command -v checkov || true)
+if [[ -n "$checkov_path" ]]; then
+  print_step "Checkov scan"
+  checkov -d "$TERRAFORM_DIR" --quiet --framework terraform
+else
+  echo "[warn] Checkov not installed; skipping policy scan"
+fi
+
+pytest_path=$(command -v pytest || true)
+if [[ -n "$pytest_path" ]]; then
+  print_step "pytest validation suite"
+  python -m pytest "$REPO_ROOT/tests/validation" -q
+else
+  echo "[warn] pytest not installed; skipping tests in tests/validation"
+fi
+
+print_step "Validation complete"

--- a/tests/README.md
+++ b/tests/README.md
@@ -155,3 +155,21 @@ pip install -r requirements.txt
 
 These tests are designed to run in CI/CD pipelines and provide rapid feedback on code quality and correctness.
 Tests require pytest>=7.2.0 and pyyaml (already in requirements.txt)
+
+## Integration tests
+
+- `tests/integration/terratest_modules_test.go` contains Terratest suites that provision the VPC, ECS application, and database modules. Tests are protected by the `integration` build tag and require `RUN_TERRATEST=true` plus AWS credentials to run. Execute them with:
+
+```bash
+cd tests/integration
+go test -tags integration -v
+```
+
+## Validation tests
+
+- `tests/validation/` adds Terraform validation and policy-as-code checks (tfsec, Checkov). You can run them directly via pytest or through the helper script:
+
+```bash
+python -m pytest tests/validation -q
+bash terraform/scripts/validate.sh
+```

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -1,0 +1,9 @@
+module portfolio-project/tests/integration
+
+go 1.21
+
+require (
+github.com/aws/aws-sdk-go v1.50.30
+github.com/gruntwork-io/terratest/v2 v2.4.4
+github.com/stretchr/testify v1.8.4
+)

--- a/tests/integration/terratest_modules_test.go
+++ b/tests/integration/terratest_modules_test.go
@@ -1,0 +1,265 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+type vpcDeployment struct {
+	vpcID           string
+	publicSubnets   []string
+	privateSubnets  []string
+	databaseSubnets []string
+}
+
+func requireIntegrationEnv(t *testing.T) (string, string) {
+	t.Helper()
+
+	if os.Getenv("RUN_TERRATEST") == "" {
+		t.Skip("Set RUN_TERRATEST=true to enable live Terraform integration tests")
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+
+	if region == "" {
+		t.Skip("AWS_REGION or AWS_DEFAULT_REGION must be set")
+	}
+
+	return region, fmt.Sprintf("pp-int-%s", strings.ToLower(random.UniqueId()))
+}
+
+func deployVpc(t *testing.T, region, name string) vpcDeployment {
+	t.Helper()
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: filepath.Join("..", "..", "infrastructure", "terraform", "modules", "vpc"),
+		Vars: map[string]interface{}{
+			"project_name":             name,
+			"environment":              "int",
+			"enable_nat_gateway":       false,
+			"single_nat_gateway":       true,
+			"enable_flow_logs":         false,
+			"enable_s3_endpoint":       false,
+			"flow_logs_retention_days": 1,
+			"tags":                     map[string]string{"Owner": "terratest"},
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+		NoColor: true,
+	})
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	deployment := vpcDeployment{
+		vpcID:           terraform.Output(t, terraformOptions, "vpc_id"),
+		publicSubnets:   terraform.OutputList(t, terraformOptions, "public_subnet_ids"),
+		privateSubnets:  terraform.OutputList(t, terraformOptions, "private_subnet_ids"),
+		databaseSubnets: terraform.OutputList(t, terraformOptions, "database_subnet_ids"),
+	}
+
+	t.Cleanup(func() {
+		terraform.Destroy(t, terraformOptions)
+	})
+
+	require.NotEmpty(t, deployment.vpcID)
+	require.NotEmpty(t, deployment.publicSubnets)
+	require.NotEmpty(t, deployment.privateSubnets)
+
+	return deployment
+}
+
+func TestNetworkingModuleProvisioning(t *testing.T) {
+	region, projectName := requireIntegrationEnv(t)
+
+	vpc := deployVpc(t, region, projectName)
+	require.GreaterOrEqual(t, len(vpc.publicSubnets), 1)
+	require.GreaterOrEqual(t, len(vpc.privateSubnets), 1)
+}
+
+func TestEcsModuleAlbAndAutoscaling(t *testing.T) {
+	region, projectName := requireIntegrationEnv(t)
+
+	vpc := deployVpc(t, region, projectName+"-ecs")
+
+	ecsTerraform := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: filepath.Join("..", "..", "infrastructure", "terraform", "modules", "ecs-application"),
+		Vars: map[string]interface{}{
+			"project_name":        projectName,
+			"environment":         "int",
+			"vpc_id":              vpc.vpcID,
+			"public_subnet_ids":   vpc.publicSubnets,
+			"private_subnet_ids":  vpc.privateSubnets,
+			"container_image":     "public.ecr.aws/docker/library/nginx:latest",
+			"container_port":      80,
+			"health_check_path":   "/",
+			"enable_autoscaling":  true,
+			"min_capacity":        1,
+			"max_capacity":        2,
+			"desired_count":       1,
+			"cpu_target_value":    50.0,
+			"memory_target_value": 50.0,
+			"tags": map[string]string{
+				"Owner": "terratest",
+			},
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+		NoColor: true,
+	})
+
+	terraform.InitAndApply(t, ecsTerraform)
+	t.Cleanup(func() {
+		terraform.Destroy(t, ecsTerraform)
+	})
+
+	tgArn := terraform.Output(t, ecsTerraform, "target_group_arn")
+	albDNS := terraform.Output(t, ecsTerraform, "alb_dns_name")
+	autoscalingTarget := terraform.Output(t, ecsTerraform, "autoscaling_target_id")
+
+	require.NotEmpty(t, tgArn)
+	require.NotEmpty(t, albDNS)
+	require.NotEmpty(t, autoscalingTarget)
+
+	sess := awsSession(t, region)
+	assertTargetGroupHealthCheck(t, sess, tgArn, "/")
+	assertAutoscalingWindow(t, sess, autoscalingTarget, 1, 2)
+
+	retry.DoWithRetry(t, "wait-for-alb", 10, 30*time.Second, func() (string, error) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:80", albDNS), 10*time.Second)
+		if err != nil {
+			return "alb not reachable yet", err
+		}
+		defer conn.Close()
+		return "alb reachable", nil
+	})
+}
+
+func TestDatabaseModuleConnectivity(t *testing.T) {
+	region, projectName := requireIntegrationEnv(t)
+	vpc := deployVpc(t, region, projectName+"-db")
+
+	dbTerraform := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: filepath.Join("..", "..", "infrastructure", "terraform", "modules", "database"),
+		Vars: map[string]interface{}{
+			"project_name":               projectName,
+			"environment":                "int",
+			"vpc_id":                     vpc.vpcID,
+			"subnet_ids":                 vpc.databaseSubnets,
+			"db_username":                "terratest",
+			"db_password":                "SuperSecretPass123!",
+			"multi_az":                   false,
+			"backup_retention_period":    1,
+			"skip_final_snapshot":        true,
+			"apply_immediately":          true,
+			"allowed_security_group_ids": []string{},
+			"tags":                       map[string]string{"Owner": "terratest"},
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+		NoColor: true,
+	})
+
+	terraform.InitAndApply(t, dbTerraform)
+	t.Cleanup(func() {
+		terraform.Destroy(t, dbTerraform)
+	})
+
+	endpoint := terraform.Output(t, dbTerraform, "db_endpoint")
+	dbSecurityGroup := terraform.Output(t, dbTerraform, "db_security_group_id")
+
+	require.NotEmpty(t, endpoint)
+	require.NotEmpty(t, dbSecurityGroup)
+
+	sess := awsSession(t, region)
+	assertRdsAvailable(t, sess, endpoint)
+}
+
+func awsSession(t *testing.T, region string) *session.Session {
+	t.Helper()
+
+	sess, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	return sess
+}
+
+func assertTargetGroupHealthCheck(t *testing.T, sess *session.Session, targetGroupArn, expectedPath string) {
+	t.Helper()
+
+	client := elbv2.New(sess)
+	out, err := client.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{TargetGroupArns: aws.StringSlice([]string{targetGroupArn})})
+	require.NoError(t, err)
+	require.Len(t, out.TargetGroups, 1)
+
+	actual := aws.StringValue(out.TargetGroups[0].HealthCheckPath)
+	require.Equal(t, expectedPath, actual)
+}
+
+func assertAutoscalingWindow(t *testing.T, sess *session.Session, targetID string, min, max int64) {
+	t.Helper()
+
+	client := applicationautoscaling.New(sess)
+	out, err := client.DescribeScalableTargets(&applicationautoscaling.DescribeScalableTargetsInput{
+		ResourceIds:       aws.StringSlice([]string{targetID}),
+		ScalableDimension: aws.String("ecs:service:DesiredCount"),
+		ServiceNamespace:  aws.String("ecs"),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.ScalableTargets, 1)
+
+	require.Equal(t, min, aws.Int64Value(out.ScalableTargets[0].MinCapacity))
+	require.Equal(t, max, aws.Int64Value(out.ScalableTargets[0].MaxCapacity))
+}
+
+func assertRdsAvailable(t *testing.T, sess *session.Session, endpoint string) {
+	t.Helper()
+
+	host := endpoint
+	if strings.Contains(endpoint, ":") {
+		parsed, err := url.Parse(fmt.Sprintf("postgres://%s", endpoint))
+		require.NoError(t, err)
+		host = parsed.Hostname()
+	}
+
+	client := rds.New(sess)
+	retry.DoWithRetry(t, "rds-available", 30, 60*time.Second, func() (string, error) {
+		out, err := client.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
+		if err != nil {
+			return "describe", err
+		}
+
+		for _, inst := range out.DBInstances {
+			if strings.Contains(aws.StringValue(inst.Endpoint.Address), host) {
+				if aws.StringValue(inst.DBInstanceStatus) == "available" {
+					return "available", nil
+				}
+				return "waiting", fmt.Errorf("db instance status: %s", aws.StringValue(inst.DBInstanceStatus))
+			}
+		}
+		return "not-found", fmt.Errorf("endpoint %s not present in describe output", host)
+	})
+}

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -1,0 +1,28 @@
+# Terraform validation and policy-as-code checks
+
+This directory houses pytest helpers that run Terraform validation alongside `tfsec` and `Checkov` security scans. These tests are wired into `terraform/scripts/validate.sh` so you can run everything from a single entry point.
+
+## Running the checks directly with pytest
+
+```bash
+python -m pytest tests/validation -q
+```
+
+Tools are optional; each test gracefully skips itself when the required binary is not present.
+
+## Running via the helper script
+
+The preferred way to execute validation locally or in CI is to call:
+
+```bash
+bash terraform/scripts/validate.sh
+```
+
+The script will:
+
+1. Initialize and validate the Terraform configuration under `terraform/`.
+2. Run `tfsec` against the same directory when installed.
+3. Run `Checkov` against the same directory when installed.
+4. Invoke the pytest suite in this folder for consistent reporting.
+
+Set `TF_IN_AUTOMATION=true` (done automatically by pytest) to avoid interactive prompts when running Terraform in CI environments.

--- a/tests/validation/test_policy_scanners.py
+++ b/tests/validation/test_policy_scanners.py
@@ -1,0 +1,40 @@
+"""Policy-as-code checks using tfsec and Checkov."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TERRAFORM_DIR = REPO_ROOT / "terraform"
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(shutil.which("tfsec") is None, reason="tfsec is not installed")
+def test_tfsec_scan() -> None:
+    """Execute tfsec against the root Terraform configuration."""
+
+    result = _run(["tfsec", str(TERRAFORM_DIR), "--no-color", "--minimum-severity", "LOW"])
+    if result.returncode != 0:
+        pytest.fail(result.stdout + result.stderr)
+
+
+@pytest.mark.skipif(shutil.which("checkov") is None, reason="checkov is not installed")
+def test_checkov_scan() -> None:
+    """Execute Checkov against the root Terraform configuration."""
+
+    result = _run(["checkov", "-d", str(TERRAFORM_DIR), "--quiet", "--framework", "terraform"])
+    if result.returncode != 0:
+        pytest.fail(result.stdout + result.stderr)

--- a/tests/validation/test_terraform_validate.py
+++ b/tests/validation/test_terraform_validate.py
@@ -1,0 +1,47 @@
+"""Terraform validation smoke tests for core infrastructure code."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TERRAFORM_DIR = REPO_ROOT / "terraform"
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env={**os.environ, "TF_IN_AUTOMATION": "true"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(shutil.which("terraform") is None, reason="terraform is not installed")
+def test_terraform_init_and_validate() -> None:
+    """Ensure terraform init/validate succeed against the root configuration."""
+
+    init_result = _run([
+        "terraform",
+        f"-chdir={TERRAFORM_DIR}",
+        "init",
+        "-backend=false",
+        "-input=false",
+    ])
+    if init_result.returncode != 0:
+        pytest.fail(init_result.stdout + init_result.stderr)
+
+    validate_result = _run([
+        "terraform",
+        f"-chdir={TERRAFORM_DIR}",
+        "validate",
+    ])
+    if validate_result.returncode != 0:
+        pytest.fail(validate_result.stdout + validate_result.stderr)


### PR DESCRIPTION
## Summary
- add Terratest-based integration coverage for the VPC, ECS application, and database modules, including ALB health check, autoscaling, and RDS availability assertions
- introduce policy-as-code validation tests (terraform validate, tfsec, Checkov) with local README guidance
- wire validations into terraform/scripts/validate.sh and document the new entry points in tests/README.md

## Testing
- python -m pytest tests/validation -q (skipped: missing terraform/tfsec/checkov)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248c6cfc088327b84306437e1e6132)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated validation and testing framework for infrastructure code
  * Added security scanning for Terraform configurations
  * Added integration tests for networking, application, and database modules
  * Added validation test suite with multiple check types

* **Documentation**
  * Added comprehensive test execution and setup guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->