### PR TITLE
Expand master factory prompt startup guidance

### DIFF
--- a/AI_PROMPT_EXECUTION_FRAMEWORK.md
+++ b/AI_PROMPT_EXECUTION_FRAMEWORK.md
@@ -6,6 +6,7 @@
 **Part 2:** `AI_PROMPT_LIBRARY_MEDIUM_LOW.md` (Medium & Low prompts)
 
 This playbook covers execution strategies, quality control, and best practices so every AI-assisted deliverable ships production-ready.
+It inherits the behavior rules in `docs/MASTER_FACTORY_PROMPT.md`, meaning **every prompt run must yield a complete, runnable deliverable** (code, config, sample data, and documentation) from the very first response.
 
 ---
 
@@ -22,11 +23,11 @@ This framework is the operational handbook for maximizing AI productivity. It ex
 
 ## 🎯 Core Execution Principles
 
-### Principle 1: Treat Prompts Like Code
-- Be explicit: context, requirements, constraints, examples
-- Show desired format and style
+### Principle 1: Treat Prompts Like Code (Deliverable-First)
+- Be explicit: context, requirements, constraints, examples, and the runnable artifact list (code/config/data/docs)
+- Show desired format and style, including directory map and entry points
 - Include negative examples (what to avoid)
-- Iterate on prompts based on output quality
+- Iterate on prompts based on output quality and whether the output can execute immediately
 
 ### Principle 2: Iterate Relentlessly
 1. Generate first draft
@@ -70,15 +71,20 @@ This framework is the operational handbook for maximizing AI productivity. It ex
 4. Apply consistent polish (tone, formatting)
 5. Commit documents together
 
-### Prompt Template Structure
+### Prompt Template Structure (runnable by default)
 ```
-Create a production-ready README for {{PROJECT_NAME}}.
+Create a production-ready README for {{PROJECT_NAME}} and ship runnable artifacts.
 
 PROJECT DETAILS:
 - Purpose: {{PURPOSE}}
 - Tech stack: {{TECH_STACK}}
 - Key metrics: {{METRICS}}
 - Target audience: {{AUDIENCE}}
+
+DELIVERABLES:
+- File map with entry points (e.g., README.md, scripts/run.sh, docs/usage.md)
+- Sample or synthetic data to execute the main path
+- Exact run instructions and validation steps
 
 [Standard instructions continue...]
 ```
@@ -101,6 +107,8 @@ terraform fmt -check && terraform validate
 yamllint k8s/**/*.yaml
 pytest
 ```
+
+For each run, verify the deliverable checklist from `docs/MASTER_FACTORY_PROMPT.md` is satisfied: runnable code with entry points, configuration and secrets guidance, sample data, documentation, and execution notes.
 
 Set up `.pre-commit-config.yaml` to run linting automatically before each commit.
 
@@ -161,7 +169,13 @@ Track usage in a spreadsheet (date, task, tool, prompt ID, time spent, quality r
 
 ---
 
-## ✅ Final Publishing Checklist
+## ✅ Final Publishing Checklist (aligned to Master Factory)
+
+**Deliverable-first**
+- [ ] Code includes runnable entry points and minimal tests where applicable
+- [ ] Configuration/env var guidance provided; secrets externalized
+- [ ] Sample/synthetic data present to execute the happy path
+- [ ] Documentation covers setup, run, and validation commands
 
 **Technical**
 - [ ] Code/commands tested

--- a/AI_PROMPT_LIBRARY.md
+++ b/AI_PROMPT_LIBRARY.md
@@ -11,8 +11,10 @@
 
 ## 📋 How to Use This Document
 
-### Prompt Structure
-Each prompt follows this format:
+All prompts in this library must comply with the behavior rules in `docs/MASTER_FACTORY_PROMPT.md`: ship **complete, runnable deliverables** starting with the first response. Every request should produce code, configuration, sample data, and usage notes—not just prompt drafts.
+
+### Prompt Structure (deliverable-first)
+Each prompt follows this format and is expected to emit runnable assets:
 ```
 PROMPT ID: [Unique identifier]
 PURPOSE: [What this generates]
@@ -20,17 +22,19 @@ PRIORITY: [Critical/High/Medium/Low]
 TIME SAVINGS: [Hours saved vs manual creation]
 AI TOOL: [Claude/ChatGPT/Gemini - which works best]
 INPUT REQUIRED: [What you need to provide]
