### PR TITLE
Add exported SVG diagrams for Phase 1 projects

### DIFF
--- a/projects/1-aws-infrastructure-automation/README.md
+++ b/projects/1-aws-infrastructure-automation/README.md
@@ -15,3 +15,10 @@ This project provisions a production-ready AWS environment with multiple impleme
 - `scripts/` — Helper scripts for planning, deployment, validation, and teardown workflows.
 
 Each implementation aligns with the runbooks described in the Wiki.js guide so the documentation, automation, and validation steps can be exercised end-to-end.
+
+## Architecture Diagram
+
+- ![AWS infrastructure automation architecture](assets/diagrams/architecture.svg)
+- [Mermaid source](assets/diagrams/architecture.mmd)
+
+**ADR Note:** Trust boundaries separate developer tooling, CI/OIDC deployers, and the AWS account; the IaC toolchain remains interchangeable (Terraform/CDK/Pulumi) while converging on the same VPC, EKS, and RDS foundation.

--- a/projects/1-aws-infrastructure-automation/assets/diagrams/architecture.mmd
+++ b/projects/1-aws-infrastructure-automation/assets/diagrams/architecture.mmd
@@ -1,0 +1,58 @@
+%% AWS Infrastructure Automation - Architecture
+flowchart LR
+    subgraph Dev[Developer & Repo]
+        DEV[Engineer Workstation]
+        GH[GitHub Repo]
+        DEV --> GH
+    end
+
+    subgraph CI[CI Pipeline]
+        ACTIONS[GitHub Actions]
+        PLAN[Plan & Validate]
+        SECURITY[tfsec/SCA]
+        ARTIFACTS[Plans, Stack Artifacts]
+        ACTIONS --> PLAN --> SECURITY --> ARTIFACTS
+    end
+
+    subgraph IaC[Infrastructure as Code Toolchain]
+        TF[Terraform Modules]
+        CDK[AWS CDK App]
+        PULUMI[Pulumi Stack]
+    end
+
+    subgraph AWS[Secure AWS Account]
+        subgraph VPC[Multi-AZ VPC]
+            PUB[Public Subnets]
+            PRIV[Private App Subnets]
+            DB[Database Subnets]
+        end
+        EKS[EKS Control Plane]
+        NODES[Managed Node Groups]
+        RDS[RDS PostgreSQL]
+        ALB[Application Load Balancer]
+        BACKUP[Snapshots/Backups]
+    end
+
+    GH --> ACTIONS
+    ARTIFACTS --> TF
+    ARTIFACTS --> CDK
+    ARTIFACTS --> PULUMI
+
+    TF --> VPC
+    CDK --> VPC
+    PULUMI --> VPC
+
+    VPC --> EKS
+    EKS --> NODES
+    NODES --> ALB
+    VPC --> RDS
+    RDS --> BACKUP
+
+    classDef trust fill:#eef,stroke:#335;
+    class Dev,CI,IaC,AWS trust;
+
+    %% Data flows
+    ACTIONS -- OIDC Deploy --> AWS
+    NODES -- Service Traffic --> ALB
+    Apps((Workloads)) --> NODES
+    Apps --> RDS

