### PR TITLE
Update PRJ-CYB-RED-001 README with full Adversary Emulation documentation

### DIFF
--- a/projects/03-cybersecurity/PRJ-CYB-RED-001/README.md
+++ b/projects/03-cybersecurity/PRJ-CYB-RED-001/README.md
@@ -91,23 +91,24 @@ resource "aws_instance" "redirector" {
   vpc_security_group_ids = [aws_security_group.c2_sg.id]
 
   user_data = <<-EOF
-              #!/bin/bash
-              apt-get update
-              apt-get install -y nginx
-              
-              # Configure Nginx as Reverse Proxy
-              cat <<EOT > /etc/nginx/sites-available/default
-              server {
-                  listen 80;
-                  server_name ${var.domain_name};
-                  location / {
-                      proxy_pass http://${var.c2_server_ip};
-                      proxy_set_header Host $host;
-                  }
-              }
-              EOT
-              systemctl restart nginx
-              EOF
+#!/bin/bash
+set -e
+apt-get update
+apt-get install -y nginx
+
+# Configure Nginx as Reverse Proxy
+cat <<EOT > /etc/nginx/sites-available/default
+server {
+    listen 80;
+    server_name ${var.domain_name};
+    location / {
+        proxy_pass http://${var.c2_server_ip};
+        proxy_set_header Host $host;
+    }
+}
+EOT
+systemctl restart nginx
+EOF
 
   tags = {
     Name = "RedTeam-Redirector-01"


### PR DESCRIPTION
### Motivation
- Replace an outdated/placeholder README with a production-ready Adversary Emulation and Red Team operations document for `PRJ-CYB-RED-001`.
- Provide a single authoritative source that documents attack-range IaC, campaign specs, TTP automation, and operational runbooks for safe exercise execution.
- Improve reproducibility and handoff by including Infrastructure-as-Code examples, tooling snippets, and Architecture Decision Records (ADRs).
- Supply defensive teams with observability and deconfliction guidance (RoE, risk register, KPIs) to support Purple Team workflows.

### Description
- Rewrote `projects/03-cybersecurity/PRJ-CYB-RED-001/README.md` to include Executive Summary, Architecture, IaC, Campaign Specifications, TTP Implementation, CI/CD, Testing Strategy, Runbooks, RoE, Risk Register, ADRs, and Metrics.
- Added an example Terraform snippet for an ephemeral Nginx redirector and a Python `AtomicRunner` TTP automation example (embedded in the README) to demonstrate safe scripted execution of Atomic Red Team techniques.
- Included a GitHub Actions CI snippet (`github-actions-redteam-ci.yml`) showing linting and Terraform validation steps and provided PromQL examples and KPIs for detection metrics.
- Documented operational procedures: engagement kickoff checklist, deconfliction protocol, authorized/excluded targets, data handling constraints, and acceptance criteria for safe emulation.

### Testing
- No automated tests were executed for this change because it is documentation-only and contains no production code modifications.
- CI linting/validation steps referenced in the README (e.g., `flake8`, `terraform fmt -check`) are examples and were not run as part of this update.
- Manual review: the README content was committed and formatted; no runtime artifacts or infrastructure were provisioned as part of this PR.
- If desired, follow the included CI snippets to validate linting and Terraform formatting in a follow-up PR or CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee8d6e05483278e99c5ee88c8ae27)