### PR TITLE
Fix CI continue-on-error behavior for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,15 @@ jobs:
 
     - name: Validate Markdown
       run: markdownlint '**/*.md' --ignore node_modules
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Check Python formatting
       run: black --check .
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Lint Python code
       run: ruff check .
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Run unit tests with coverage
       run: |
@@ -68,7 +68,7 @@ jobs:
           -m "not integration" \
           --maxfail=1 \
           --durations=10
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Run PostgreSQL integration tests
       env:
@@ -79,7 +79,7 @@ jobs:
         POSTGRES_SOURCE_DB: migration_source
         POSTGRES_TARGET_DB: migration_target
       run: pytest tests/integration -m integration --maxfail=1 --durations=10
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
@@ -140,11 +140,11 @@ jobs:
 
     - name: Lint
       run: npm run lint
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Type check
       run: npm run type-check
-      continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+      continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
     - name: Run tests with coverage
       run: npm run test:coverage -- --reporter=verbose


### PR DESCRIPTION
### Motivation
- The CI currently used `continue-on-error: ${{ github.ref != 'refs/heads/main' }}` which evaluates true for `pull_request` events because `github.ref` is `refs/pull/.../merge`, allowing failures on PRs to be ignored.
- The intent is to permit soft failures only for non-main *pushes*, while ensuring PRs fail the workflow on lint/test/format errors.

### Description
- Updated multiple `continue-on-error` expressions in `.github/workflows/ci.yml` to `continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}` so the condition only permits non-main pushes to continue on error.
- The change touches both backend and frontend test/job steps (several lint/format/test steps were updated across the workflow).
- Replaced seven occurrences of the previous expression with the new combined `event_name` + `ref` check.

### Testing
- No automated tests were run because this is a workflow-only change and affects GitHub Actions configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c182130208327a97f551d5b690a9b)