### PR TITLE
Reference Grafana datasource provisioning file in observability README

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -8,7 +8,7 @@ support the portfolio observability stack.
 - **Grafana dashboards**: [grafana/dashboards/orchestration.json](./grafana/dashboards/orchestration.json) provides the
   "Portfolio Orchestration Overview" dashboard with panels for API request rate, latency, orchestration run counters,
   and collector logs.
-- **Grafana provisioning**: [grafana/provisioning/dashboards/dashboard.yml](./grafana/provisioning/dashboards/dashboard.yml)
+- **Grafana provisioning**: [grafana/provisioning/datasources/datasource.yml](./grafana/provisioning/datasources/datasource.yml)
   defines the Prometheus datasource (`http://otel-collector:9464`) and loads dashboards from
   `/var/lib/grafana/dashboards`.
 - **Collector configuration**: [otel-collector.yaml](./otel-collector.yaml) stores the OpenTelemetry collector


### PR DESCRIPTION
### Motivation
- Correct the Grafana provisioning file referenced in `observability/README.md` so it points to the datasource provisioning file and keeps the Prometheus URL (`http://otel-collector:9464`) and dashboard load path (`/var/lib/grafana/dashboards`) intact.

### Description
- Replace the provisioning link from `grafana/provisioning/dashboards/dashboard.yml` to `grafana/provisioning/datasources/datasource.yml` in `observability/README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff66ec5808327ad8387fa290c9138)