### PR TITLE
Add structured bullets to test summary

### DIFF
--- a/TEST_SUMMARY.md
+++ b/TEST_SUMMARY.md
@@ -2,214 +2,69 @@
 
 ## Overview
 
-This document provides a complete summary of the test suite generated for the Portfolio Project. The tests cover all bash scripts and configuration files that were added in the recent merge.
+This document summarizes the test suite generated for the Portfolio Project and highlights the recent merge that added tests covering every bash script and configuration file. Details are organized with bullet points, tables, and quick-reference lists for faster scanning.
 
 ## Test Coverage
 
 ### 1. Bash Scripts (3 scripts, 5 test files total)
 
 #### A. verify-pbs-backups.sh (291 lines)
-**Location:** `projects/01-sde-devops/PRJ-SDE-002/assets/scripts/verify-pbs-backups.sh`
-**Test File:** `tests/scripts/test_verify_pbs_backups.py`
-
-**Test Coverage:**
-- ✅ Script existence and executability
-- ✅ Help flag and usage display
-- ✅ Invalid flag error handling
-- ✅ Missing PBS_TOKEN environment variable detection
-- ✅ Verbose and dry-run flag parsing
-- ✅ API call construction (GET and POST)
-- ✅ Job status detection and evaluation
-- ✅ Failed job error code setting
-- ✅ Backup age warnings (>24h)
-- ✅ Duration threshold warnings (>1h)
-- ✅ Size drop detection
-- ✅ Snapshot age detection (>7 days)
-- ✅ Zero-size snapshot detection
-- ✅ Datastore high usage warnings (>80%)
-- ✅ Old garbage collection warnings (>7 days)
-- ✅ HTML report generation
-- ✅ Report section validation
-- ✅ Email delivery (dry-run mode)
-- ✅ Missing mailx command handling
-- ✅ Empty job list handling
-- ✅ Malformed JSON handling
-- ✅ API failure handling
-
-**Key Features Tested:**
-- Argument parsing and validation
-- Environment variable requirements
-- API interaction patterns
-- Health threshold monitoring
-- Report generation and formatting
-- Error handling and recovery
+* **Location / Tests:** `projects/01-sde-devops/PRJ-SDE-002/assets/scripts/verify-pbs-backups.sh`; tests in `tests/scripts/test_verify_pbs_backups.py`.
+* **CLI & Environment:** Ensures script exists, is executable, shows help, rejects invalid flags, and fails when `PBS_TOKEN` is missing; verifies verbose and dry-run flags.
+* **API Behavior:** Builds GET/POST calls, handles API failures, processes empty job lists, and tolerates malformed JSON.
+* **Health Thresholds:** Warns on backups older than 24h or running longer than 1h; flags size drops; detects snapshots older than 7 days or zero size; highlights datastores above 80% and garbage collection older than 7 days.
+* **Reporting & Delivery:** Generates validated HTML reports; simulates email delivery in dry-run mode; handles missing `mailx`.
+* **Reliability:** Confirms correct exit codes; validates argument parsing, environment requirements, report formatting, and recovery behaviors.
 
 #### B. dr-drill.sh (215 lines)
-**Location:** `projects/p01-aws-infra/scripts/dr-drill.sh`
-**Test File:** `tests/scripts/test_dr_drill.py`
-
-**Test Coverage:**
-- ✅ Script existence and executability
-- ✅ Help flag display
-- ✅ No command usage display
-- ✅ Unknown command error handling
-- ✅ Report command with explicit DB instance ID
-- ✅ Report command with environment variable
-- ✅ Failover command validation
-- ✅ --db-instance-id flag validation
-- ✅ --terraform-dir flag validation
-- ✅ --terraform-output-name flag validation
-- ✅ Unknown option error handling
-- ✅ Environment variable overrides (DR_DRILL_*)
-- ✅ Terraform directory override
-- ✅ AWS CLI environment variable
-- ✅ Logging output with timestamps
-
-**Key Features Tested:**
-- Command-line argument parsing
-- Environment variable precedence
-- Terraform integration
-- AWS CLI interaction
-- Logging and error reporting
+* **Location / Tests:** `projects/p01-aws-infra/scripts/dr-drill.sh`; tests in `tests/scripts/test_dr_drill.py`.
+* **CLI Validation:** Confirms script existence/executable bit, help output, and rejection of unknown commands or options; surfaces usage when no command is provided.
+* **Command Coverage:** Validates `report` with explicit DB instance ID or environment variable; checks `failover` input validation; enforces flags such as `--db-instance-id`, `--terraform-dir`, and `--terraform-output-name`.
+* **Environment & Integrations:** Ensures `DR_DRILL_*` overrides are honored; Terraform directory overrides work; AWS CLI environment variables pass through.
+* **Logging & Errors:** Verifies timestamped logging and proper error reporting across workflows.
 
 #### C. fix_unicode_arrows.sh (38 lines)
