### PR TITLE
Add P02 IAM hardening master factory artifacts

### DIFF
--- a/projects/p02-iam-hardening/master-factory/README.md
+++ b/projects/p02-iam-hardening/master-factory/README.md
@@ -1,0 +1,18 @@
+# P02 IAM Hardening Master Factory
+
+This master factory packages P02 artifacts into an operator-friendly bundle that keeps IAM development focused on least privilege, external-access detection, and unused credential cleanup. It mirrors the P01 master pattern while emphasizing policy lifecycle automation via Access Analyzer, MFA enforcement, and continuous verification.
+
+## Artifact Map
+- `diagrams.md` — Mermaid and ASCII diagrams for system, CI/CD, and IaC flows.
+- `code-prompts.md` — Prompt starter pack for policy authors, reviewers, and platform engineers.
+- `testing-suite.md` — Guidance for running `make setup`, `make validate-policies`, `make policy-diff`, `make simulate`, and `make test` with IAM tooling.
+- `operations.md` — Operational playbook for rollout, rollback, and access hygiene.
+- `reporting.md` — Reporting hooks for surfacing Access Analyzer and MFA health.
+- `observability.md` — Dashboards, alerts, and log signals tied to IAM events.
+- `security.md` — Guardrails that enforce least privilege and MFA-first access.
+- `risk.md` — Risk register with mitigations for policy drift and unused credentials.
+- `adrs.md` — Decision log for IAM automation, MFA checks, and analyzer cadence.
+- `business-narrative.md` — Executive story linking IAM hygiene to audit confidence.
+
+## Usage
+Leverage the prompts to design changes, run the testing suite for validation, and consult operations/reporting docs for rollout. Keep Access Analyzer scans and MFA enforcement wired into CI/CD to prevent privilege creep and external exposure.

--- a/projects/p02-iam-hardening/master-factory/adrs.md
+++ b/projects/p02-iam-hardening/master-factory/adrs.md
@@ -1,0 +1,8 @@
+# Architecture Decision Records — P02 IAM Hardening Master Factory
+
+1. **Access Analyzer as gate:** All policy changes must pass Access Analyzer simulations in CI/CD and IaC flows before release.
+2. **MFA-first posture:** Privileged roles require MFA; automation roles use conditional MFA keys with limited scope.
+3. **Deny by default:** Policies default to deny-all with explicit allow lists; wildcards rejected in `make validate-policies`.
+4. **Automated cleanup:** Scheduled jobs remove unused credentials; failures block release until resolved.
+5. **Diff-driven change control:** `make policy-diff` artifacts are the source of truth for approvals and audits.
+6. **Observability integration:** Access Analyzer, MFA events, and cleanup logs stream to dashboards and alerts to prevent silent drift.

--- a/projects/p02-iam-hardening/master-factory/business-narrative.md
+++ b/projects/p02-iam-hardening/master-factory/business-narrative.md
@@ -1,0 +1,8 @@
+# Business Narrative — P02 IAM Hardening Master Factory
+
+Stakeholders want provable least privilege, rapid detection of external access, and disciplined cleanup of unused credentials. This master factory packages the operating model to deliver that outcome.
+
+- **Audit readiness:** Access Analyzer gating and MFA enforcement ensure every release produces evidence suitable for audits.
+- **Risk reduction:** Automated detection of cross-account/public exposures and swift credential cleanup lowers breach likelihood.
+- **Operational efficiency:** Codified make targets (`setup`, `validate-policies`, `policy-diff`, `simulate`, `test`) keep teams aligned and reduce manual IAM reviews.
+- **Business continuity:** Clear rollback and alerting paths mean IAM changes no longer jeopardize uptime or compliance windows.

--- a/projects/p02-iam-hardening/master-factory/code-prompts.md
+++ b/projects/p02-iam-hardening/master-factory/code-prompts.md
@@ -1,0 +1,19 @@
+# Code Prompts — P02 IAM Hardening Master Factory
+
+Use these prompts when collaborating with AI or reviewers to keep IAM work aligned with least privilege, Access Analyzer feedback, MFA enforcement, and unused credential cleanup.
+
+## Policy Authoring
+- "Generate an IAM policy that grants only the minimum S3 actions for the listed prefixes; include session MFA requirements and note how `make simulate` will validate it against Access Analyzer findings."
+- "Rewrite this wildcard-heavy policy into least-privilege statements, then outline the expected `make validate-policies` and `make policy-diff` outputs before merging."
+
+## Access Analyzer and MFA Checks
+- "Given the Access Analyzer report, propose policy updates that remove external access while keeping automation working; show how to verify via `make simulate` and MFA test hooks."
+- "Suggest automated cleanups for unused IAM roles/keys and describe how `make test` should assert the cleanup jobs run with MFA enforced."
+
+## CI/CD and IaC
+- "Describe the CI/CD gate that runs `make setup`, `make validate-policies`, `make policy-diff`, and `make simulate`; ensure Access Analyzer and MFA checks block promotion until clean."
+- "For a Terraform change, produce a plan review script that maps IAM resources to Access Analyzer scans and flags any changes that weaken least privilege before `terraform apply`."
+
+## Operational Guardrails
+- "Draft rollback steps that reapply the last known-good IAM bundle, rerun `make validate-policies`, and confirm MFA enforcement for break-glass roles."
+- "Propose monitoring queries that detect external access introductions and unused credentials, and describe how they feed `reporting.md` KPIs."