--- a/projects/1-aws-infrastructure-automation/assets/diagrams/architecture.svg
+++ b/projects/1-aws-infrastructure-automation/assets/diagrams/architecture.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" width="1200" height="720" aria-labelledby="title desc">
+  <title id="title">AWS Infrastructure Automation Architecture</title>
+  <desc id="desc">Trust boundaries for developer tools, CI, IaC toolchains, and AWS foundations with data flows.</desc>
+  <style>
+    .boundary { fill: #eef3ff; stroke: #335; stroke-width: 2; }
+    .box { fill: #fff; stroke: #333; stroke-width: 1.5; rx: 6; ry: 6; }
+    .label { font: 14px sans-serif; fill: #111; }
+    .title { font: 16px sans-serif; font-weight: bold; fill: #111; }
+    .arrow { stroke: #444; stroke-width: 1.5; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" fill="#444">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+  <rect class="boundary" x="40" y="40" width="220" height="260" />
+  <text class="title" x="60" y="70">Developer &amp; Repo</text>
+  <rect class="box" x="70" y="100" width="170" height="60" />
+  <text class="label" x="90" y="135">Engineer Workstation</text>
+  <rect class="box" x="70" y="180" width="170" height="60" />
+  <text class="label" x="110" y="215">GitHub Repo</text>
+
+  <rect class="boundary" x="320" y="40" width="230" height="260" />
+  <text class="title" x="340" y="70">CI Pipeline</text>
+  <rect class="box" x="350" y="100" width="170" height="50" />
+  <text class="label" x="395" y="130">GitHub Actions</text>
+  <rect class="box" x="350" y="160" width="170" height="45" />
+  <text class="label" x="382" y="188">Plan &amp; Validate</text>
+  <rect class="box" x="350" y="210" width="170" height="45" />
+  <text class="label" x="384" y="238">tfsec / SCA</text>
+  <rect class="box" x="350" y="260" width="170" height="35" />
+  <text class="label" x="362" y="284">Plans &amp; Artifacts</text>
+
+  <rect class="boundary" x="600" y="40" width="240" height="260" />
+  <text class="title" x="620" y="70">IaC Toolchain</text>
+  <rect class="box" x="630" y="100" width="180" height="60" />
+  <text class="label" x="678" y="135">Terraform</text>
+  <rect class="box" x="630" y="180" width="180" height="40" />
+  <text class="label" x="685" y="206">AWS CDK</text>
+  <rect class="box" x="630" y="230" width="180" height="40" />
+  <text class="label" x="690" y="256">Pulumi</text>
+
+  <rect class="boundary" x="880" y="40" width="260" height="620" />
+  <text class="title" x="900" y="70">Secure AWS Account</text>
+  <rect class="box" x="900" y="100" width="220" height="120" />
+  <text class="label" x="940" y="130">Multi-AZ VPC</text>
+  <text class="label" x="920" y="155">Public / Private / DB subnets</text>
+  <rect class="box" x="940" y="180" width="140" height="30" />
+  <text class="label" x="970" y="200">EKS Control Plane</text>
+  <rect class="box" x="940" y="220" width="140" height="30" />
+  <text class="label" x="970" y="240">Managed Nodes</text>
+  <rect class="box" x="940" y="260" width="140" height="30" />
+  <text class="label" x="975" y="280">Application LB</text>
+  <rect class="box" x="940" y="300" width="140" height="30" />
+  <text class="label" x="980" y="320">RDS Postgres</text>
+  <rect class="box" x="940" y="340" width="140" height="30" />
+  <text class="label" x="975" y="360">Snapshots / Backup</text>
+
+  <text class="title" x="440" y="350">Data Flows</text>
+  <line class="arrow" x1="240" y1="210" x2="320" y2="210" />
+  <line class="arrow" x1="550" y1="210" x2="630" y2="210" />
+  <line class="arrow" x1="820" y1="210" x2="880" y2="210" />
+  <line class="arrow" x1="1020" y1="330" x2="1020" y2="365" />
+  <line class="arrow" x1="1020" y1="150" x2="1020" y2="175" />
+  <line class="arrow" x1="1020" y1="175" x2="1020" y2="205" />
+  <line class="arrow" x1="1020" y1="205" x2="1020" y2="235" />
+  <line class="arrow" x1="1020" y1="235" x2="1020" y2="265" />
+  <line class="arrow" x1="1020" y1="265" x2="1020" y2="295" />
+  <text class="label" x="250" y="195">Push commits</text>
+  <text class="label" x="390" y="195">OIDC deploy</text>
+  <text class="label" x="680" y="195">Plans applied</text>
+  <text class="label" x="1040" y="348" transform="rotate(90 1040 348)">Backups</text>
+
+  <circle cx="840" cy="520" r="70" fill="#f6f6ff" stroke="#335" stroke-width="2" />
+  <text class="title" x="795" y="500">Workloads</text>
+  <text class="label" x="780" y="520">Ingress via ALB</text>
+  <text class="label" x="780" y="540">Reads/Writes to RDS</text>
+</svg>

--- a/projects/2-database-migration/README.md
+++ b/projects/2-database-migration/README.md
@@ -5,3 +5,10 @@ Change data capture service enabling zero-downtime migrations between PostgreSQL
 ## Highlights
 - Debezium connector configurations stored under `config/`.
 - Python orchestrator coordinates cutover, validation, and rollback steps (`src/migration_orchestrator.py`).
+
+## Architecture Diagram
+
+- ![Database migration architecture](assets/diagrams/architecture.svg)
+- [Mermaid source](assets/diagrams/architecture.mmd)
+
+**ADR Note:** Debezium/Kafka and AWS DMS run inside a dedicated migration control plane, with the orchestrator owning cutover, rollback, and CloudWatch/SNS signaling while isolating source and target PostgreSQL trust boundaries.

--- a/projects/2-database-migration/assets/diagrams/architecture.mmd
+++ b/projects/2-database-migration/assets/diagrams/architecture.mmd
@@ -1,0 +1,44 @@
+%% Database Migration Platform - Architecture
+flowchart LR
+    subgraph Src[Source Environment]
+        SRCDB[(PostgreSQL Primary)]
+        SRCAPP[Source App]
+        SRCAPP --> SRCDB
+    end
+
+    subgraph Control[Migration Control Plane]
+        ORCH[Migration Orchestrator]
+        METRICS[CloudWatch Metrics]
+        ALERTS[SNS/Email Alerts]
+        ORCH --> METRICS
+        ORCH --> ALERTS
+    end
+
+    subgraph CDC[CDC & Replication]
+        DEBEZIUM[Debezium Connector]
+        KAFKA[Kafka Connect]
+        DMS[AWS DMS Task]
+    end
+
+    subgraph Tgt[Target Environment]
+        TGTDB[(Target PostgreSQL)]
+        TGTAPP[Target App]
+        TGTAPP --> TGTDB
+    end
+
+    SRCDB -- Change Stream --> DEBEZIUM
+    DEBEZIUM -- Events --> KAFKA
+    KAFKA -- Replicated Changes --> DMS
+    DMS -- Apply Changes --> TGTDB
+    ORCH -- Control & Validation --> DEBEZIUM
+    ORCH -- Configure --> DMS
+    ORCH -- Health Checks --> TGTDB
+    ORCH -- Readiness --> SRCDB
+
+    classDef trust fill:#f3f7ff,stroke:#345;
+    class Src,CDC,Control,Tgt trust;
+
+    %% Data flow notes
+    SRCDB -- Cutover Approval --> ORCH
+    ORCH -- Rollback Path --> SRCDB
+    ORCH -- Final Sync --> TGTDB

--- a/projects/2-database-migration/assets/diagrams/architecture.svg
+++ b/projects/2-database-migration/assets/diagrams/architecture.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" width="1200" height="720" aria-labelledby="title desc">
+  <title id="title">Database Migration Architecture</title>
+  <desc id="desc">Online migration flow with source Postgres, migration runner, cutover, and observability.</desc>
+  <style>
+    .boundary { fill: #eef3ff; stroke: #335; stroke-width: 2; }
+    .box { fill: #fff; stroke: #333; stroke-width: 1.5; rx: 6; ry: 6; }
+    .label { font: 14px sans-serif; fill: #111; }
+    .title { font: 16px sans-serif; font-weight: bold; fill: #111; }
+    .arrow { stroke: #444; stroke-width: 1.5; marker-end: url(#arrowhead); }
+    .dashed { stroke-dasharray: 6 4; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" fill="#444">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+  <rect class="boundary" x="40" y="40" width="260" height="260" />
+  <text class="title" x="60" y="70">Source Environment</text>
+  <rect class="box" x="70" y="100" width="200" height="60" />
+  <text class="label" x="110" y="135">Legacy App</text>
+  <rect class="box" x="70" y="180" width="200" height="60" />
+  <text class="label" x="105" y="215">PostgreSQL (On-Prem)</text>
+
+  <rect class="boundary" x="340" y="40" width="260" height="260" />
+  <text class="title" x="360" y="70">Migration Runner</text>
+  <rect class="box" x="370" y="100" width="200" height="40" />
+  <text class="label" x="400" y="125">Schema Diff &amp; DDL</text>
+  <rect class="box" x="370" y="150" width="200" height="40" />
+  <text class="label" x="408" y="175">Data Pump / DMS</text>
+  <rect class="box" x="370" y="200" width="200" height="40" />
+  <text class="label" x="392" y="225">pglogical / CDC</text>
+  <rect class="box" x="370" y="250" width="200" height="40" />
+  <text class="label" x="415" y="275">Cutover Orchestrator</text>
+
+  <rect class="boundary" x="640" y="40" width="240" height="260" />
+  <text class="title" x="660" y="70">Target Cloud</text>
+  <rect class="box" x="670" y="100" width="180" height="40" />
+  <text class="label" x="690" y="125">AWS RDS Postgres</text>
+  <rect class="box" x="670" y="150" width="180" height="40" />
+  <text class="label" x="705" y="175">Proxy / App Nodes</text>
+  <rect class="box" x="670" y="200" width="180" height="40" />
+  <text class="label" x="714" y="225">Backups &amp; PITR</text>
+
+  <rect class="boundary" x="920" y="40" width="220" height="260" />
+  <text class="title" x="940" y="70">Observability</text>
+  <rect class="box" x="950" y="100" width="160" height="40" />
+  <text class="label" x="980" y="125">Grafana</text>
+  <rect class="box" x="950" y="150" width="160" height="40" />
+  <text class="label" x="978" y="175">Prometheus</text>
+  <rect class="box" x="950" y="200" width="160" height="40" />
+  <text class="label" x="986" y="225">Alertmanager</text>
+
+  <text class="title" x="80" y="340">Data Flows</text>
+  <line class="arrow" x1="270" y1="210" x2="340" y2="210" />
+  <text class="label" x="270" y="195">Logical/Full dumps</text>
+  <line class="arrow" x1="600" y1="210" x2="640" y2="210" />
+  <text class="label" x="560" y="195">CDC + DDL</text>
+  <line class="arrow" x1="820" y1="170" x2="920" y2="170" />
+  <text class="label" x="830" y="155">Metrics / Alerts</text>
+  <line class="arrow" x1="520" y1="120" x2="670" y2="120" class="dashed" />
+  <text class="label" x="540" y="105">Pilot sync</text>
+  <line class="arrow" x1="520" y1="260" x2="670" y2="260" class="dashed" />
+  <text class="label" x="535" y="245">Cutover window</text>
+
+  <rect class="box" x="200" y="420" width="280" height="120" fill="#f8fff2" stroke="#4a6" />
+  <text class="title" x="220" y="450">Guardrails</text>
+  <text class="label" x="220" y="475">- Preflight checks &amp; dry runs</text>
+  <text class="label" x="220" y="495">- Rollback scripts</text>
+  <text class="label" x="220" y="515">- Dual write feature flags</text>
+</svg>

--- a/projects/23-advanced-monitoring/README.md
+++ b/projects/23-advanced-monitoring/README.md
@@ -7,3 +7,10 @@ Unified observability stack with Prometheus, Tempo, Loki, and Grafana dashboards
 - `dashboards/portfolio.json` – Grafana dashboard visualizing SLOs, burn rates, and release markers.
 - `alerts/portfolio_rules.yml` – Prometheus alerting rules with time-windowed burn rate calculations.
 - `manifests/` – Kustomize overlays for staging/production clusters.
+
+## Architecture Diagram
+
+- ![Advanced monitoring architecture](assets/diagrams/architecture.svg)
+- [Mermaid source](assets/diagrams/architecture.mmd)
+
+**ADR Note:** Observability data stays inside the cluster boundary via OTel Collector and Promtail before flowing into Prometheus, Loki, Tempo, and Grafana; Alertmanager fans out to ChatOps while dashboards stay read-only for operators.

--- a/projects/23-advanced-monitoring/assets/diagrams/architecture.mmd
+++ b/projects/23-advanced-monitoring/assets/diagrams/architecture.mmd
@@ -1,0 +1,51 @@
+%% Advanced Monitoring & Observability - Architecture
+flowchart LR
+    subgraph Services[Portfolio Services]
+        APP1[Apps & APIs]
+        EXPORTERS[Prometheus Exporters]
+        LOGS[App Logs]
+        TRACES[Otel Instrumentation]
+        APP1 --> EXPORTERS
+        APP1 --> LOGS
+        APP1 --> TRACES
+    end
+
+    subgraph Collectors[Data Collection Boundary]
+        OTECOL[OpenTelemetry Collector]
+        PROMTAIL[Promtail]
+    end
+
+    subgraph Stack[Observability Stack]
+        PROM[Prometheus]
+        LOKI[Loki]
+        TEMPO[Tempo]
+        ALERTMGR[Alertmanager]
+        GRAFANA[Grafana]
+    end
+
+    subgraph Consumers[Consumers]
+        DASH[Dashboards]
+        ONCALL[On-call / ChatOps]
+    end
+
+    EXPORTERS --> OTECOL
+    TRACES --> OTECOL
+    LOGS --> PROMTAIL
+
+    OTECOL --> PROM
+    OTECOL --> TEMPO
+    PROMTAIL --> LOKI
+
+    PROM --> ALERTMGR
+    PROM --> GRAFANA
+    LOKI --> GRAFANA
+    TEMPO --> GRAFANA
+
+    GRAFANA --> DASH
+    ALERTMGR --> ONCALL
+
+    classDef trust fill:#eef5ff,stroke:#335;
+    class Services,Collectors,Stack,Consumers trust;
+
+    %% Data flows
+    ONCALL -- Feedback & Runbooks --> APP1

--- a/projects/23-advanced-monitoring/assets/diagrams/architecture.svg
+++ b/projects/23-advanced-monitoring/assets/diagrams/architecture.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" width="1200" height="720" aria-labelledby="title desc">
+  <title id="title">Advanced Monitoring and Observability Architecture</title>
+  <desc id="desc">Cluster telemetry path through collectors, storage backends, dashboards, and alerting.</desc>
+  <style>
+    .boundary { fill: #eef3ff; stroke: #335; stroke-width: 2; }
+    .box { fill: #fff; stroke: #333; stroke-width: 1.5; rx: 6; ry: 6; }
+    .label { font: 14px sans-serif; fill: #111; }
+    .title { font: 16px sans-serif; font-weight: bold; fill: #111; }
+    .arrow { stroke: #444; stroke-width: 1.5; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" fill="#444">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+  <rect class="boundary" x="60" y="60" width="260" height="280" />
+  <text class="title" x="80" y="90">Cluster Boundary</text>
+  <rect class="box" x="90" y="120" width="200" height="60" />
+  <text class="label" x="120" y="155">Workloads</text>
+  <rect class="box" x="90" y="190" width="200" height="60" />
+  <text class="label" x="118" y="225">OpenTelemetry SDKs</text>
+  <rect class="box" x="90" y="260" width="200" height="60" />
+  <text class="label" x="130" y="295">Promtail DaemonSet</text>
+
+  <rect class="boundary" x="360" y="60" width="220" height="280" />
+  <text class="title" x="380" y="90">In-Cluster Collectors</text>
+  <rect class="box" x="390" y="120" width="160" height="50" />
+  <text class="label" x="425" y="150">OTel Collector</text>
+  <rect class="box" x="390" y="190" width="160" height="50" />
+  <text class="label" x="425" y="220">Prometheus</text>
+  <rect class="box" x="390" y="260" width="160" height="50" />
+  <text class="label" x="440" y="290">Alertmanager</text>
+
+  <rect class="boundary" x="640" y="60" width="220" height="280" />
+  <text class="title" x="660" y="90">Storage Backends</text>
+  <rect class="box" x="670" y="120" width="160" height="50" />
+  <text class="label" x="710" y="150">Tempo</text>
+  <rect class="box" x="670" y="190" width="160" height="50" />
+  <text class="label" x="713" y="220">Loki</text>
+  <rect class="box" x="670" y="260" width="160" height="50" />
+  <text class="label" x="700" y="290">Prometheus TSDB</text>
+
+  <rect class="boundary" x="920" y="60" width="220" height="280" />
+  <text class="title" x="940" y="90">Visualization</text>
+  <rect class="box" x="950" y="120" width="170" height="70" />
+  <text class="label" x="980" y="155">Grafana Dashboards</text>
+  <rect class="box" x="950" y="210" width="170" height="70" />
+  <text class="label" x="975" y="245">SLOs &amp; Burn Rates</text>
+
+  <text class="title" x="120" y="380">Data Flows</text>
+  <line class="arrow" x1="290" y1="150" x2="360" y2="150" />
+  <text class="label" x="260" y="135">Traces / Metrics</text>
+  <line class="arrow" x1="290" y1="220" x2="360" y2="220" />
+  <text class="label" x="262" y="205">Metrics scrape</text>
+  <line class="arrow" x1="290" y1="290" x2="360" y2="290" />
+  <text class="label" x="270" y="275">Logs</text>
+  <line class="arrow" x1="580" y1="150" x2="640" y2="150" />
+  <text class="label" x="560" y="135">OTLP</text>
+  <line class="arrow" x1="580" y1="220" x2="640" y2="220" />
+  <text class="label" x="565" y="205">Remote write</text>
+  <line class="arrow" x1="580" y1="290" x2="640" y2="290" />
+  <text class="label" x="572" y="275">Alerts / silence</text>
+  <line class="arrow" x1="860" y1="150" x2="920" y2="150" />
+  <text class="label" x="865" y="135">Dashboards</text>
+  <line class="arrow" x1="860" y1="220" x2="920" y2="220" />
+  <text class="label" x="865" y="205">Alerts to ChatOps</text>
+
+  <rect class="box" x="220" y="450" width="760" height="160" fill="#f8fff2" stroke="#4a6" />
+  <text class="title" x="240" y="480">Trust Boundaries</text>
+  <text class="label" x="240" y="505">1) Workloads &amp; log agents remain inside the cluster; 2) Collectors enforce tenant limits; 3) Storage</text>
+  <text class="label" x="240" y="525">endpoints exposed via mTLS; 4) Dashboards read-only for operators; 5) Alert fan-out limited to ChatOps and</text>
+  <text class="label" x="240" y="545">PagerDuty.</text>
+</svg>

--- a/projects/3-kubernetes-cicd/README.md
+++ b/projects/3-kubernetes-cicd/README.md
@@ -5,3 +5,10 @@ Declarative delivery pipeline with GitHub Actions, ArgoCD, and progressive deliv
 ## Contents
 - `pipelines/github-actions.yaml` — build/test/deploy workflow.
 - `pipelines/argocd-app.yaml` — GitOps application manifest.
+
+## Architecture Diagram
+
+- ![Kubernetes CI/CD architecture](assets/diagrams/architecture.svg)
+- [Mermaid source](assets/diagrams/architecture.mmd)
+
+**ADR Note:** GitHub Actions builds and scans images before ArgoCD syncs manifests from the registry into dev → staging → production clusters using progressive delivery policies, preserving clear trust boundaries between CI, registry, and runtime.

--- a/projects/3-kubernetes-cicd/assets/diagrams/architecture.mmd
+++ b/projects/3-kubernetes-cicd/assets/diagrams/architecture.mmd
@@ -1,0 +1,54 @@
+%% Kubernetes CI/CD Pipeline - Architecture
+flowchart LR
+    subgraph Dev[Developer Boundary]
+        DEV[Engineer]
+        REPO[GitHub Repo]
+        DEV --> REPO
+    end
+
+    subgraph CI[CI/CD Boundary]
+        ACTIONS[GitHub Actions]
+        BUILD[Build & Test]
+        SCAN[Security Scan]
+        IMAGE[Container Image]
+        ACTIONS --> BUILD --> SCAN --> IMAGE
+    end
+
+    subgraph REG[Registry]
+        REGISTRY[(Container Registry)]
+    end
+
+    subgraph CD[GitOps Control]
+        ARGO[ArgoCD]
+        POLICIES[Sync Policies]
+    end
+
+    subgraph Clusters[Runtime Clusters]
+        subgraph DEV[Dev Cluster]
+            DEVAPP[App Dev]
+        end
+        subgraph STG[Staging Cluster]
+            STGAPP[App Staging]
+        end
+        subgraph PRD[Prod Cluster]
+            PRDAPP[App Prod]
+            CANARY[Canary/Blue-Green]
+        end
+    end
+
+    REPO --> ACTIONS
+    IMAGE --> REGISTRY
+    REGISTRY --> ARGO
+    ARGO --> DEVAPP
+    DEVAPP -- Promote --> STGAPP
+    STGAPP -- Progressive Delivery --> CANARY
+    CANARY -- Roll Forward --> PRDAPP
+    ARGO --> POLICIES
+
+    classDef trust fill:#eef7ff,stroke:#345;
+    class Dev,CI,REG,CD,Clusters trust;
+
+    %% Data flows
+    ACTIONS -- Manifests --> ARGO
+    ARGO -- Health/Sync --> ACTIONS
+    DEVAPP -- Metrics/Logs --> ACTIONS

--- a/projects/3-kubernetes-cicd/assets/diagrams/architecture.svg
+++ b/projects/3-kubernetes-cicd/assets/diagrams/architecture.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" width="1200" height="720" aria-labelledby="title desc">
+  <title id="title">Kubernetes CI/CD Architecture</title>
+  <desc id="desc">Pipeline from developers through CI, container registry, Kubernetes clusters, and monitoring.</desc>
+  <style>
+    .boundary { fill: #eef3ff; stroke: #335; stroke-width: 2; }
+    .box { fill: #fff; stroke: #333; stroke-width: 1.5; rx: 6; ry: 6; }
+    .label { font: 14px sans-serif; fill: #111; }
+    .title { font: 16px sans-serif; font-weight: bold; fill: #111; }
+    .arrow { stroke: #444; stroke-width: 1.5; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" fill="#444">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+  <rect class="boundary" x="40" y="40" width="230" height="200" />
+  <text class="title" x="60" y="70">Developers</text>
+  <rect class="box" x="70" y="100" width="170" height="50" />
+  <text class="label" x="105" y="130">GitOps Repos</text>
+  <rect class="box" x="70" y="160" width="170" height="50" />
+  <text class="label" x="103" y="190">Dockerfiles</text>
+
+  <rect class="boundary" x="310" y="40" width="240" height="200" />
+  <text class="title" x="330" y="70">CI System</text>
+  <rect class="box" x="340" y="100" width="180" height="45" />
+  <text class="label" x="375" y="128">GitHub Actions</text>
+  <rect class="box" x="340" y="150" width="180" height="45" />
+  <text class="label" x="358" y="178">Lint / Build / Test</text>
+
+  <rect class="boundary" x="590" y="40" width="200" height="200" />
+  <text class="title" x="610" y="70">Registry</text>
+  <rect class="box" x="620" y="100" width="150" height="45" />
+  <text class="label" x="650" y="128">OCI Images</text>
+  <rect class="box" x="620" y="150" width="150" height="45" />
+  <text class="label" x="635" y="178">SBOM &amp; Signatures</text>
+
+  <rect class="boundary" x="840" y="40" width="320" height="300" />
+  <text class="title" x="860" y="70">Kubernetes Clusters</text>
+  <rect class="box" x="870" y="100" width="260" height="60" />
+  <text class="label" x="900" y="130">Staging (Kustomize)</text>
+  <rect class="box" x="870" y="170" width="260" height="60" />
+  <text class="label" x="905" y="200">Production (ArgoCD)</text>
+  <rect class="box" x="870" y="240" width="260" height="60" />
+  <text class="label" x="920" y="270">Ingress + Services</text>
+
+  <rect class="boundary" x="640" y="320" width="360" height="240" />
+  <text class="title" x="660" y="350">Monitoring</text>
+  <rect class="box" x="670" y="380" width="300" height="45" />
+  <text class="label" x="720" y="408">Prometheus / Loki / Tempo</text>
+  <rect class="box" x="670" y="430" width="300" height="45" />
+  <text class="label" x="760" y="458">Grafana Dashboards</text>
+  <rect class="box" x="670" y="480" width="300" height="45" />
+  <text class="label" x="760" y="508">Alertmanager</text>
+
+  <text class="title" x="80" y="280">Data Flows</text>
+  <line class="arrow" x1="270" y1="140" x2="310" y2="140" />
+  <text class="label" x="270" y="125">Push / PR</text>
+  <line class="arrow" x1="550" y1="140" x2="590" y2="140" />
+  <text class="label" x="515" y="125">Build &amp; Scan</text>
+  <line class="arrow" x1="790" y1="140" x2="840" y2="140" />
+  <text class="label" x="760" y="125">Deploy via GitOps</text>
+  <line class="arrow" x1="1000" y1="300" x2="1000" y2="320" />
+  <text class="label" x="1015" y="312">Logs/metrics</text>
+  <line class="arrow" x1="820" y1="420" x2="870" y2="230" />
+  <text class="label" x="780" y="380">SLO feedback</text>
+</svg>

--- a/projects/4-devsecops/README.md
+++ b/projects/4-devsecops/README.md
@@ -4,3 +4,10 @@ Security-first CI pipeline with SBOM generation, container scanning, and policy 
 
 ## Contents
 - `pipelines/github-actions.yaml` — orchestrates build, security scanning, and deployment gates.
+
+## Architecture Diagram
+
+- ![DevSecOps pipeline architecture](assets/diagrams/architecture.svg)
+- [Mermaid source](assets/diagrams/architecture.mmd)
+
+**ADR Note:** Security controls run inside the CI trust boundary (SAST, SCA, secrets, SBOM, DAST) before signed artifacts are promoted to a trusted registry and admission controls enforce policy in runtime clusters.

--- a/projects/4-devsecops/assets/diagrams/architecture.mmd
+++ b/projects/4-devsecops/assets/diagrams/architecture.mmd
@@ -1,0 +1,43 @@
+%% DevSecOps Pipeline - Architecture
+flowchart LR
+    subgraph Dev[Developer Workspace]
+        DEV[Engineer]
+        REPO[Source Repo]
+        DEV --> REPO
+    end
+
+    subgraph CI[CI Security Boundary]
+        ACTIONS[GitHub Actions]
+        SAST[Semgrep/Bandit]
+        SCA[Trivy/Snyk]
+        SECRETS[Gitleaks/TruffleHog]
+        SBOM[Syft SBOM]
+        DAST[OWASP ZAP]
+        GATES[Policy as Code]
+        ACTIONS --> SAST --> SCA --> SECRETS --> SBOM --> DAST --> GATES
+    end
+
+    subgraph Artifacts[Trusted Registry]
+        REGISTRY[(Image Registry)]
+        REPORTS[[Security Reports]]
+    end
+
+    subgraph Deploy[Deployment Boundary]
+        CLUSTER[(Kubernetes/Runtime)]
+        ADMISSION[Admission Controls]
+    end
+
+    REPO --> ACTIONS
+    GATES -- Signed Artifacts --> REGISTRY
+    SBOM --> REPORTS
+    DAST --> REPORTS
+    REGISTRY --> ADMISSION
+    ADMISSION --> CLUSTER
+
+    classDef trust fill:#f5f7ff,stroke:#345;
+    class Dev,CI,Artifacts,Deploy trust;
+
+    %% Data flows
+    ACTIONS -- SARIF --> REPORTS
+    GATES -- Gate Status --> ACTIONS
+    CLUSTER -- Runtime Scan Events --> REPORTS

--- a/projects/4-devsecops/assets/diagrams/architecture.svg
+++ b/projects/4-devsecops/assets/diagrams/architecture.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" width="1200" height="720" aria-labelledby="title desc">
+  <title id="title">DevSecOps Architecture</title>
+  <desc id="desc">Security controls in CI/CD pipelines with artifact hardening, policy gates, and runtime protections.</desc>
+  <style>
+    .boundary { fill: #eef3ff; stroke: #335; stroke-width: 2; }
+    .box { fill: #fff; stroke: #333; stroke-width: 1.5; rx: 6; ry: 6; }
+    .label { font: 14px sans-serif; fill: #111; }
+    .title { font: 16px sans-serif; font-weight: bold; fill: #111; }
+    .arrow { stroke: #444; stroke-width: 1.5; marker-end: url(#arrowhead); }
+    .dashed { stroke-dasharray: 6 4; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" fill="#444">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+  <rect class="boundary" x="40" y="40" width="240" height="240" />
+  <text class="title" x="60" y="70">Developer</text>
+  <rect class="box" x="70" y="100" width="180" height="50" />
+  <text class="label" x="90" y="130">Repo &amp; Branch Policies</text>
+  <rect class="box" x="70" y="170" width="180" height="50" />
+  <text class="label" x="96" y="200">Secrets Management</text>
+
+  <rect class="boundary" x="320" y="40" width="240" height="240" />
+  <text class="title" x="340" y="70">CI Security</text>
+  <rect class="box" x="350" y="100" width="180" height="45" />
+  <text class="label" x="368" y="128">SAST / Secrets scan</text>
+  <rect class="box" x="350" y="150" width="180" height="45" />
+  <text class="label" x="378" y="178">SCA / SBOM</text>
+  <rect class="box" x="350" y="200" width="180" height="45" />
+  <text class="label" x="375" y="228">Policy as Code</text>
+
+  <rect class="boundary" x="600" y="40" width="230" height="240" />
+  <text class="title" x="620" y="70">Build &amp; Supply Chain</text>
+  <rect class="box" x="630" y="100" width="170" height="45" />
+  <text class="label" x="670" y="128">Image Build</text>
+  <rect class="box" x="630" y="150" width="170" height="45" />
+  <text class="label" x="640" y="178">Signing / Attestations</text>
+  <rect class="box" x="630" y="200" width="170" height="45" />
+  <text class="label" x="668" y="228">Registry Policies</text>
+
+  <rect class="boundary" x="880" y="40" width="260" height="240" />
+  <text class="title" x="900" y="70">Runtime</text>
+  <rect class="box" x="910" y="100" width="200" height="45" />
+  <text class="label" x="970" y="128">Admission</text>
+  <rect class="box" x="910" y="150" width="200" height="45" />
+  <text class="label" x="950" y="178">Network Policy</text>
+  <rect class="box" x="910" y="200" width="200" height="45" />
+  <text class="label" x="970" y="228">Runtime IDS</text>
+
+  <rect class="boundary" x="200" y="340" width="760" height="260" />
+  <text class="title" x="220" y="370">Feedback &amp; Governance</text>
+  <rect class="box" x="230" y="400" width="320" height="60" />
+  <text class="label" x="250" y="435">Dashboards (SIEM, Grafana, Security Hub)</text>
+  <rect class="box" x="230" y="470" width="320" height="60" />
+  <text class="label" x="252" y="505">Alerts to ChatOps + PagerDuty</text>
+  <rect class="box" x="570" y="400" width="360" height="130" />
+  <text class="label" x="590" y="430">Continuous Compliance (CIS / SOC2)</text>
+  <text class="label" x="590" y="450">Drift detection &amp; waivers</text>
+  <text class="label" x="590" y="470">Release gates via OPA/Rego</text>
+
+  <text class="title" x="80" y="310">Flows</text>
+  <line class="arrow" x1="280" y1="140" x2="320" y2="140" />
+  <text class="label" x="270" y="125">PR checks</text>
+  <line class="arrow" x1="560" y1="140" x2="600" y2="140" />
+  <text class="label" x="540" y="125">Scan results</text>
+  <line class="arrow" x1="830" y1="140" x2="880" y2="140" />
+  <text class="label" x="790" y="125">Signed images</text>
+  <line class="arrow" x1="1010" y1="280" x2="1010" y2="340" class="dashed" />
+  <text class="label" x="1020" y="315">Runtime events</text>
+  <line class="arrow" x1="420" y1="470" x2="420" y2="340" />
+  <text class="label" x="430" y="365">Ticketing</text>
+</svg>


### PR DESCRIPTION
## Summary
- add rendered SVG exports for the Phase 1 architecture diagrams
- keep diagram sources in Mermaid and linkable README references untouched
- ensure each project folder now includes a viewable architecture graphic

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924838b4efc8327a633b70e74ad32e2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive architecture diagrams and architectural decision records across five projects (AWS Infrastructure Automation, Database Migration, Advanced Monitoring, Kubernetes CI/CD, and DevSecOps). Diagrams provide visual representations of system design, component interactions, and trust boundaries; decision records document architectural choices for infrastructure and deployment workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->