### PR TITLE
Add Alertmanager service for AstraDup monitoring

### DIFF
--- a/projects/astradup-video-deduplication/README.md
+++ b/projects/astradup-video-deduplication/README.md
@@ -21,6 +21,7 @@ For cross-project documentation, standards, and runbooks, see the [Portfolio Doc
 
 ### Monitoring
 - **Prometheus:** `http://localhost:9090` (config: `prometheus/prometheus.yml`)
+- **Alertmanager:** `http://localhost:9093` (config: `alertmanager/alertmanager.yml`)
 - **Grafana:** `http://localhost:3000` (dashboard: `grafana/dashboards/astradup-video-deduplication-dashboard.json`)
 - **API health check:** `http://localhost:8000/health`
 - **Airflow UI:** `http://localhost:8080`

--- a/projects/astradup-video-deduplication/alertmanager/alertmanager.yml
+++ b/projects/astradup-video-deduplication/alertmanager/alertmanager.yml
@@ -1,0 +1,5 @@
+global: {}
+route:
+  receiver: default
+receivers:
+  - name: default

--- a/projects/astradup-video-deduplication/docker-compose.yml
+++ b/projects/astradup-video-deduplication/docker-compose.yml
@@ -184,6 +184,19 @@ services:
     networks:
       - astradup-network
 
+  # Alertmanager
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: astradup-alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+    volumes:
+      - ./alertmanager:/etc/alertmanager
+    ports:
+      - "9093:9093"
+    networks:
+      - astradup-network
+
 networks:
   astradup-network:
     driver: bridge


### PR DESCRIPTION
### Motivation
- Ensure Prometheus' configured `alertmanagers` target (`alertmanager:9093`) has a corresponding service in the local Docker Compose stack so alerts can be delivered.

### Description
- Add an `alertmanager` service to `projects/astradup-video-deduplication/docker-compose.yml` using `prom/alertmanager:latest`, mounting `./alertmanager` and binding port `9093`.
- Add a minimal Alertmanager configuration file at `projects/astradup-video-deduplication/alertmanager/alertmanager.yml` with a default receiver and route.
- Document the Alertmanager endpoint in the Monitoring section of `projects/astradup-video-deduplication/README.md`.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9419fc008327965b1342b7f99fdf)