--- a/projects/p02-iam-hardening/master-factory/diagrams-ascii.md
+++ b/projects/p02-iam-hardening/master-factory/diagrams-ascii.md
@@ -1,0 +1,34 @@
+# Diagram Appendix (ASCII) — P02 IAM Hardening Master Factory
+
+ASCII renditions complement the Mermaid diagrams to support quick reviews in terminals and tickets.
+
+## System Flow
+```
+[Engineer]
+   |
+   v
+[Policy PR] -> (make validate-policies) -> (make simulate) -> [Access Analyzer]
+                                                   |                 |
+                                                   |<-- fixes ------+
+                                                   v
+                                           [MFA enforcement]
+                                                   |
+                                   [Observability + Reporting]
+                                                   |
+                                   [Unused credential cleanup]
+```
+
+## CI/CD Flow
+```
+Repo -> CI `make setup`
+        -> `make validate-policies`
+        -> `make policy-diff`
+        -> `make simulate` -> Access Analyzer -> MFA tests -> Approval -> Release
+```
+
+## IaC Flow
+```
+IaC templates -> Lint -> `make validate-policies` -> `make policy-diff` -> `make simulate`
+        -> Terraform plan -> Access Analyzer -> MFA session enforcement -> Apply
+        -> External access detection -> Credential cleanup -> Metrics/Alerts
+```

--- a/projects/p02-iam-hardening/master-factory/diagrams.md
+++ b/projects/p02-iam-hardening/master-factory/diagrams.md
@@ -1,0 +1,74 @@
+# Diagrams — P02 IAM Hardening Master Factory
+
+The following diagrams visualize the IAM policy lifecycle with Access Analyzer scans, MFA enforcement, and automation triggers across system, CI/CD, and IaC delivery paths.
+
+## System Flow (Mermaid)
+```mermaid
+graph TD
+  Dev[Engineer] --> PR[Policy PR]
+  PR --> CI[Make validate-policies]
+  CI --> Sim[Make simulate]
+  Sim --> AA[Access Analyzer Scan]
+  AA --> Decision{Diff Clean?}
+  Decision -- No --> Fix[Refine Policy]
+  Decision -- Yes --> Deploy[Apply to IAM]
+  Deploy --> MFA[MFA Enforcement Check]
+  MFA --> Monitor[Observability Alerts]
+  Monitor --> Cleanup[Unused Credential Cleanup]
+  Cleanup --> Report[Reporting Feed]
+  Report --> Risk[Risk Register Update]
+```
+
+## System Flow (ASCII)
+```
+Engineer -> Policy PR -> make validate-policies -> make simulate -> Access Analyzer
+      |                                                                |
+      +----< fixes if diff/misaligned >----+                           v
+                                     Apply to IAM -> MFA check -> Observability
+                                                            |                
+                                            Unused credential cleanup -> Reporting -> Risk log
+```
+
+## CI/CD Flow (Mermaid)
+```mermaid
+graph LR
+  Code[Repo Policies] --> Actions[CI Pipeline]
+  Actions --> Setup[make setup]
+  Setup --> Validate[make validate-policies]
+  Validate --> Diff[make policy-diff]
+  Diff --> Simulate[make simulate]
+  Simulate --> AA[Access Analyzer Gate]
+  AA --> MFA[MFA Policy Test]
+  MFA --> Approve[Auto/Manual Approval]
+  Approve --> Release[Tagged Release]
+  Release --> Notify[Chat/Email Notifications]
+```
+
+## CI/CD Flow (ASCII)
+```
+Repo -> CI (make setup -> validate-policies -> policy-diff -> simulate) -> Access Analyzer gate -> MFA policy test
+      -> approval -> release -> notifications
+```
+
+## IaC Flow (Mermaid)
+```mermaid
+graph TD
+  Template[IaC Templates] --> Lint[Schema/Lint]
+  Lint --> Validate[make validate-policies]
+  Validate --> Diff[make policy-diff]
+  Diff --> Sim[make simulate]
+  Sim --> Plan[Terraform Plan with IAM]
+  Plan --> AA[Access Analyzer Pre-apply]
+  AA --> Enforce[MFA Session Enforcement]
+  Enforce --> Apply[Terraform Apply]
+  Apply --> Detect[External Access Detection]
+  Detect --> Cleanup[Automated Credential Cleanup]
+  Cleanup --> Metrics[Observability + Reporting]
+```
+
+## IaC Flow (ASCII)
+```
+IaC templates -> lint -> make validate-policies -> make policy-diff -> make simulate -> terraform plan
+        -> Access Analyzer pre-apply -> MFA session enforcement -> apply
+        -> external access detection -> automated credential cleanup -> metrics/reporting
+```

