### PR TITLE
Fix CI test imports and add missing project requirements (boto3, pytest-cov)

### DIFF
--- a/.github/workflows/critical-projects-ci.yml
+++ b/.github/workflows/critical-projects-ci.yml
@@ -69,4 +69,4 @@ jobs:
       - name: Run tests with coverage
         working-directory: ${{ matrix.project }}
         run: |
-          pytest --cov=src --cov-report=term-missing
+          PYTHONPATH=. pytest --cov=src --cov-report=term-missing

--- a/projects/1-aws-infrastructure-automation/requirements.txt
+++ b/projects/1-aws-infrastructure-automation/requirements.txt
@@ -1,0 +1,3 @@
+boto3>=1.34.14
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/10-blockchain-smart-contract-platform/requirements.txt
+++ b/projects/10-blockchain-smart-contract-platform/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/23-advanced-monitoring/requirements.txt
+++ b/projects/23-advanced-monitoring/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/24-report-generator/requirements.txt
+++ b/projects/24-report-generator/requirements.txt
@@ -5,3 +5,5 @@ pyyaml>=6.0
 click>=8.1
 python-dateutil>=2.8
 APScheduler>=3.10.0
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/25-portfolio-website/requirements.txt
+++ b/projects/25-portfolio-website/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/3-kubernetes-cicd/requirements.txt
+++ b/projects/3-kubernetes-cicd/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/4-devsecops/requirements.txt
+++ b/projects/4-devsecops/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/projects/5-real-time-data-streaming/requirements.txt
+++ b/projects/5-real-time-data-streaming/requirements.txt
@@ -5,3 +5,4 @@ confluent-kafka>=2.1.0
 avro-python3>=1.10.2
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
+pytest-cov>=4.1.0

--- a/projects/9-multi-region-disaster-recovery/requirements.txt
+++ b/projects/9-multi-region-disaster-recovery/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-cov>=4.1.0


### PR DESCRIPTION
### Motivation

- Tests in multiple critical projects were failing with `ModuleNotFoundError: No module named 'src'` because the test runner did not include project source on `PYTHONPATH`.
- Integration tests also failed due to missing runtime dependencies (for example `boto3` required by the AWS integration tests).
- The CI workflow also omitted `pytest-cov` or per-project `requirements.txt` for several matrix entries, causing inconsistent test environments.

### Description

- Update `.github/workflows/critical-projects-ci.yml` to run tests with `PYTHONPATH=.` so project `src` directories are discoverable by `pytest`.
- Add `projects/1-aws-infrastructure-automation/requirements.txt` including `boto3`, and add baseline `requirements.txt` files for projects: `projects/3`, `4`, `9`, `10`, `23`, and `25` to ensure `pytest` and `pytest-cov` are installed.
- Add `pytest-cov` to existing requirements in `projects/5-real-time-data-streaming/requirements.txt` and `projects/24-report-generator/requirements.txt`.
- Keep dependency additions minimal and scoped to test/runtime needs so CI installs dependencies via the existing install step.

### Testing

- No automated tests were executed in this environment; the changes are intended to be validated by the CI run for the pull request.
- The workflow change enables the existing `pytest` step to discover packages under each project's `src` when the matrix jobs run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed23328d483279c9fd11a0d8a1c4a)