### PR TITLE
Add AWS setup guide and documentation/UI templates for SamSJPortfolio

### DIFF
--- a/docs/aws_setup_samsjportfolio.md
+++ b/docs/aws_setup_samsjportfolio.md
@@ -43,7 +43,7 @@ This guide walks through **setting up AWS from scratch** in **us-west-2**, using
 2. Add users to appropriate groups.
 3. Create roles for services:
    - `ecsTaskExecutionRole-SamSJPortfolio` → AmazonECSTaskExecutionRolePolicy
-   - `report-gen-task-role-SamSJPortfolio` → custom least-privilege policy
+   - `report-gen-task-role-SamSJPortfolio` → Create a custom least-privilege policy. This role needs permissions to access secrets (Secrets Manager), read configuration (SSM), and write to S3 buckets.
 
 ## Step 5: Configure AWS CLI
 1. Install AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html


### PR DESCRIPTION
### Motivation
- Provide a beginner-friendly, step-by-step AWS setup tailored to region `us-west-2` and the `SamSJPortfolio` naming suffix.
- Centralize reproducible resource names and security best-practices for the report generator deployment.
- Supply ready-to-use documentation templates to speed onboarding and standardize project docs.
- Give UI/UX guidance and visual tokens to align the report generator interface design with implementation.

### Description
- Add a new documentation file at `docs/aws_setup_samsjportfolio.md` containing a full AWS setup guide and resource naming examples (VPC, S3, ECS, RDS, IAM, CloudWatch, CloudTrail, CI/CD).
- Include recreated `README.md` and `CONTRIBUTING.md` templates within the same guide for immediate copy/paste use and local editing.
- Provide UI/UX templates and patterns including user flows, layout skeleton, form components, table history patterns, visual tokens, and accessibility guidance.
- This is a documentation-only change focused on instructions, templates, and implementation guidance rather than runtime code.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69497255be9883279f38d9ee753e034b)