### PR TITLE
Make resource tiles interactive with centralized links

### DIFF
--- a/src/components/EnterpriseWiki.tsx
+++ b/src/components/EnterpriseWiki.tsx
@@ -3,12 +3,14 @@ import {
   enterpriseWikiIcons,
   roleContent,
   roleThemes,
+  resourceCards,
   roles,
 } from './enterpriseWikiData';
 import type {
   RoleDefinition,
   RoleKey,
   RoleTheme,
+  ResourceLink,
   WeekPlan,
 } from './enterpriseWikiData';
 
@@ -266,21 +268,28 @@ const EnterpriseWiki: React.FC = () => {
             {activeWeek && <WeekDetail week={activeWeek} theme={currentTheme} />}
 
             <div className="grid md:grid-cols-3 gap-4 mt-6">
-              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
-                <Code className="w-8 h-8 text-blue-500 mb-2" />
-                <h4 className="font-semibold text-white">Code Examples</h4>
-                <p className="text-sm text-slate-400">Full implementation samples</p>
-              </div>
-              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
-                <Activity className="w-8 h-8 text-green-500 mb-2" />
-                <h4 className="font-semibold text-white">Live Demos</h4>
-                <p className="text-sm text-slate-400">Interactive tutorials</p>
-              </div>
-              <div className="bg-slate-800 rounded-xl p-4 hover:bg-slate-700 transition-colors cursor-pointer">
-                <Shield className="w-8 h-8 text-purple-500 mb-2" />
-                <h4 className="font-semibold text-white">Best Practices</h4>
-                <p className="text-sm text-slate-400">Industry standards</p>
-              </div>
+              {resourceCards.map((resource: ResourceLink) => {
+                const Icon = resource.icon;
+                return (
+                  <button
+                    key={resource.key}
+                    type="button"
+                    onClick={() =>
+                      window.open(resource.href, '_blank', 'noreferrer noopener')
+                    }
+                    className="group bg-slate-800 rounded-xl p-4 text-left transition transform hover:-translate-y-0.5 hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400 focus-visible:ring-offset-slate-900"
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <Icon className={classNames('w-8 h-8', resource.iconColor)} />
+                      <span className="text-xs font-semibold text-blue-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition">
+                        Open
+                      </span>
+                    </div>
+                    <h4 className="font-semibold text-white">{resource.title}</h4>
+                    <p className="text-sm text-slate-400">{resource.description}</p>
+                  </button>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/enterpriseWikiData.ts
+++ b/src/components/enterpriseWikiData.ts
@@ -15,6 +15,7 @@ import type {
   RoleDefinition,
   RoleKey,
   RoleTheme,
+  ResourceLink,
 } from './enterpriseWikiTypes';
 import { roleContent } from './__private__/enterpriseWikiContent';
 
@@ -80,6 +81,33 @@ export const enterpriseWikiIcons = {
   FileText,
   Shield,
 } as const;
+
+export const resourceCards: ResourceLink[] = [
+  {
+    key: 'codeExamples',
+    title: 'Code Examples',
+    description: 'Full implementation samples',
+    href: 'https://github.com/vercel/next.js/tree/canary/examples',
+    icon: Code,
+    iconColor: 'text-blue-500',
+  },
+  {
+    key: 'liveDemos',
+    title: 'Live Demos',
+    description: 'Interactive tutorials',
+    href: 'https://stackblitz.com/@vercel',
+    icon: Activity,
+    iconColor: 'text-green-500',
+  },
+  {
+    key: 'bestPractices',
+    title: 'Best Practices',
+    description: 'Industry standards',
+    href: 'https://web.dev/learn/#best-practices',
+    icon: Shield,
+    iconColor: 'text-purple-500',
+  },
+];
 
 export { roleContent };
 export * from './enterpriseWikiTypes';

--- a/src/components/enterpriseWikiTypes.ts
+++ b/src/components/enterpriseWikiTypes.ts
@@ -16,6 +16,15 @@ export type RoleTheme = {
   selectedButton: string;
 };
 
+export type ResourceLink = {
+  key: 'codeExamples' | 'liveDemos' | 'bestPractices';
+  title: string;
+  description: string;
+  href: string;
+  icon: LucideIcon;
+  iconColor: string;
+};
+
 export type WeekPlan = {
   number: number;
   title: string;


### PR DESCRIPTION
## Summary
- convert the resource tiles into interactive buttons that open relevant external resources
- centralize resource metadata and target URLs in enterpriseWikiData along with supporting types
- apply hover and focus-visible styles to reflect interactivity

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694020e3dbb883279002ec7d403abd28)