### PR TITLE
Reconcile portfolio status table and add verification evidence

### DIFF
--- a/PORTFOLIO_ASSESSMENT_REPORT.md
+++ b/PORTFOLIO_ASSESSMENT_REPORT.md
@@ -6,6 +6,19 @@ The authoritative, current status table for Projects 1–25 lives in
 [PORTFOLIO_STATUS_UPDATED.md](PORTFOLIO_STATUS_UPDATED.md). This report is a
 historical snapshot from 2025-11-10 and should not be used for current planning.
 
+## Reconciliation Addendum (2025-12-26)
+To prevent future drift, the status table has been centralized in
+[PORTFOLIO_STATUS_UPDATED.md](PORTFOLIO_STATUS_UPDATED.md) with timestamps and
+evidence links. Specific mismatches between this historical report and the
+current project directories were verified and reconciled in that table:
+- Projects **1–3**: tests + CI + infra/deploy assets verified.
+- Projects **6–7**: tests + CI + infra/deploy assets verified.
+- Project **9**: tests + CI + Terraform verified.
+- Projects **23–24**: tests + CI verified (Project 23 includes docker-compose).
+
+Use this report only for historical narrative and recommendations, not for
+current status planning.
+
 ## Executive Summary
 - **Total Projects Analyzed**: 25
 - **Complete/Production-Ready**: ~2

--- a/PORTFOLIO_STATUS_UPDATED.md
+++ b/PORTFOLIO_STATUS_UPDATED.md
@@ -12,10 +12,16 @@ This document is the **authoritative status table** for portfolio planning. All 
 
 ## Mismatch Summary (What Was Reconciled)
 The following projects were marked as **minimal/partial** in older reports but now have tests and CI workflows, with additional infrastructure or deployment artifacts verified in the project directories:
-- Projects **1–3**: tests + CI + infra/deploy assets are present.
-- Projects **6–7**: tests + CI + infra/deploy assets are present.
-- Project **9**: tests + CI + Terraform present.
-- Projects **23–24**: tests + CI present (Project 23 also has docker-compose).
+- Projects **1–3**: tests + CI + infra/deploy assets are present (see [P1 tests](projects/1-aws-infrastructure-automation/tests), [P1 CI](projects/1-aws-infrastructure-automation/.github/workflows/terraform.yml), [P2 tests](projects/2-database-migration/tests), [P2 CI](projects/2-database-migration/.github/workflows/ci.yml), [P3 tests](projects/3-kubernetes-cicd/tests), [P3 CI](projects/3-kubernetes-cicd/.github/workflows/ci-cd.yaml)).
+- Projects **6–7**: tests + CI + infra/deploy assets are present (see [P6 tests](projects/6-mlops-platform/tests), [P6 CI](projects/6-mlops-platform/.github/workflows/ci.yml), [P7 tests](projects/7-serverless-data-processing/tests), [P7 CI](projects/7-serverless-data-processing/.github/workflows/ci.yml)).
+- Project **9**: tests + CI + Terraform present (see [P9 tests](projects/9-multi-region-disaster-recovery/tests), [P9 CI](projects/9-multi-region-disaster-recovery/.github/workflows/ci.yml), [P9 terraform](projects/9-multi-region-disaster-recovery/terraform)).
+- Projects **23–24**: tests + CI present (see [P23 tests](projects/23-advanced-monitoring/tests), [P23 CI](projects/23-advanced-monitoring/.github/workflows/monitoring.yml), [P23 compose](projects/23-advanced-monitoring/docker-compose.yml), [P24 tests](projects/24-report-generator/tests), [P24 CI](projects/24-report-generator/.github/workflows/ci.yml)).
+
+## Verification Notes (2025-12-26)
+Reconciliation was confirmed by inspecting project directories for the presence of:
+- `tests/` suites
+- `.github/workflows/*.yml` CI workflows
+- Infra/deploy artifacts such as `terraform/`, `k8s/`, `infrastructure/`, or `docker-compose.yml`
 
 ---
 
@@ -48,4 +54,3 @@ The following projects were marked as **minimal/partial** in older reports but n
 | 23 | Advanced Monitoring & Observability | Implemented (tests + CI + deploy) | [tests](projects/23-advanced-monitoring/tests) · [CI](projects/23-advanced-monitoring/.github/workflows/monitoring.yml) · [docker-compose](projects/23-advanced-monitoring/docker-compose.yml) |
 | 24 | Report Generator | Implemented (tests + CI) | [tests](projects/24-report-generator/tests) · [CI](projects/24-report-generator/.github/workflows/ci.yml) |
 | 25 | Portfolio Website | Implemented (tests + CI) | [tests](projects/25-portfolio-website/tests) · [CI](projects/25-portfolio-website/.github/workflows/ci.yml) |
-

--- a/PORTFOLIO_SUMMARY_TABLE.txt
+++ b/PORTFOLIO_SUMMARY_TABLE.txt
@@ -9,6 +9,6 @@ Reason: to prevent drift between multiple summary files, status planning should
 reference the single reconciled table that includes timestamps and evidence
 links for Projects 1–25.
 
-Last reconciled table: 2025-12-26 (see PORTFOLIO_STATUS_UPDATED.md)
+Last reconciled table: 2025-12-26 (see PORTFOLIO_STATUS_UPDATED.md for evidence)
 
 ================================================================================


### PR DESCRIPTION
### Motivation
- Reconcile conflicting status information between `PORTFOLIO_STATUS_UPDATED.md`, `PORTFOLIO_ASSESSMENT_REPORT.md`, and `PORTFOLIO_SUMMARY_TABLE.txt` for Projects 1–25.
- Establish a single source of truth with a timestamp and evidence links to prevent future drift.
- Surface verified project artifacts (tests, CI, infra/deploy) so planning uses current state.
- Record the reconciliation decision and verification criteria to aid future maintainers.

### Description
- Update `PORTFOLIO_STATUS_UPDATED.md` to expand the mismatch summary with direct evidence links for Projects 1–3, 6–7, 9, and 23–24 and add a `Verification Notes` section describing the checks performed for `tests/`, `.github/workflows/*.yml`, and infra/deploy artifacts.
- Add a `Reconciliation Addendum` to `PORTFOLIO_ASSESSMENT_REPORT.md` that summarizes the reconciled mismatches and points readers to the authoritative table.
- Clarify the pointer in `PORTFOLIO_SUMMARY_TABLE.txt` to reference evidence in `PORTFOLIO_STATUS_UPDATED.md`.
- Verification included inspecting project directories (for example `projects/1-aws-infrastructure-automation/`, `projects/2-database-migration/`, `projects/3-kubernetes-cicd/`, `projects/6-mlops-platform/`, `projects/7-serverless-data-processing/`, `projects/9-multi-region-disaster-recovery/`, `projects/23-advanced-monitoring/`, and `projects/24-report-generator/`) to confirm presence of `tests/`, CI workflows, and infra artifacts.

### Testing
- No automated tests were executed because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed0bd051c8327837b08b788323cbd)