--- a/projects/p02-iam-hardening/master-factory/observability.md
+++ b/projects/p02-iam-hardening/master-factory/observability.md
@@ -1,0 +1,19 @@
+# Observability — P02 IAM Hardening Master Factory
+
+Observability captures IAM signals that prove least privilege, detect external access, and surface unused credential cleanup.
+
+## Dashboards
+- **Policy Health:** Access Analyzer findings by severity, mapped to repositories and IaC stacks.
+- **MFA Enforcement:** Success/failure counts for MFA-required role sessions; trends by environment.
+- **Credential Hygiene:** Number of disabled keys/roles per week; age distribution before cleanup.
+
+## Alerts
+- High/medium Access Analyzer findings emitted during `make simulate` or pipeline runs.
+- MFA enforcement failures on privileged roles or automation identities.
+- Detection of new external principals or public bucket policies in `make policy-diff` outputs.
+- Cleanup job failures or backlog growth beyond SLA.
+
+## Logging and Tracing
+- Centralize IAM change logs, Access Analyzer exports, and MFA enforcement events.
+- Tag logs with PR/commit IDs to trace lineage back to code changes.
+- Emit structured events from cleanup scripts to power reporting metrics.

--- a/projects/p02-iam-hardening/master-factory/operations.md
+++ b/projects/p02-iam-hardening/master-factory/operations.md
@@ -1,0 +1,22 @@
+# Operations — P02 IAM Hardening Master Factory
+
+Operational runbook for sustaining IAM least privilege, detecting external access, and cleaning unused credentials.
+
+## Rollout
+- Use feature branches with `make validate-policies` and `make simulate` gating merges.
+- Require Access Analyzer green status and MFA test pass before tagging a release.
+- Deploy via automation that logs every IAM change and triggers `reporting.md` pipelines.
+
+## Rollback
+- Keep a last-known-good policy bundle; reapply and rerun `make policy-diff` to confirm parity.
+- Re-enable MFA enforcement controls and revoke temporary exceptions.
+- Trigger Access Analyzer rescans to ensure no residual external access.
+
+## Hygiene and Cleanup
+- Schedule weekly unused credential sweeps; disable keys older than policy thresholds and document in `reporting.md`.
+- Review cross-account accesses flagged by Access Analyzer; quarantine unexpected principals.
+- Rotate automation role credentials with MFA session enforcement.
+
+## Operational Alerts
+- Promote observability alerts for Access Analyzer high/medium findings and MFA failures (see `observability.md`).
+- Route cleanup job results to incident channels with runbooks attached.

--- a/projects/p02-iam-hardening/master-factory/reporting.md
+++ b/projects/p02-iam-hardening/master-factory/reporting.md
@@ -1,0 +1,20 @@
+# Reporting — P02 IAM Hardening Master Factory
+
+Reporting focuses on least privilege adherence, external-access detection, and unused credential cleanup efficacy.
+
+## Key Metrics
+- **Access Analyzer findings:** Count and severity trend; time-to-remediate after `make simulate` fails.
+- **MFA enforcement coverage:** Percentage of privileged roles requiring MFA; number of MFA enforcement failures per release.
+- **External access drift:** New cross-account/public resources detected per sprint.
+- **Unused credential cleanup:** Disabled/removed keys and roles per cycle; time idle before cleanup.
+
+## Data Sources
+- `make policy-diff` artifacts for change deltas and access expansions.
+- Access Analyzer reports exported from CI/CD and IaC pipelines.
+- MFA test harness outputs from `make test` and enforcement hooks.
+- Cleanup job logs (keys/roles) forwarded by observability pipelines.
+
+## Delivery Cadence
+- Weekly dashboards to engineering and security leads.
+- Release-level summaries attached to change tickets with Access Analyzer/MFA status.
+- Quarterly audit packet including ADR excerpts, risk register, and remediation performance.