+DELIVERABLES: [Code/config/data/docs expected in the response]
+RUN INSTRUCTIONS: [Exact commands or steps to execute the deliverable]
 OUTPUT: [What you'll receive]
 PROMPT: [The actual prompt to use]
-POST-PROCESSING: [How to refine the output]
+POST-PROCESSING: [How to refine the output and validate it]
 ```
 
 ### Workflow
 1. **Select by priority** - Start with Critical, work down
 2. **Batch similar prompts** - Do all READMEs together, all diagrams together
 3. **Quality check immediately** - Review AI output while context is fresh
-4. **Iterate if needed** - Refine prompts based on first results
-5. **Track completion** - Check off each prompt as you use it
+4. **Iterate if needed** - Refine prompts based on first results and keep the outputs runnable
+5. **Track completion** - Check off each prompt as you use it, confirming the deliverable checklist from `docs/MASTER_FACTORY_PROMPT.md`
 
 ---
 

--- a/AI_PROMPT_LIBRARY_MEDIUM_LOW.md
+++ b/AI_PROMPT_LIBRARY_MEDIUM_LOW.md
@@ -2,9 +2,21 @@
 
 ## Complete Guide to Portfolio Enhancement (Part 2 of 3)
 
-**Part 1:** See `AI_PROMPT_LIBRARY.md` for Critical & High priority prompts  
-**Part 2:** This document (Medium & Low priorities)  
+**Part 1:** See `AI_PROMPT_LIBRARY.md` for Critical & High priority prompts
+**Part 2:** This document (Medium & Low priorities)
 **Part 3:** See `AI_PROMPT_EXECUTION_FRAMEWORK.md` for execution strategies
+
+All prompts must follow `docs/MASTER_FACTORY_PROMPT.md` behavior rules: produce full, runnable deliverables (code, config, sample data, docs) from the first response. Include run commands, entry points, and validation steps in every output.
+
+### Deliverable-First Prompt Template
+```
+PROMPT ID: [Unique identifier]
+PURPOSE: [What this generates]
+DELIVERABLES: [Code/config/data/docs emitted in the response]
+RUN INSTRUCTIONS: [Commands to run and validate]
+PROMPT: [The actual prompt text]
+POST-PROCESSING: [How to polish and test]
+```
 
 ---
 

--- a/docs/MASTER_FACTORY_PROMPT.md
+++ b/docs/MASTER_FACTORY_PROMPT.md
@@ -1,0 +1,36 @@
+# Master Factory Prompt
+
+## Purpose
+This document defines the default behavior rules for any factory-style prompt execution within the portfolio. It clarifies what "done" means so downstream users request and deliver complete, runnable outputs rather than intermediary prompt snippets.
+
+## Behavior Rules
+- **Produce complete deliverables.** Responses must include everything required for a working solution: runnable code, configuration, supporting data samples, and user-facing documentation or instructions. Start assembling these artifacts in the very first response instead of deferring to “future work.”
+- **Do not stop at prompt drafts.** If a user asks for a prompt, also supply the fully realized assets (code, data, docs) that the prompt would produce so the requester can execute immediately.
+- **Assume execution-ready outputs.** Provide file names, directory structure, and any commands necessary to run or validate the generated solution.
+- **Document dependencies.** Call out runtime requirements, environment variables, secrets, and install steps so the deliverable can be reproduced without guesswork.
+- **Align with safety and compliance.** Preserve security, privacy, and licensing considerations in all generated assets, noting any constraints or required approvals.
+
+## Code Generation Expectations
+- Default to **generating full, runnable code** (not pseudocode) that compiles or executes as written, including entry points, configuration, and test coverage when applicable.
+- When templates or placeholders are unavoidable, mark them explicitly and explain how to replace them so the final output remains runnable.
+- Prefer **concrete examples and sample data** that exercise the code paths and demonstrate expected behavior.
+- Include concise **run instructions** (e.g., commands, scripts, or API calls) and, when appropriate, minimal tests to validate correctness.
+- Structure the response so files can be copied directly into a repository with minimal manual stitching.
+- Proactively surface **next actions** (e.g., “seed the database with sample_rows.csv before running `npm start`”) so downstream owners can continue execution without new prompts.
+
+## Deliverable Startup Recipe
+- Begin each engagement by proposing a minimal, runnable scaffold. Include:
+  - A directory map (e.g., `src/`, `tests/`, `config/`, `docs/`).
+  - Named entry points (scripts, services, or notebooks) with brief role descriptions.
+  - At least one sample data file or inline fixture that demonstrates expected input/output.
+  - A short README snippet that explains setup and a single “happy path” run command.
+- If the request is broad, ship a **first working slice** (e.g., one endpoint, one pipeline stage, or one UI route) so users can execute something immediately while you elaborate further.
+
+## Deliverable Checklist for Downstream Users
+- [ ] Source code with clear entry points and comments where necessary.
+- [ ] Configuration files, environment variable references, and secret management guidance.
+- [ ] Sample or synthetic data sufficient to run the solution end-to-end.
+- [ ] Documentation explaining setup, execution, and verification steps.
+- [ ] Notes on performance, security, and compliance considerations specific to the deliverable.
+
+Following these rules ensures factory prompts yield production-ready assets, reducing rework and ambiguity for downstream teams.


### PR DESCRIPTION
## Summary
- require deliverables to start in the initial response and include next-step guidance
- add a deliverable startup recipe covering scaffolds, entry points, sample data, and run instructions

## Testing
- not run; documentation-only changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f075dbd5c8327ac627a3f86a52d54)