### PR TITLE
Add Requested Deliverables Intake and link in documentation index

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -131,6 +131,12 @@ Use the documents below as the single source of truth for each operational area.
 
 ---
 
+## Requested Deliverables Intake
+
+Use this intake document to track newly requested documentation bundles and readiness before execution.
+
+- **Requested Deliverables Intake**: [docs/REQUESTED_DELIVERABLES_INTAKE.md](docs/REQUESTED_DELIVERABLES_INTAKE.md)
+
 ## How to Use These Documents
 
 ### Scenario 1: "I need to explain the portfolio to someone"

--- a/docs/REQUESTED_DELIVERABLES_INTAKE.md
+++ b/docs/REQUESTED_DELIVERABLES_INTAKE.md
@@ -1,0 +1,72 @@
+# Requested Deliverables Intake (User Request Review)
+
+This document validates the user-provided deliverables list against the current repository and records what exists, what is missing, and what should be created next. It is intended to ensure the repo is ready to begin implementation work with clear, scoped tasks.
+
+## Scope of Review
+
+The user requested several large documentation bundles (study guides, companion textbooks, AstraDup proposal pack, homelab proposals, AI builder kit, and a comprehensive checklist/manifest). This intake maps those requests to existing repo content and identifies gaps.
+
+## Inventory Check (Current Repo State)
+
+### 1) IT & Cybersecurity Study Guide — Volume 1 (Expanded & APA Editions)
+- **Status**: **Not found** as standalone docs in the repo.
+- **Nearest references**: No matching files found under `docs/` or root index.
+- **Action**: Create new documents under `docs/` with the requested content and add to the documentation index.
+
+### 2) Portfolio Project Companion Textbook (Complete Learning Guide v1.0)
+- **Status**: **Not found** as a standalone doc in the repo.
+- **Action**: Create new document under `docs/` and link from `DOCUMENTATION_INDEX.md`.
+
+### 3) Part I–IV + Appendices (Git/GitHub, Webflow, Toolchain, Endpoint Mgmt)
+- **Status**: **Not found** as a standalone doc in the repo.
+- **Action**: Create a structured doc (or multi-doc set) under `docs/` and link in index.
+
+### 4) Role Alignment & 6‑Month Project Roadmap
+- **Status**: **Not found** as a standalone doc in the repo.
+- **Action**: Create new roadmap doc under `docs/` and link from index.
+
+### 5) AstraDup Proposal / POC / Prototype / Reporting Pack
+- **Status**: **Not found** as a standalone pack.
+- **Related**: AstraDup project exists at `projects/astradup-video-deduplication/`.
+- **Action**: Create a proposal pack under `projects/astradup-video-deduplication/docs/` and link from project README + index.
+
+### 6) Homelab Program — Executive Proposal & POC Plan
+- **Status**: **Not found** as a standalone proposal file.
+- **Related**: Homelab program README exists at `projects/06-homelab/PRJ-HOME-004/README.md`.
+- **Action**: Extract/author a formal proposal document under `projects/06-homelab/PRJ-HOME-004/` and cross-link.
+
+### 7) Homelab Build Instructions (Numbered Steps & Makefile)
+- **Status**: **Not found** as a standalone build guide.
+- **Action**: Create build guide doc under `projects/06-homelab/PRJ-HOME-004/`.
+
+### 8) AI Builder Kit for Finalizing the Portfolio
+- **Status**: **Not found** as a standalone doc.
+- **Action**: Create `docs/AI_BUILDER_KIT.md` and link in index.
+
+### 9) AI Agent Instruction Sets (Runbooks, Diagrams, Test Plans, Docs)
+- **Status**: **Not found** as a standalone doc.
+- **Action**: Include in the AI Builder Kit or a separate `docs/AI_AGENT_INSTRUCTION_SETS.md`.
+
+### 10) Comprehensive Project Checklist & AI‑Generated Components
+- **Status**: **Not found** as a standalone doc.
+- **Action**: Create `docs/COMPREHENSIVE_PROJECT_CHECKLIST.md`.
+
+### 11) Domain‑Specific Bundles & Exports (DevOps, QA, Cloud Infra)
+- **Status**: **Not found** as doc(s) or export artifacts.
+- **Action**: Document packaging approach and generate bundle list in `docs/`.
+
+## Proposed Task Start (Ready‑to‑Execute)
+
+1. **Create a docs hub section** for the requested bundle set and link it from `DOCUMENTATION_INDEX.md`.
+2. **Add the missing documents** (Study Guide, APA edition, Companion Textbook, Toolchain guide, Roadmap).
+3. **Add AstraDup pack** under the AstraDup project docs folder.
+4. **Add Homelab proposal + build guide** under `projects/06-homelab/PRJ-HOME-004/`.
+5. **Add AI Builder Kit + instruction sets + checklist + JSON manifest** under `docs/`.
+6. **Update documentation index** with the new files and a clear “Requested Deliverables” section.
+
+## Acceptance Criteria (Ready to Start)
+
+- All requested items have dedicated markdown files.
+- Each file is linked from `DOCUMENTATION_INDEX.md`.
+- Project-specific artifacts (AstraDup, Homelab) are linked from their project READMEs.
+- A JSON manifest for the comprehensive checklist is added under `docs/` or `reports/`.


### PR DESCRIPTION
### Motivation
- Provide a canonical intake to validate user-requested deliverables, capture repository gaps, and record readiness before implementation begins.

### Description
- Add `docs/REQUESTED_DELIVERABLES_INTAKE.md` which inventories requested bundles, maps gaps to the repo, and lists proposed next steps and acceptance criteria, and update `DOCUMENTATION_INDEX.md` to link the new intake for discoverability.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e83ea6b10832799ab4ee5b0e410f8)