### PR TITLE
Fix Portfolio Blueprints anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ flowchart LR
 - [EnterpriseWiki](./src/components/EnterpriseWiki.tsx) — React component that renders interactive learning paths for  
   SDE, DevOps, QA, and architecture roles.
 
-## 📦 Portfolio Blueprints
+## 🧭 Portfolio Blueprints & Evidence
 
 - 🟢 [Project 1: AWS Infrastructure Automation](./projects/1-aws-infrastructure-automation/README.md) — Multi-tool  
   infrastructure-as-code implementation covering Terraform, AWS CDK, and Pulumi with reusable deploy scripts.
@@ -597,7 +597,7 @@ pie title Coverage: Website
 
 🟢 Done · 🟠 In Progress · 🔵 Planned
 
-Latest updates: [PORTFOLIO_STATUS_UPDATED.md](./PORTFOLIO_STATUS_UPDATED.md)
+Latest updates: [PORTFOLIO_STATUS_UPDATED.md](./PORTFOLIO_STATUS_UPDATED.md) · [Portfolio Blueprints](#portfolio-blueprints--evidence)
 
 ### 🟢 Done
 


### PR DESCRIPTION
### Motivation
- Ensure the Status Board link targets the actual GitHub heading slug by updating the Portfolio Blueprints heading and anchor reference in `README.md`.

### Description
- Rename the section heading to `## 🧭 Portfolio Blueprints & Evidence` and add the Status Board link that points to `#portfolio-blueprints--evidence` in `README.md`.

### Testing
- No automated tests were executed because this is a documentation-only change; the file change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e93c20cec8327bb98baf77ac87fbf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README section headers with improved labeling to better convey the relationship between portfolio blueprints and supporting evidence components.
  * Added new navigation link to Portfolio Blueprints in the quick status reference section for enhanced discoverability of portfolio resources.
  * Applied minor formatting adjustments to ensure consistent documentation presentation and proper file structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->