### PR TITLE
Add evidence placeholder for streaming k8s metrics

### DIFF
--- a/projects/5-real-time-data-streaming/README.md
+++ b/projects/5-real-time-data-streaming/README.md
@@ -22,6 +22,9 @@ For cross-project documentation, standards, and runbooks, see the [Portfolio Doc
 ### Live deployment screenshots
 ![Live deployment dashboard](../../assets/screenshots/live-deployment-placeholder.svg)
 
+### Evidence
+Deployment and metrics evidence are tracked in [`evidence/README.md`](./evidence/README.md).
+
 
 ## 📊 Portfolio Status Board
 

--- a/projects/5-real-time-data-streaming/evidence/README.md
+++ b/projects/5-real-time-data-streaming/evidence/README.md
@@ -1,0 +1,30 @@
+# Real-time Data Streaming Evidence
+
+## Deployment Attempt
+
+The Kubernetes deployment was attempted from this environment, but the required tooling and cluster access were not available.
+
+### Command Output
+
+```bash
+$ kubectl version --client
+bash: command not found: kubectl
+```
+
+## Metrics & Charts
+
+Throughput, end-to-end latency percentiles, and error-rate metrics require a running Kubernetes stack with Prometheus/Grafana scraping the streaming services. Because the cluster tooling was unavailable in this environment, no Prometheus data or Grafana dashboards could be queried, and no charts/screenshots could be produced here.
+
+### How to Generate Metrics Once a Cluster Is Available
+
+1. Ensure `kubectl` is installed and configured for the target cluster.
+2. Deploy the stack following `k8s/README.md`.
+3. Run a sample workload from the project root (example):
+
+```bash
+python src/producer.py --high-volume --rate 100 --duration 60
+```
+
+4. Query Prometheus for throughput and latency metrics, then export charts (Grafana panels or Prometheus query results). Store resulting CSV/PNG outputs under this directory.
+5. Capture dashboard screenshots from Grafana and save them alongside the charts.
+


### PR DESCRIPTION
### Motivation
- Provide a place to record deployment and metrics evidence for the real-time streaming project and surface it from the main README.
- Capture that the Kubernetes deployment attempt could not run in this environment due to missing cluster tooling and provide step-by-step guidance to produce metrics when a cluster is available.

### Description
- Add `projects/5-real-time-data-streaming/evidence/README.md` documenting the failed deployment attempt, the `kubectl` error, and instructions to generate throughput, latency percentile, and error-rate metrics and screenshots.
- Update `projects/5-real-time-data-streaming/README.md` to link to the new evidence folder for easier navigation.
- Include example commands such as `kubectl version --client` and `python src/producer.py --high-volume --rate 100 --duration 60` in the evidence guidance.

### Testing
- No automated tests were executed because cluster tooling (`kubectl`) and a target Kubernetes cluster were not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710b292d34832786fb39b305227990)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Real-time Data Streaming evidence, including deployment notes and step-by-step instructions for generating metrics with Prometheus and Grafana.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->