### PR TITLE
Add README governance policy, PR checklist, validator script, and scheduled compliance workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/readme-governance-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/readme-governance-checklist.md
@@ -1,0 +1,25 @@
+## Summary
+Describe the change and why README updates are/are not required.
+
+## README Governance Checklist (Required when architecture/setup/testing/risk/roadmap changed)
+- [ ] I evaluated whether this PR changes architecture, setup, testing, risk posture, or roadmap.
+- [ ] I updated the impacted README(s) in this PR.
+- [ ] I updated the **Documentation Freshness** table for each impacted area README.
+- [ ] I added/updated evidence links for:
+  - [ ] Architecture/design source
+  - [ ] Testing/validation source
+  - [ ] Risk/security source
+  - [ ] Roadmap source (if applicable)
+- [ ] I ran the README validator and link checker locally (or documented why not).
+
+## Impacted README Paths
+- [ ] `projects/README.md`
+- [ ] `projects-new/README.md`
+- [ ] `terraform/README.md`
+- [ ] Project-level README(s) (list below)
+
+## Related Issues
+Link issues here (e.g., #123).
+
+## Notes
+Add any deployment, rollback, or follow-up details.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,14 @@
 ## Summary
 Describe the change and its intent.
 
+## README Governance Gate
+If this PR changes **architecture, setup, testing, risk posture, or roadmap**, README updates are required.
+
+- [ ] README update required
+- [ ] README update completed in this PR
+- [ ] Documentation Freshness table updated
+- [ ] Evidence links added/updated (architecture, testing, risk, roadmap when applicable)
+
 ## Checklist
 - [ ] Documentation updated (if applicable)
 - [ ] Tests added/updated (if applicable)

--- a/.github/workflows/readme-governance.yml
+++ b/.github/workflows/readme-governance.yml
@@ -1,0 +1,77 @@
+name: README Governance
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  readme-compliance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run README validator
+        id: validator
+        continue-on-error: true
+        run: ./scripts/readme-validator.sh
+
+      - name: Run markdown link checker
+        id: linkcheck
+        continue-on-error: true
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --format markdown
+            --output artifacts/link-check-report.md
+            docs/readme-governance.md projects/README.md projects-new/README.md terraform/README.md
+
+      - name: Build non-compliance issue body
+        if: steps.validator.outcome == 'failure' || steps.linkcheck.outcome == 'failure'
+        run: |
+          mkdir -p artifacts
+          {
+            echo "# README Governance Non-Compliance Report"
+            echo
+            echo "Automated check detected documentation governance violations."
+            echo
+            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "## README Validator"
+            if [[ -f artifacts/readme-noncompliance-report.md ]]; then
+              cat artifacts/readme-noncompliance-report.md
+            else
+              echo "Validator report not found."
+            fi
+            echo
+            echo "## Link Checker"
+            if [[ -f artifacts/link-check-report.md ]]; then
+              cat artifacts/link-check-report.md
+            else
+              echo "Link checker report not found."
+            fi
+          } > artifacts/readme-governance-issue.md
+
+      - name: Upload governance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: readme-governance-reports
+          path: artifacts/*.md
+
+      - name: Open issue for non-compliance
+        if: steps.validator.outcome == 'failure' || steps.linkcheck.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "README governance non-compliance report"
+          content-filepath: artifacts/readme-governance-issue.md
+          labels: |
+            documentation
+            compliance

--- a/docs/readme-governance.md
+++ b/docs/readme-governance.md
@@ -1,0 +1,38 @@
+# README Governance Policy
+
+## Purpose
+This policy defines how README documentation is maintained across the portfolio repository so engineering, operations, and security stakeholders can trust that docs reflect the current system state.
+
+## Required Update Cadence
+
+| Documentation Type | Cadence | Trigger-Based Override |
+| --- | --- | --- |
+| Root and area README files | At least monthly (every 30 days) | Update in the same PR whenever architecture, setup, testing, risk, or roadmap changes |
+| Project README files (`projects/`, `projects-new/`) | At least once per sprint (or every 14 days) | Update in the same PR for feature, infra, or operational behavior changes |
+| Terraform README files (`terraform/`) | At least monthly and before each infra release | Update in the same PR for module/input/output/security control changes |
+
+## Owner Roles per Project Area
+
+| Area | Primary Documentation Owner | Secondary/Review Owner | Scope |
+| --- | --- | --- | --- |
+| `projects/` | Platform Portfolio Maintainer | QA & Reliability Lead | Legacy and canonical project guides/runbooks |
+| `projects-new/` | Solutions Architecture Lead | Security Engineering Lead | Net-new project documentation and implementation guidance |
+| `terraform/` | Infrastructure as Code Lead | Cloud Security Lead | Terraform usage, modules, state, and operational runbooks |
+| `.github/` process docs and templates | Developer Experience Lead | Repository Maintainer | CI/doc governance workflows and contribution templates |
+
+## Evidence-Link Expectations
+
+Every README update that is required by this policy must include verifiable evidence links:
+
+1. **Change evidence**: At least one link to architecture/design source (`ARCHITECTURE.md`, ADR, diagram, or equivalent).
+2. **Validation evidence**: At least one link to testing/verification source (`TESTING.md`, CI run summary, or report).
+3. **Risk evidence**: At least one link to risk/security source (`RISK_REGISTER.md`, threat model, security runbook, or issue).
+4. **Roadmap evidence** (if roadmap changed): Link to the roadmap tracker, milestone, or backlog issue.
+
+Use relative links whenever possible so evidence remains portable across forks.
+
+## Compliance and Reporting
+
+- PRs must complete the README governance checklist in `.github/pull_request_template.md`.
+- Scheduled CI runs the README validator and markdown link checker.
+- If non-compliance is found, CI auto-opens an issue containing the report artifact for triage.

--- a/projects-new/README.md
+++ b/projects-new/README.md
@@ -1,0 +1,13 @@
+# Projects-New Documentation Index
+
+This directory contains net-new project implementations and active build tracks.
+
+## Documentation Freshness
+
+| Area | Documentation Owner | Backup Owner | Last Reviewed | Next Review Due | Evidence Links |
+| --- | --- | --- | --- | --- | --- |
+| `projects-new/` project READMEs | Solutions Architecture Lead | Security Engineering Lead | 2026-02-26 | 2026-03-12 | [Governance Policy](../docs/readme-governance.md), [Validation Script](../scripts/readme-validator.sh) |
+
+## Notes
+- Update this table whenever architecture, setup, testing approach, risk posture, or roadmap details change.
+- Ensure new projects include links to testing and risk artifacts.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,13 @@
+# Projects Documentation Index
+
+This directory contains canonical and legacy project implementations.
+
+## Documentation Freshness
+
+| Area | Documentation Owner | Backup Owner | Last Reviewed | Next Review Due | Evidence Links |
+| --- | --- | --- | --- | --- | --- |
+| `projects/` portfolio project READMEs | Platform Portfolio Maintainer | QA & Reliability Lead | 2026-02-26 | 2026-03-27 | [Governance Policy](../docs/readme-governance.md), [Validation Script](../scripts/readme-validator.sh) |
+
+## Notes
+- Update this table whenever architecture, setup, testing approach, risk posture, or roadmap details change.
+- Keep evidence links current and relative.

--- a/scripts/readme-validator.sh
+++ b/scripts/readme-validator.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT_DIR="${ROOT_DIR}/artifacts"
+REPORT_FILE="${REPORT_DIR}/readme-noncompliance-report.md"
+
+mkdir -p "${REPORT_DIR}"
+
+failures=0
+checks=0
+
+require_file() {
+  local file="$1"
+  checks=$((checks + 1))
+  if [[ ! -f "${ROOT_DIR}/${file}" ]]; then
+    failures=$((failures + 1))
+    echo "- [ ] Missing required file: \\`${file}\\`" >> "${REPORT_FILE}"
+  fi
+}
+
+require_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local description="$3"
+  checks=$((checks + 1))
+  if ! rg -q "${pattern}" "${ROOT_DIR}/${file}"; then
+    failures=$((failures + 1))
+    echo "- [ ] ${description} (file: \\`${file}\\`)" >> "${REPORT_FILE}"
+  fi
+}
+
+cat > "${REPORT_FILE}" <<REPORT
+# README Non-Compliance Report
+
+Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+## Findings
+REPORT
+
+require_file "docs/readme-governance.md"
+require_file "projects/README.md"
+require_file "projects-new/README.md"
+require_file "terraform/README.md"
+
+require_pattern "projects/README.md" "## Documentation Freshness" "Missing 'Documentation Freshness' section"
+require_pattern "projects-new/README.md" "## Documentation Freshness" "Missing 'Documentation Freshness' section"
+require_pattern "terraform/README.md" "## Documentation Freshness" "Missing 'Documentation Freshness' section"
+
+require_pattern "projects/README.md" "Platform Portfolio Maintainer" "Missing explicit documentation owner for projects/"
+require_pattern "projects-new/README.md" "Solutions Architecture Lead" "Missing explicit documentation owner for projects-new/"
+require_pattern "terraform/README.md" "Infrastructure as Code Lead" "Missing explicit documentation owner for terraform/"
+
+require_pattern "projects/README.md" "Evidence Links" "Missing Evidence Links column in projects/README.md"
+require_pattern "projects-new/README.md" "Evidence Links" "Missing Evidence Links column in projects-new/README.md"
+require_pattern "terraform/README.md" "Evidence Links" "Missing Evidence Links column in terraform/README.md"
+
+if [[ ${failures} -eq 0 ]]; then
+  echo "- ✅ No non-compliance findings." >> "${REPORT_FILE}"
+  echo "README validation passed (${checks} checks)."
+  exit 0
+fi
+
+echo >> "${REPORT_FILE}"
+echo "Total checks: ${checks}" >> "${REPORT_FILE}"
+echo "Failures: ${failures}" >> "${REPORT_FILE}"
+
+echo "README validation failed (${failures}/${checks} failed). See ${REPORT_FILE}."
+exit 1

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -88,3 +88,11 @@ Notes:
 GitHub Actions (`.github/workflows/terraform.yml`) runs `terraform fmt`, `validate`, `tfsec`, and `tflint`, produces a plan on pull requests, and requires environment approval before applying to `main`.
 
 For OIDC role creation steps, refer to `terraform/iam/github_oidc_trust_policy.json` and `terraform/iam/github_actions_ci_policy.json`.
+
+## Documentation Freshness
+
+| Area | Documentation Owner | Backup Owner | Last Reviewed | Next Review Due | Evidence Links |
+| --- | --- | --- | --- | --- | --- |
+| `terraform/` root and module READMEs | Infrastructure as Code Lead | Cloud Security Lead | 2026-02-26 | 2026-03-27 | [Governance Policy](../docs/readme-governance.md), [Terraform CI](../.github/workflows/terraform.yml) |
+
+- Update this table when Terraform architecture, setup, testing, risk posture, or roadmap assumptions change.


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for README maintenance cadence, ownership, and evidence expectations across the repository. 
- Ensure README updates are required and tracked when architecture, setup, testing, risk posture, or roadmap change. 
- Detect and surface documentation non-compliance automatically to reduce drift and improve operational confidence. 

### Description
- Add a central governance policy at `docs/readme-governance.md` defining update cadence, owner roles per area, evidence-link expectations, and reporting rules. 
- Add repository-level PR guidance at `.github/PULL_REQUEST_TEMPLATE/readme-governance-checklist.md` and add a README governance gate to `.github/pull_request_template.md`. 
- Implement a validator script `scripts/readme-validator.sh` that produces `artifacts/readme-noncompliance-report.md` and fails when required files/sections/owners/evidence links are missing. 
- Add a scheduled GitHub Actions workflow `.github/workflows/readme-governance.yml` (weekly + manual dispatch) that runs the validator and `lychee` link checker, uploads artifacts, and auto-opens an issue when non-compliance is detected. 
- Add/update area README indexes with explicit "Documentation Freshness" tables in `projects/README.md`, `projects-new/README.md`, and update `terraform/README.md` to include ownership and evidence links. 

### Testing
- Executed `./scripts/readme-validator.sh` locally which completed successfully and generated `artifacts/readme-noncompliance-report.md` indicating no non-compliance (passed). 
- Verified script syntax with `bash -n scripts/readme-validator.sh` which returned without errors. 
- Confirmed the scheduled workflow uses `lycheeverse/lychee-action` for link checking and `peter-evans/create-issue-from-file` for automatic issue creation when checks fail (configuration added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ac33343c832785bfc7ddd3c6300e)