### PR TITLE
Add ADRs for observability and policy distribution

### DIFF
--- a/projects-new/P11-ZERO-TRUST-SECURITY/docs/adrs/ADR-004.md
+++ b/projects-new/P11-ZERO-TRUST-SECURITY/docs/adrs/ADR-004.md
@@ -1,0 +1,25 @@
+# ADR-004: Observability Stack Selection
+
+**Status:** Accepted  
+**Date:** 2025-06-06
+
+## Context
+The Zero Trust Security platform must provide end-to-end visibility into authentication flows, policy evaluation, and service-to-service traffic across heterogeneous runtimes (VMs, containers, serverless). The observability solution needs to instrument data plane proxies and control-plane services uniformly, correlate events for incident response, and remain vendor-neutral for on-prem and cloud deployments. It should support high-cardinality labels (e.g., tenant, workload, policy version), enforce transport encryption, and minimize per-service configuration overhead.
+
+## Decision
+Adopt an OpenTelemetry-first observability stack with the following components:
+- **Instrumentation:** Use OpenTelemetry SDKs and sidecar auto-instrumentation for services, plus Envoy/ingress exporters to emit metrics, traces, and logs via OTLP over mTLS.
+- **Collection & Processing:** Deploy the OpenTelemetry Collector as a tiered pipeline (node-level agents plus regional gateways) to normalize, redact sensitive fields, and route signals.
+- **Storage & Visualization:** Persist metrics in Prometheus-compatible storage (e.g., Cortex/Thanos for HA), traces in Tempo, and logs in Loki, all visualized through Grafana dashboards and alerts.
+- **Governance:** Enforce schema and label conventions via collector processors and CI checks on dashboard/alert definitions stored as code.
+
+## Alternatives
+- **Vendor APM suite (proprietary agent):** Simplifies setup but reduces portability, increases licensing costs, and limits deep integration with custom policy metadata.
+- **Metrics-only stack (Prometheus + Alertmanager):** Lower operational cost but lacks distributed tracing for policy decision latency analysis and cross-service causality.
+- **Push-based logging without centralized schema control:** Easiest to adopt but risks inconsistent fields, weak correlation across signals, and higher MTTR.
+
+## Consequences
+- Enables consistent, encrypted telemetry export across all workloads with minimal app code changes.
+- Provides rich correlation (metrics/logs/traces) for policy debugging, threat hunting, and SLO tracking.
+- Increases platform footprint (collectors, storage backends) and requires capacity planning plus runbooks for multi-tenant scaling.
+- Relies on disciplined label governance; drift can degrade query performance and alert quality.

--- a/projects-new/P11-ZERO-TRUST-SECURITY/docs/adrs/ADR-005.md
+++ b/projects-new/P11-ZERO-TRUST-SECURITY/docs/adrs/ADR-005.md
@@ -1,0 +1,24 @@
+# ADR-005: Policy Distribution Approach
+
+**Status:** Accepted  
+**Date:** 2025-06-06
+
+## Context
+Zero Trust enforcement points (sidecars, gateways, and host agents) require consistent, auditable policy updates across regions and trust zones. Policies must be versioned, signed, and quickly rolled out with safe rollback while minimizing downtime and preventing stale configurations. The distribution mechanism must operate over mutually authenticated channels and support intermittent connectivity in edge locations.
+
+## Decision
+Use a **pull-based policy distribution model** backed by signed bundles:
+- Author and store policies (e.g., OPA/Rego, RBAC, routing rules) in a Git repository; CI pipelines sign immutable bundles and publish them to an OCI-compatible registry.
+- Enforcement agents poll a regional control plane over mTLS to fetch the latest bundle manifest, download bundles from the registry, verify signatures, and hot-reload policies atomically.
+- The control plane exposes version metadata and health endpoints for observability and orchestrates staged rollouts (canary then global) via feature flags.
+
+## Alternatives
+- **Push-based distribution via message bus:** Faster fan-out but requires persistent connectivity, complicates idempotency, and increases blast radius for bad updates.
+- **Config management tooling (e.g., Ansible/Puppet) for policies:** Familiar ops tooling but slower convergence, limited fine-grained rollout control, and heavier agents on minimal footprints.
+- **Manual updates at gateways:** Lowest complexity but unscalable, error-prone, and incompatible with audit/compliance needs.
+
+## Consequences
+- Pull + signed bundles reduce reliance on continuous connectivity while providing strong integrity guarantees.
+- Staged rollout support lowers risk of outages from policy regressions and simplifies rollback.
+- Requires operating an OCI registry and control-plane APIs with HA; registry unavailability can delay updates (agents must cache last-known-good bundles).
+- Adds CI/CD steps for signing and publishing, increasing pipeline complexity but improving compliance posture.


### PR DESCRIPTION
## Summary
- add ADR-004 describing the observability stack for the zero trust security platform
- add ADR-005 documenting the pull-based, signed policy distribution model

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9ee3fe548327bee5b6d15ad4ea9b)