### PR TITLE
Fix portfolio metrics commit recommendation rendering

### DIFF
--- a/scripts/portfolio-metrics.py
+++ b/scripts/portfolio-metrics.py
@@ -325,6 +325,18 @@ class PortfolioMetrics:
         bar = "█" * filled + "░" * (length - filled)
         print(f"   [{bar}] {percentage}%")
 
+    def _generate_recommendations(self) -> list[str]:
+        """Generate portfolio improvement recommendations."""
+        github_stats = self.metrics.get("github", {})
+        total_commits = github_stats.get("total_commits", 0)
+
+        return [
+            (
+                f"Commit history shows {total_commits} total commits; "
+                "maintain frequent, descriptive commits to preserve traceability."
+            )
+        ]
+
     def save_metrics(self, output_file="portfolio-metrics.json"):
         """Save metrics to JSON file"""
         output_path = self.base_dir / output_file

--- a/tests/scripts/test_portfolio_metrics_recommendations.py
+++ b/tests/scripts/test_portfolio_metrics_recommendations.py
@@ -1,0 +1,28 @@
+"""Tests for recommendation generation in portfolio-metrics script."""
+from importlib import util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parent.parent.parent / "scripts" / "portfolio-metrics.py"
+
+
+def load_portfolio_metrics():
+    """Dynamically load the portfolio-metrics module."""
+    spec = util.spec_from_file_location("portfolio_metrics", MODULE_PATH)
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_recommendations_renders_commit_total():
+    """Ensure commit totals are interpolated into recommendations."""
+    module = load_portfolio_metrics()
+    metrics = module.PortfolioMetrics(base_dir=Path("."))
+    metrics.metrics["github"]["total_commits"] = 42
+
+    recommendations = metrics._generate_recommendations()
+
+    assert recommendations, "Recommendations should not be empty"
+    assert "42 total commits" in recommendations[0]
+    assert "{metrics.total_commits}" not in recommendations[0]


### PR DESCRIPTION
## Summary
- render the commit-history recommendation with the actual total_commits value
- add a test to ensure the recommendation includes the numeric commit count

## Testing
- pytest tests/scripts/test_portfolio_metrics_recommendations.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694975507de883279394bd7eb5b9219f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio metrics now generates personalized recommendations based on commit history, including guidance on maintaining frequent and descriptive commits for better code traceability and collaboration practices.

* **Tests**
  * Added comprehensive test suite to verify recommendations are correctly generated with accurate commit totals and proper formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->