-**Location:** `scripts/fix_unicode_arrows.sh`
-**Test File:** `tests/scripts/test_fix_unicode_arrows.py`
-
-**Test Coverage:**
-- ✅ Script existence and executability
-- ✅ Script runs without errors on valid files
-- ✅ Replaces -\u003e with ->
-- ✅ Replaces -\\u003e with ->
-- ✅ Replaces HTML-encoded arrows (&#45;&#62;)
-- ✅ Normalizes spaced arrows (- >)
-- ✅ Creates backup files (.bak)
-- ✅ Preserves original content in backups
-- ✅ Validates Python syntax after replacement
-- ✅ Restores backup on invalid syntax
-- ✅ Processes multiple Python files
-- ✅ Processes nested directories
-- ✅ Handles empty directories
-- ✅ Handles already correct files
-- ✅ Idempotent execution (safe to run multiple times)
-- ✅ Displays repository root
-- ✅ Displays completion message
-
-**Key Features Tested:**
-- Unicode/HTML entity replacement
-- Backup and restore mechanisms
-- Python syntax validation
-- File system traversal
-- Idempotency and safety
+* **Location / Tests:** `scripts/fix_unicode_arrows.sh`; tests in `tests/scripts/test_fix_unicode_arrows.py`.
+* **Replacement Logic:** Replaces `-\u003e`/`-\\u003e` with `->`, converts HTML-encoded arrows (e.g., `&#45;&#62;`), normalizes spaced arrows, and remains idempotent across runs.
+* **Safety Nets:** Creates `.bak` backups preserving originals; restores backups on invalid syntax; validates Python syntax post-replacement.
+* **Filesystem Handling:** Processes multiple Python files and nested directories; tolerates empty directories and already-correct files; prints repo root and completion message.
 
 ### 2. Configuration Files
 
-#### A. YAML Configurations
-**Test File:** `tests/config/test_yaml_configs.py`
+#### A. YAML Configurations (tests in `tests/config/test_yaml_configs.py`)
+* **prometheus.yml:** Valid YAML; required `global` and `scrape_configs`; alerting and rule file settings validated.
+* **alertmanager.yml:** Valid YAML; `route` and `receivers` sections present; receiver names validated.
+* **loki-config.yml:** Ensures authentication and server configuration blocks are present.
+* **promtail-config.yml:** Validates server settings, client definitions, and scrape configs.
+* **infrastructure_alerts.yml:** Checks valid YAML, properly named alert groups, and rules containing `alert` or `record` expressions.
+* **ArgoCD application.yaml:** Confirms valid syntax, `apiVersion`, `kind`, named metadata, and `spec` with both `source` and `destination`.
 
-**Files Covered:**
-
-1. **prometheus.yml**
-   - ✅ Valid YAML syntax
-   - ✅ Required sections (global, scrape_configs)
-   - ✅ Global configuration (scrape_interval, evaluation_interval)
-   - ✅ Alerting configuration
-   - ✅ Rule files configuration
-
-2. **alertmanager.yml**
-   - ✅ Valid YAML syntax
-   - ✅ Required sections (route, receivers)
-   - ✅ Route configuration with receiver
-   - ✅ Receivers list validation
-   - ✅ Receiver names validation
-
-3. **loki-config.yml**
-   - ✅ Valid YAML syntax
-   - ✅ Authentication configuration
-   - ✅ Server configuration
-
-4. **promtail-config.yml**
-   - ✅ Valid YAML syntax
-   - ✅ Server configuration
-   - ✅ Clients configuration
-   - ✅ Scrape configs validation
-
-5. **infrastructure_alerts.yml**
-   - ✅ Valid YAML syntax
-   - ✅ Alert groups presence
-   - ✅ Group names validation
-   - ✅ Rules within groups
-   - ✅ Required rule fields (alert/record, expr)
-
-6. **application.yaml** (ArgoCD)
-   - ✅ Valid YAML syntax
-   - ✅ apiVersion presence
-   - ✅ kind field validation
-   - ✅ Metadata with name
-   - ✅ Spec with source/destination
-
-#### B. JSON Configurations
-**Test File:** `tests/config/test_json_configs.py`
-
-**Files Covered:**
-
-1. **application-metrics.json** (Grafana)
-   - ✅ Valid JSON syntax
-   - ✅ Dashboard title
-   - ✅ Panels array
-   - ✅ Unique panel IDs
-   - ✅ Version/schema version
-
-2. **infrastructure-overview.json** (Grafana)
-   - ✅ Valid JSON syntax
-   - ✅ Dashboard title
-   - ✅ Panels array with content
-   - ✅ Panel titles
-   - ✅ Time range configuration
-   - ✅ Panel targets validation
-   - ✅ Dashboard UID
-
-3. **Cross-Dashboard Validation**
-   - ✅ Consistent structure
-   - ✅ Unique UIDs
-   - ✅ Data source references
-   - ✅ Proper JSON formatting
-   - ✅ No trailing commas
+#### B. JSON Configurations (tests in `tests/config/test_json_configs.py`)
+* **application-metrics.json (Grafana):** Valid JSON; dashboard title; populated `panels` array; unique panel IDs; correct versioning.
+* **infrastructure-overview.json:** Valid JSON; titled dashboard with populated panels and sensible titles; configured time ranges; validated panel targets; dashboard UID required.
+* **Cross-file checks:** Consistent structure; unique UIDs; proper data source references; clean formatting without trailing commas.
 
 ## Test Statistics
 
-| Category | Files Tested | Test Cases | Lines of Test Code |
-|----------|--------------|------------|-------------------|
-| Bash Scripts | 3 | ~80 | ~800 |
-| YAML Configs | 6 | ~40 | ~400 |
-| JSON Configs | 2 | ~20 | ~300 |
-| **Total** | **11** | **~140** | **~1500** |
+| Area                | Files Covered | Approx. Test Cases | Approx. Test LOC |
+|---------------------|---------------|--------------------|------------------|
+| Bash scripts        | 3             | ~80                | ~800             |
+| YAML configurations | 6             | ~40                | ~400             |
+| JSON configurations | 2             | ~20                | ~300             |
+| **Total**           | **11**        | **~140**           | **~1,500**       |
 
 ## Test Execution
 
-### Running All Tests
-```bash
-python -m pytest tests/ -v
-```
-
-### Running Specific Test Categories
-```bash
-# Script tests only
-python -m pytest tests/scripts/ -v
-
-# Configuration tests only
-python -m pytest tests/config/ -v
-
-# Specific script tests
-python -m pytest tests/scripts/test_verify_pbs_backups.py -v
-python -m pytest tests/scripts/test_dr_drill.py -v
-python -m pytest tests/scripts/test_fix_unicode_arrows.py -v
-
-# Specific config tests
-python -m pytest tests/config/test_yaml_configs.py -v
-python -m pytest tests/config/test_json_configs.py -v
-```
+* **Full suite:** `python -m pytest tests/ -v`
+* **Scripts only:** `python -m pytest tests/scripts/ -v`
+* **Configs only:** `python -m pytest tests/config/ -v`
+* **Targeted files:**
+  * `python -m pytest tests/scripts/test_verify_pbs_backups.py -v`
+  * `python -m pytest tests/scripts/test_dr_drill.py -v`
+  * `python -m pytest tests/scripts/test_fix_unicode_arrows.py -v`
+  * `python -m pytest tests/config/test_yaml_configs.py -v`
+  * `python -m pytest tests/config/test_json_configs.py -v`
 
 ### Test Output Example
-```bash
-```
+
+Pytest emits verbose output showing collection and individual test results in standard format (dots for success, detailed assertion messages on failure).


### PR DESCRIPTION
## Summary
- Reformat the test suite summary into bullet lists for bash script coverage, configuration checks, and execution steps
- Add a statistics table to present file coverage, test counts, and line totals at a glance
- Improve readability with quick-reference commands and clarified output notes

## Testing
- Not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447a1fc0288327b75e78c30d7453a3)