### PR TITLE
Improve Docker build for p09 cloud native POC

### DIFF
--- a/projects/p09-cloud-native-poc/.dockerignore
+++ b/projects/p09-cloud-native-poc/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore local environment and build artifacts
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.pytest_cache
+htmlcov
+coverage.xml
+*.log
+*.sqlite
+
+# VCS and editor settings
+.git
+.gitignore
+*.swp
+.idea
+.vscode
+
+# Dependency caches
+node_modules
+*.egg-info
+build
+dist

--- a/projects/p09-cloud-native-poc/docker/Dockerfile
+++ b/projects/p09-cloud-native-poc/docker/Dockerfile
@@ -18,11 +18,11 @@ RUN useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
 
 # Copy dependencies from builder
-COPY --from=builder /root/.local /home/appuser/.local
+COPY --from=builder --chown=appuser:appuser /root/.local /home/appuser/.local
 
 # Copy application code
-COPY src/ ./src/
-COPY tests/ ./tests/
+COPY --chown=appuser:appuser src/ ./src/
+COPY --chown=appuser:appuser tests/ ./tests/
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
## Summary
- add a .dockerignore to avoid sending virtualenv and build artifacts to the Docker daemon
- ensure Docker build copies files with the correct ownership for the non-root runtime user

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fb1ef29c83278e0d73f8244ee912)