### PR TITLE
Replace binary chart artifacts with CSV evidence and update README

### DIFF
--- a/projects/7-serverless-data-processing/README.md
+++ b/projects/7-serverless-data-processing/README.md
@@ -71,6 +71,20 @@ pytest
 aws lambda invoke --function-name ingest --payload file://events/sample.json out.json
 ```
 
+## Evidence (local simulation)
+The following artifacts capture the infrastructure plan, workflow execution logs, output data, and
+cloud-metric charts generated in a local simulation (SAM/AWS CLI unavailable in this environment).
+
+- Deployment plan summary: [`evidence/deployment-summary.json`](evidence/deployment-summary.json)
+- Sample events used to trigger the workflow: [`evidence/sample-events.json`](evidence/sample-events.json)
+- Execution logs: [`evidence/workflow-execution.log`](evidence/workflow-execution.log)
+- Output data: [`evidence/workflow-output.json`](evidence/workflow-output.json)
+- Metrics data: [`evidence/workflow-metrics.json`](evidence/workflow-metrics.json)
+- Chart-ready CSVs:
+  - Invocation count: [`evidence/invocation-count.csv`](evidence/invocation-count.csv)
+  - Duration: [`evidence/duration-ms.csv`](evidence/duration-ms.csv)
+  - Cost: [`evidence/cost-usd.csv`](evidence/cost-usd.csv)
+
 ### Containerized infrastructure workflows
 
 Use the provided multi-stage image for SAM validation and packaging from consistent tooling:

--- a/projects/7-serverless-data-processing/evidence/cost-usd.csv
+++ b/projects/7-serverless-data-processing/evidence/cost-usd.csv
@@ -1,0 +1,6 @@
+invocation,event_id,event_type,cost_usd
+1,evt-1001,user_action,2.873e-07
+2,evt-1002,metric_update,2.87e-07
+3,evt-1003,system_event,2.875e-07
+4,evt-1004,audit_log,2.873e-07
+5,evt-1005,error_event,2.872e-07

--- a/projects/7-serverless-data-processing/evidence/deployment-summary.json
+++ b/projects/7-serverless-data-processing/evidence/deployment-summary.json
@@ -1,0 +1,40 @@
+{
+  "generated_at": "2026-01-22T15:30:57.306609+00:00",
+  "template": "infrastructure/template.yaml",
+  "parameters": [
+    "CuratedTableName",
+    "WorkflowArn"
+  ],
+  "resource_count": 4,
+  "resources": {
+    "IngestionFunction": {
+      "type": "AWS::Serverless::Function",
+      "properties": [
+        "CodeUri",
+        "Handler",
+        "Environment",
+        "Events"
+      ]
+    },
+    "AnalyticsFunction": {
+      "type": "AWS::Serverless::Function",
+      "properties": [
+        "CodeUri",
+        "Handler",
+        "Environment"
+      ]
+    },
+    "CuratedTable": {
+      "type": "AWS::DynamoDB::Table",
+      "properties": [
+        "BillingMode",
+        "AttributeDefinitions",
+        "KeySchema"
+      ]
+    },
+    "RawEventBucket": {
+      "type": "AWS::S3::Bucket",
+      "properties": []
+    }
+  }
+}

--- a/projects/7-serverless-data-processing/evidence/duration-ms.csv
+++ b/projects/7-serverless-data-processing/evidence/duration-ms.csv
@@ -1,0 +1,6 @@
+invocation,event_id,event_type,duration_ms
+1,evt-1001,user_action,20.45
+2,evt-1002,metric_update,20.4
+3,evt-1003,system_event,20.5
+4,evt-1004,audit_log,20.45
+5,evt-1005,error_event,20.43

--- a/projects/7-serverless-data-processing/evidence/invocation-count.csv
+++ b/projects/7-serverless-data-processing/evidence/invocation-count.csv
@@ -1,0 +1,6 @@
+event_type,invocations
+user_action,1
+metric_update,1
+system_event,1
+audit_log,1
+error_event,1

--- a/projects/7-serverless-data-processing/evidence/sample-events.json
+++ b/projects/7-serverless-data-processing/evidence/sample-events.json
@@ -1,0 +1,53 @@
+[
+  {
+    "event_id": "evt-1001",
+    "event_type": "user_action",
+    "timestamp": "2025-01-05T12:00:00Z",
+    "data": {
+      "action": "click",
+      "page": "home",
+      "user_id": "u-100"
+    },
+    "source": "web"
+  },
+  {
+    "event_id": "evt-1002",
+    "event_type": "metric_update",
+    "timestamp": "2025-01-05T12:00:05Z",
+    "data": {
+      "metric": "cpu",
+      "value": 0.62
+    },
+    "source": "collector"
+  },
+  {
+    "event_id": "evt-1003",
+    "event_type": "system_event",
+    "timestamp": "2025-01-05T12:00:10Z",
+    "data": {
+      "status": "healthy",
+      "service": "ingest"
+    },
+    "source": "healthcheck"
+  },
+  {
+    "event_id": "evt-1004",
+    "event_type": "audit_log",
+    "timestamp": "2025-01-05T12:00:12Z",
+    "data": {
+      "actor": "admin",
+      "action": "config_update"
+    },
+    "source": "admin_ui"
+  },
+  {
+    "event_id": "evt-1005",
+    "event_type": "error_event",
+    "timestamp": "2025-01-05T12:00:15Z",
+    "data": {
+      "error": "timeout",
+      "retry": true
+    },
+    "source": "worker"
+  }
+]

--- a/projects/7-serverless-data-processing/evidence/workflow-execution.log
+++ b/projects/7-serverless-data-processing/evidence/workflow-execution.log
@@ -1,0 +1,10 @@
+2026-01-22 15:30:57,308 INFO Invocation 1: received event_id=evt-1001
+2026-01-22 15:30:57,329 INFO Invocation 1: processed event_id=evt-1001 duration_ms=20.45
+2026-01-22 15:30:57,329 INFO Invocation 2: received event_id=evt-1002
+2026-01-22 15:30:57,350 INFO Invocation 2: processed event_id=evt-1002 duration_ms=20.40
+2026-01-22 15:30:57,351 INFO Invocation 3: received event_id=evt-1003
+2026-01-22 15:30:57,372 INFO Invocation 3: processed event_id=evt-1003 duration_ms=20.50
+2026-01-22 15:30:57,373 INFO Invocation 4: received event_id=evt-1004
+2026-01-22 15:30:57,394 INFO Invocation 4: processed event_id=evt-1004 duration_ms=20.45
+2026-01-22 15:30:57,394 INFO Invocation 5: received event_id=evt-1005
+2026-01-22 15:30:57,415 INFO Invocation 5: processed event_id=evt-1005 duration_ms=20.43

--- a/projects/7-serverless-data-processing/evidence/workflow-metrics.json
+++ b/projects/7-serverless-data-processing/evidence/workflow-metrics.json
@@ -1,0 +1,37 @@
+[
+  {
+    "invocation": 1,
+    "event_id": "evt-1001",
+    "event_type": "user_action",
+    "duration_ms": 20.45,
+    "cost_usd": 2.873e-07
+  },
+  {
+    "invocation": 2,
+    "event_id": "evt-1002",
+    "event_type": "metric_update",
+    "duration_ms": 20.4,
+    "cost_usd": 2.87e-07
+  },
+  {
+    "invocation": 3,
+    "event_id": "evt-1003",
+    "event_type": "system_event",
+    "duration_ms": 20.5,
+    "cost_usd": 2.875e-07
+  },
+  {
+    "invocation": 4,
+    "event_id": "evt-1004",
+    "event_type": "audit_log",
+    "duration_ms": 20.45,
+    "cost_usd": 2.873e-07
+  },
+  {
+    "invocation": 5,
+    "event_id": "evt-1005",
+    "event_type": "error_event",
+    "duration_ms": 20.43,
+    "cost_usd": 2.872e-07
+  }
+]

--- a/projects/7-serverless-data-processing/evidence/workflow-output.json
+++ b/projects/7-serverless-data-processing/evidence/workflow-output.json
@@ -1,0 +1,80 @@
+[
+  {
+    "event_id": "evt-1001",
+    "event_type": "user_action",
+    "timestamp": "2025-01-05T12:00:00Z",
+    "processed_at": "2026-01-22T15:30:57.308888+00:00",
+    "data": {
+      "action": "click",
+      "page": "home",
+      "user_id": "u-100",
+      "enriched": true,
+      "processed_by": "lambda-processor"
+    },
+    "metadata": {
+      "source": "web",
+      "version": "1.0",
+      "environment": "production"
+    }
+  },
+  {
+    "event_id": "evt-1002",
+    "event_type": "metric_update",
+    "timestamp": "2025-01-05T12:00:05Z",
+    "processed_at": "2026-01-22T15:30:57.330242+00:00",
+    "data": {
+      "metric": "cpu",
+      "value": 0.62
+    },
+    "metadata": {
+      "source": "collector",
+      "version": "1.0",
+      "environment": "production"
+    }
+  },
+  {
+    "event_id": "evt-1003",
+    "event_type": "system_event",
+    "timestamp": "2025-01-05T12:00:10Z",
+    "processed_at": "2026-01-22T15:30:57.352131+00:00",
+    "data": {
+      "status": "healthy",
+      "service": "ingest"
+    },
+    "metadata": {
+      "source": "healthcheck",
+      "version": "1.0",
+      "environment": "production"
+    }
+  },
+  {
+    "event_id": "evt-1004",
+    "event_type": "audit_log",
+    "timestamp": "2025-01-05T12:00:12Z",
+    "processed_at": "2026-01-22T15:30:57.373780+00:00",
+    "data": {
+      "actor": "admin",
+      "action": "config_update"
+    },
+    "metadata": {
+      "source": "admin_ui",
+      "version": "1.0",
+      "environment": "production"
+    }
+  },
+  {
+    "event_id": "evt-1005",
+    "event_type": "error_event",
+    "timestamp": "2025-01-05T12:00:15Z",
+    "processed_at": "2026-01-22T15:30:57.395296+00:00",
+    "data": {
+      "error": "timeout",
+      "retry": true
+    },
+    "metadata": {
+      "source": "worker",
+      "version": "1.0",
+      "environment": "production"
+    }
+  }
+]


### PR DESCRIPTION
### Motivation
- Replace binary chart images with lightweight, text-first artifacts so metric evidence is diff-friendly and repository-friendly.
- Make workflow metrics and charts inspectable without rendering PNGs by providing CSV exports derived from `workflow-metrics.json`.
- Keep the local-simulation evidence bundle discoverable via the project README.

### Description
- Removed binary chart artifacts and added chart-ready CSVs: `invocation-count.csv`, `duration-ms.csv`, and `cost-usd.csv` under `projects/7-serverless-data-processing/evidence`.
- Updated `projects/7-serverless-data-processing/README.md` to reference the new CSV evidence instead of PNG images.
- Included or preserved local-simulation evidence files used to generate the CSVs such as `workflow-metrics.json`, `workflow-output.json`, `workflow-execution.log`, `sample-events.json`, and `deployment-summary.json`.
- Generated the CSVs from `workflow-metrics.json` using a small Python export script (creation captured in the rollout transcript).

### Testing
- Executed the CSV-generation Python script which exited successfully and produced `invocation-count.csv`, `duration-ms.csv`, and `cost-usd.csv`.
- Verified the resulting CSV files contain the expected headers and rows matching the `workflow-metrics.json` entries via automated file output inspection.
- No unit test suite or CI pipeline was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723f0f91188327a0854dd5b1614785)