### PR TITLE
Add README migration script with section remapping and markdown normalization

### DIFF
--- a/scripts/readme_migration/upgrade_readmes.py
+++ b/scripts/readme_migration/upgrade_readmes.py
@@ -112,7 +112,7 @@ def parse_markdown_sections(content: str) -> ReadmeDocument:
 def map_section_heading(old_heading: str) -> str | None:
     normalized = normalize_heading_key(old_heading)
     for token, mapped in SECTION_MAPPING.items():
-        if token in normalized:
+        if re.search(r'\b' + re.escape(token) + r'\b', normalized):
             return mapped
     return None
 


### PR DESCRIPTION
### Motivation
- Provide a repeatable migration that standardizes all `README.md` files into the required portfolio template order so documentation is consistent across repo and subdirectories. 
- Preserve existing project-specific content by mapping legacy headings into the closest new sections instead of dropping context. 
- Ensure migrated markdown is syntactically sound by normalizing table rows and Mermaid fences as a post-pass. 

### Description
- Add `scripts/readme_migration/upgrade_readmes.py`, a CLI utility that discovers `README.md` files and rewrites them using the exact ordered sections list: `## 🎯 Overview`, `## 📌 Scope & Status`, `## 🏗️ Architecture`, `## 🚀 Setup & Runbook`, `## ✅ Testing & Quality Evidence`, `## 🔐 Security, Risk & Reliability`, `## 🔄 Delivery & Observability`, `## 🗺️ Roadmap`, `## 📎 Evidence Index`, `## 🧾 Documentation Freshness`, plus the final checklist block. 
- Implement heading remapping via `SECTION_MAPPING` so headings like `Usage`, `Design`, `Testing`, and `Security` are moved under the nearest new target section, and unmapped headings are retained under `## 📎 Evidence Index`. 
- Insert scope-aware planned-state placeholders that use the requested status key emojis (`🟢/🟠/🔵/🔄/📝`) for any missing sections and include different wording for root vs subdirectory READMEs. 
- Add safe post-processing to normalize markdown table structures and ensure Mermaid code fences use ` ```mermaid `/closing fence, and provide CLI flags `--apply` (write changes) and `--target` (single-file dry-run). 

### Testing
- Ran `python3 scripts/readme_migration/upgrade_readmes.py --help` and observed successful CLI output. 
- Ran a focused dry-run with `python3 scripts/readme_migration/upgrade_readmes.py --target tests/README.md` which reported `[would-update] tests/README.md` and completed successfully. 
- The script defaults to dry-run mode and supports `--apply` for writing changes after validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a9621d988327984223b13af7a334)