### PR TITLE
Add deliverable-first guidance to AI prompt template

### DIFF
--- a/AI_PROMPT_LIBRARY.md
+++ b/AI_PROMPT_LIBRARY.md
@@ -2,17 +2,19 @@
 
 ## Complete Guide to Using AI for GitHub Portfolio Enhancement
 
-**Purpose:** Actionable AI prompts to generate every missing component  
-**Target:** github.com/samueljackson-collab/Portfolio-Project  
-**Status:** 35% of work remaining can be AI-generated  
+**Purpose:** Actionable AI prompts to generate every missing component
+**Target:** github.com/samueljackson-collab/Portfolio-Project
+**Status:** 35% of work remaining can be AI-generated
 **Estimated Time Savings:** 80-100 hours with AI assistance
+
+All prompts must follow the Master Factory behavior rules and the Deliverable Startup Recipe to produce runnable artifacts on the first iteration—complete code, sample data, and execution commands alongside the narrative prompt content.
 
 ---
 
 ## 📋 How to Use This Document
 
 ### Prompt Structure
-Each prompt follows this format:
+Each prompt follows this format and must enforce deliverable-ready outputs from the first iteration:
 ```
 PROMPT ID: [Unique identifier]
 PURPOSE: [What this generates]
@@ -20,8 +22,9 @@ PRIORITY: [Critical/High/Medium/Low]
 TIME SAVINGS: [Hours saved vs manual creation]
 AI TOOL: [Claude/ChatGPT/Gemini - which works best]
 INPUT REQUIRED: [What you need to provide]
-OUTPUT: [What you'll receive]
-PROMPT: [The actual prompt to use]
+DELIVERABLE EXPECTATIONS: [Code files, sample data, run commands; cite Master Factory behavior rules + Deliverable Startup Recipe]
+OUTPUT: [What you'll receive, including runnable artifacts and documentation]
+PROMPT: [The actual prompt to use with deliverable-first instructions]
 POST-PROCESSING: [How to refine the output]
 ```
 
@@ -31,6 +34,7 @@ POST-PROCESSING: [How to refine the output]
 3. **Quality check immediately** - Review AI output while context is fresh
 4. **Iterate if needed** - Refine prompts based on first results
 5. **Track completion** - Check off each prompt as you use it
+6. **Enforce deliverables** - Every run must produce code, sample data, and executable instructions aligned to the Master Factory behavior rules and Deliverable Startup Recipe so artifacts are runnable immediately.
 
 ---
 


### PR DESCRIPTION
## Summary
- add deliverable-first expectations to prompt library intro referencing Master Factory behavior rules and Deliverable Startup Recipe
- update prompt structure template to require runnable artifacts, sample data, and run commands
- extend workflow guidance to enforce deliverable-ready outputs from initial iteration

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f10ead0808327873f784f93aeea75)