### PR TITLE
Add Playwright report artifacts, BASE_URL config and CI workflow for P06 E2E

### DIFF
--- a/.github/workflows/p06-e2e-testing.yml
+++ b/.github/workflows/p06-e2e-testing.yml
@@ -1,0 +1,43 @@
+name: P06 E2E Testing
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: projects/p06-e2e-testing
+    env:
+      BASE_URL: ${{ secrets.P06_BASE_URL || 'http://localhost:3000' }}
+      TEST_USER: ${{ secrets.P06_TEST_USER || 'test@example.com' }}
+      TEST_PASSWORD: ${{ secrets.P06_TEST_PASSWORD || 'ChangeMe123!' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: projects/p06-e2e-testing/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: p06-e2e-test-reports
+          path: projects/p06-e2e-testing/reports

--- a/projects/p06-e2e-testing/.env.example
+++ b/projects/p06-e2e-testing/.env.example
@@ -4,3 +4,8 @@ AWS_REGION=us-east-1
 LOG_LEVEL=INFO
 METRICS_ENDPOINT=http://localhost:9090/metrics
 FEATURE_FLAGS=baseline
+
+# E2E target configuration
+BASE_URL=http://localhost:3000
+TEST_USER=test@example.com
+TEST_PASSWORD=ChangeMe123!

--- a/projects/p06-e2e-testing/Makefile
+++ b/projects/p06-e2e-testing/Makefile
@@ -41,7 +41,7 @@ test-webkit: ## Run tests on WebKit only
 
 report: ## Open HTML test report
 	@echo "Opening test report..."
-	npx playwright show-report
+	npx playwright show-report reports/playwright-html
 
 trace: ## Show trace viewer (specify TRACE_FILE)
 	@if [ -z "$(TRACE_FILE)" ]; then \
@@ -63,7 +63,7 @@ lint: ## Lint test files
 	fi
 
 clean: ## Clean test artifacts and reports
-	rm -rf test-results playwright-report .playwright
+	rm -rf reports test-results playwright-report .playwright
 	rm -rf node_modules package-lock.json
 	find . -type f -name "*.zip" -delete
 

--- a/projects/p06-e2e-testing/README.md
+++ b/projects/p06-e2e-testing/README.md
@@ -58,6 +58,8 @@ make report
 
 ## Configuration
 
+**Target URL**: Set `BASE_URL` to the application under test. Local default is `http://localhost:3000`; staging example: `https://staging.example.com`.
+
 | Env Var | Purpose | Example | Required |
 |---------|---------|---------|----------|
 | `BASE_URL` | Target application URL | `https://example.com` | Yes |
@@ -73,6 +75,11 @@ make report
 cp .env.example .env
 # Edit .env with your test credentials
 ```
+
+**CI Secrets (GitHub Actions)**:
+- `P06_BASE_URL` (target URL)
+- `P06_TEST_USER`
+- `P06_TEST_PASSWORD`
 
 ## Testing
 
@@ -99,10 +106,11 @@ npx playwright test --update-snapshots
 ## Operations
 
 ### Logs, Metrics, Traces
-- **Test Reports**: `playwright-report/index.html` (generated after test run)
+- **Test Reports**: `reports/playwright-html/index.html` (generated after test run)
+- **Machine-readable Reports**: `reports/playwright-report.json`, `reports/playwright-junit.xml`
 - **Trace Viewer**: `npx playwright show-trace trace.zip`
-- **Screenshots**: `test-results/` directory (on failure)
-- **Videos**: `test-results/` directory (configurable)
+- **Screenshots**: `reports/test-results/` directory (on failure)
+- **Videos**: `reports/test-results/` directory (configurable)
 
 ### Common Issues & Fixes
 

--- a/projects/p06-e2e-testing/playwright.config.ts
+++ b/projects/p06-e2e-testing/playwright.config.ts
@@ -9,10 +9,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : 4,
+  outputDir: 'reports/test-results',
   reporter: [
-    ['html'],
-    ['json', { outputFile: 'test-results/results.json' }],
-    ['junit', { outputFile: 'test-results/junit.xml' }]
+    ['html', { outputFolder: 'reports/playwright-html', open: 'never' }],
+    ['json', { outputFile: 'reports/playwright-report.json' }],
+    ['junit', { outputFile: 'reports/playwright-junit.xml' }]
   ],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',


### PR DESCRIPTION
### Motivation
- Centralize E2E artifacts and make machine-readable reports available for review and CI upload for the Playwright suite in `projects/p06-e2e-testing`.
- Provide an explicit, documented target URL and example credentials so local runs and CI use the same `BASE_URL` configuration.
- Ensure CI captures HTML/JSON/JUnit reports and test artifacts so PRs and main branch runs can be reviewed and archived.

### Description
- Updated `playwright.config.ts` to set `outputDir` and emit `html`, `json`, and `junit` reports under a `reports/` hierarchy (`reports/playwright-html`, `reports/playwright-report.json`, `reports/playwright-junit.xml`).
- Extended `projects/p06-e2e-testing/.env.example` with `BASE_URL`, `TEST_USER`, and `TEST_PASSWORD` and documented the target URL and CI secret names in `README.md`.
- Adjusted `projects/p06-e2e-testing/Makefile` to open the HTML report from `reports/playwright-html` and to clean the `reports/` folder.
- Added a new GitHub Actions workflow `.github/workflows/p06-e2e-testing.yml` that runs `npx playwright test` in `projects/p06-e2e-testing` and uploads the `projects/p06-e2e-testing/reports` directory as the artifact `p06-e2e-test-reports`.

### Testing
- No automated tests were run as part of this change.
- The new CI job `P06 E2E Testing` is configured to run `npx playwright test` on `pull_request`/`push` to `main` and will upload `projects/p06-e2e-testing/reports` as an artifact when executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed309c1448327babdcf89574b3bbc)