### PR TITLE
Update SAM build example to avoid Docker requirement

### DIFF
--- a/projects/7-serverless-data-processing/README.md
+++ b/projects/7-serverless-data-processing/README.md
@@ -58,7 +58,7 @@ docker run --rm \
 Because the container entrypoint is `sam`, you can override the command for other workflows, for example to build or package artefacts:
 
 ```bash
-docker run --rm -v "$(pwd):/app" serverless-data-platform build --use-container
+docker run --rm -v "$(pwd):/app" serverless-data-platform build
 ```
 
 ## Operations


### PR DESCRIPTION
## Summary
- update the serverless data processing README to remove the `--use-container` flag from the SAM build example
- keep the container workflow runnable without requiring Docker inside the image

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd3f46214832781be8f7a1295fecc)