--- a/projects/p02-iam-hardening/master-factory/risk.md
+++ b/projects/p02-iam-hardening/master-factory/risk.md
@@ -1,0 +1,11 @@
+# Risk Register — P02 IAM Hardening Master Factory
+
+Risks focus on drift from least privilege, unnoticed external access, and stale credentials.
+
+| Risk | Impact | Mitigation | Owner |
+| --- | --- | --- | --- |
+| Access Analyzer disabled or misconfigured | External access goes undetected | CI/CD guard requiring successful `make simulate`; observability alert on missing scans | Platform Security |
+| MFA enforcement bypassed | Privileged access without MFA | Session policies deny non-MFA; test harness in `make test`; manual checks during releases | IAM Ops |
+| Wildcard/overbroad policies merged | Privilege creep and audit findings | Policy linting in `make validate-policies`; mandatory reviewer sign-off; ADR for exceptions | Engineering Leads |
+| Unused credentials linger | Increased compromise surface | Scheduled cleanup jobs with reports; `reporting.md` tracks MTTR; automation disables keys | Identity Engineering |
+| Policy drift between IaC and runtime | Inconsistent access | `make policy-diff` in pipelines; drift alerts in observability; rollback steps in `operations.md` | Platform SRE |

--- a/projects/p02-iam-hardening/master-factory/security.md
+++ b/projects/p02-iam-hardening/master-factory/security.md
@@ -1,0 +1,18 @@
+# Security — P02 IAM Hardening Master Factory
+
+Security guardrails concentrate on enforcing least privilege, eliminating external-access drift, and ensuring MFA-first operations.
+
+## Controls
+- Mandatory Access Analyzer scans on every `make simulate` and pre-apply IaC run.
+- MFA required for privileged roles; session policies enforce MFA for console and CLI access.
+- Deny statements for wildcard actions and unknown principals by default.
+- Automated disablement of unused credentials with alerting.
+
+## Reviews
+- PR checklist ties to `make validate-policies` and `make policy-diff` outputs.
+- CI gates block merges when Access Analyzer reports high/medium findings or MFA enforcement fails.
+- Quarterly control review to refresh policy baselines and cleanup thresholds.
+
+## Exceptions
+- Break-glass roles documented with time-bounded approvals; Access Analyzer rescans post-use.
+- Exceptions must include remediation plans and test evidence stored in `reporting.md`.

--- a/projects/p02-iam-hardening/master-factory/testing-suite.md
+++ b/projects/p02-iam-hardening/master-factory/testing-suite.md
@@ -1,0 +1,21 @@
+# Testing Suite — P02 IAM Hardening Master Factory
+
+Use the existing Make targets to validate IAM changes end-to-end. Align every run to least privilege, external-access detection, and unused credential cleanup.
+
+## Workflow
+1. `make setup` — Install IAM tooling (linters, Access Analyzer helpers, MFA test harnesses).
+2. `make validate-policies` — Static validation for least-privilege structure, including deny-by-default checks.
+3. `make policy-diff` — Compare generated policies against deployed state; flag new external principals or broader actions.
+4. `make simulate` — Run Access Analyzer simulations and MFA enforcement tests against staged policies.
+5. `make test` — Execute integration tests for cleanup jobs (unused keys/roles), policy attachments, and analyzer alert routing.
+
+## Test Scenarios
+- **Least privilege enforcement:** Assert no wildcards remain after diff; simulate should return zero high-risk findings.
+- **External access detection:** Ensure Access Analyzer reports fail CI when new cross-account or public access appears.
+- **MFA enforcement:** Validate that privileged roles demand MFA sessions and automation roles use conditional keys.
+- **Unused credential cleanup:** Confirm scheduled jobs identify and disable aged keys and unused roles, with reports emitted.
+
+## Evidence Collection
+- Archive `make policy-diff` outputs for auditing.
+- Export Access Analyzer findings and MFA test logs to observability dashboards (see `observability.md`).
+- Include failing scenarios in `reporting.md` to track MTTR for IAM hygiene.


### PR DESCRIPTION
## Summary
- add master-factory documentation set for P02 IAM hardening mirroring P01 pattern
- include mermaid and ASCII diagrams covering system, CI/CD, and IaC policy lifecycle automation
- provide prompts, testing guidance, and operational/security/risk docs aligned to least privilege and MFA/Access Analyzer goals

## Testing
- not run (documentation changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248237667c8327b77986a506ddb18f)