### PR TITLE
Add GitHub PR cleanup utility

### DIFF
--- a/scripts/github_pr_cleanup.py
+++ b/scripts/github_pr_cleanup.py
@@ -142,10 +142,26 @@ def close_prs(
             close_pr(token, repo, pr)
 
 
+def validate_github_repo(repo: str) -> str:
+    """
+    Validate that the repository identifier is in the 'owner/repo' format.
+
+    Raises:
+        ValueError: If the repository string is not in the expected format.
+    """
+    owner, sep, name = repo.partition("/")
+    if sep != "/" or not owner or not name or "/" in name:
+        raise ValueError(
+            f"Invalid GITHUB_REPO value: {repo!r}. Expected format 'owner/repo'."
+        )
+    return repo
+
+
 def main() -> None:
     args = parse_args()
     token = get_env("GITHUB_TOKEN")
-    repo = get_env("GITHUB_REPO")
+    repo_raw = get_env("GITHUB_REPO")
+    repo = validate_github_repo(repo_raw)
 
     open_prs = fetch_open_prs(token, repo)
     open_prs.sort(key=lambda pr: pr.updated_at)


### PR DESCRIPTION
### Motivation
- Provide a safe, scriptable way to reduce large numbers of open PRs by identifying and closing stale pull requests.
- Support repository automation workflows that require bulk PR maintenance using environment-based configuration.
- Allow operators to preview actions via `--dry-run` before making destructive changes.
- Handle large repos by paging through GitHub API results and limiting closures with `--max`.

### Description
- Add `scripts/github_pr_cleanup.py`, a CLI utility that lists open PRs and closes stale PRs using the GitHub REST API.
- Implement CLI flags `--list`, `--close-stale`, `--dry-run`, `--days`, and `--max` to control behavior.
- Configure access via environment variables `GITHUB_TOKEN` and `GITHUB_REPO`, and include pagination to fetch all open PRs.
- Use `requests` to call the API, compute PR age, and optionally patch PRs to `closed` state when not in dry-run mode.

### Testing
- No automated tests were executed for this change (no CI run was requested).
- The script was lint/format not run; basic runtime inspection performed during development.
- Manual usage examples are provided in the file header (e.g., `python scripts/github_pr_cleanup.py --dry-run --close-stale --days 30`).
- The new file was added and committed as `scripts/github_pr_cleanup.py` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696140aba5448327bb45ada7a264db02)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility for managing pull requests with the ability to list open PRs and close stale ones based on inactivity threshold.
  * Supports dry-run mode to preview changes before executing.
  * Configurable filters for stale PR age and maximum closure limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->