### PR TITLE
Add local-relative README link validation for priority template sections

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -256,9 +256,9 @@ flowchart LR
 
 ## 📎 Evidence Index
 - [Repository root](./)
-- [Documentation directory](./docs/)
-- [Tests directory](./tests/)
-- [CI workflows](./.github/workflows/)
+- [Documentation directory](../docs/)
+- [Tests directory](../tests/)
+- [CI workflows](../.github/workflows/)
 - [Project implementation files](./)
 
 ## 🧾 Documentation Freshness
@@ -279,4 +279,3 @@ flowchart LR
 - [ ] Roadmap includes next milestones
 - [ ] Evidence links resolve correctly
 - [ ] README reflects current implementation state
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -805,9 +805,9 @@ flowchart LR
 
 ## 📎 Evidence Index
 - [Repository root](./)
-- [Documentation directory](./docs/)
-- [Tests directory](./tests/)
-- [CI workflows](./.github/workflows/)
+- [Documentation directory](../docs/)
+- [Tests directory](../tests/)
+- [CI workflows](../.github/workflows/)
 - [Project implementation files](./)
 
 ## 🧾 Documentation Freshness
@@ -828,4 +828,3 @@ flowchart LR
 - [ ] Roadmap includes next milestones
 - [ ] Evidence links resolve correctly
 - [ ] README reflects current implementation state
-

--- a/scripts/readme_migration/validate_template.py
+++ b/scripts/readme_migration/validate_template.py
@@ -8,9 +8,11 @@ import json
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import unquote
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -34,6 +36,14 @@ TABLE_REQUIRED_SECTIONS: dict[str, str] = {
     "roadmap": "roadmap",
     "documentation_freshness": "documentation_freshness",
 }
+
+LOCAL_LINK_SECTION_PATTERNS: tuple[str, ...] = (
+    r"evidence\s+index",
+    r"setup\s*&\s*runbook",
+    r"delivery\s*&\s*observability",
+)
+
+MARKDOWN_LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
 @dataclass
@@ -131,6 +141,52 @@ def has_non_empty_table(section_lines: list[str]) -> bool:
     return False
 
 
+def iter_section_headings(headings: list[Heading], patterns: Iterable[str]) -> Iterator[Heading]:
+    compiled = [re.compile(pattern, flags=re.IGNORECASE) for pattern in patterns]
+    for heading in headings:
+        if any(regex.search(heading.title) for regex in compiled):
+            yield heading
+
+
+def normalize_markdown_target(target: str) -> str:
+    candidate = target.strip()
+    if candidate.startswith("<") and candidate.endswith(">"):
+        candidate = candidate[1:-1].strip()
+    if " " in candidate:
+        candidate = candidate.split(" ", 1)[0]
+    candidate = candidate.split("#", 1)[0]
+    candidate = candidate.split("?", 1)[0]
+    return unquote(candidate)
+
+
+def is_local_relative_target(target: str) -> bool:
+    if not target:
+        return False
+    lowered = target.lower()
+    if target.startswith("#") or target.startswith("/"):
+        return False
+    if "://" in target or lowered.startswith("mailto:"):
+        return False
+    return True
+
+
+def find_broken_local_links(path: Path, lines: list[str], headings: list[Heading]) -> list[str]:
+    errors: list[str] = []
+    for heading in iter_section_headings(headings, LOCAL_LINK_SECTION_PATTERNS):
+        for line_no, line in enumerate(lines[heading.start:heading.end], start=heading.start + 1):
+            for match in MARKDOWN_LINK_PATTERN.finditer(line):
+                target = normalize_markdown_target(match.group(1))
+                if not is_local_relative_target(target):
+                    continue
+                link_path = (path.parent / target).resolve()
+                if link_path.exists():
+                    continue
+                errors.append(
+                    f"broken_local_link:{line_no}:{heading.title}:{target}"
+                )
+    return errors
+
+
 def validate_readme(path: Path) -> dict[str, object]:
     content = path.read_bytes().decode("utf-8", errors="replace")
     lines = content.splitlines()
@@ -167,6 +223,8 @@ def validate_readme(path: Path) -> dict[str, object]:
         section_lines = lines[section_heading.start:section_heading.end]
         if not has_non_empty_table(section_lines):
             errors.append(f"missing_non_empty_table:{table_name}")
+
+    errors.extend(find_broken_local_links(path, lines, headings))
 
     return {
         "path": str(path.relative_to(REPO_ROOT)),

--- a/tools/README.md
+++ b/tools/README.md
@@ -775,9 +775,9 @@ flowchart LR
 
 ## 📎 Evidence Index
 - [Repository root](./)
-- [Documentation directory](./docs/)
-- [Tests directory](./tests/)
-- [CI workflows](./.github/workflows/)
+- [Documentation directory](../docs/)
+- [Tests directory](../tests/)
+- [CI workflows](../.github/workflows/)
 - [Project implementation files](./)
 
 ## 🧾 Documentation Freshness
@@ -798,4 +798,3 @@ flowchart LR
 - [ ] Roadmap includes next milestones
 - [ ] Evidence links resolve correctly
 - [ ] README reflects current implementation state
-


### PR DESCRIPTION
### Motivation
- Shared README template sections (e.g., `Evidence Index`, `Setup & Runbook`, `Delivery & Observability`) are repeated across many README files and broken local links there propagate widely. 
- Enforcing a filesystem-level validation for local relative Markdown targets prevents regressions and makes README quality failures actionable in CI.

### Description
- Extended `scripts/readme_migration/validate_template.py` to parse Markdown links in priority sections and validate local relative targets on disk. 
- Added normalization and filtering for Markdown targets (strip angle-brackets, anchors, query parts, ignore external/anchor/mailto links) and a new check that emits `broken_local_link:<line>:<section>:<target>` errors for missing targets. 
- Focused the link pass on the template headings `Evidence Index`, `Setup & Runbook`, and `Delivery & Observability` to prioritize high-impact, repeated links. 
- Corrected repeated canonical Evidence Index links in a few high-impact READMEs (`projects/README.md`, `scripts/README.md`, `tools/README.md`) to repository-relative paths so they resolve from their directory context.
- The new checks are enforced automatically by the existing `README Quality Gate` workflow because it runs `scripts/readme_migration/validate_template.py` for PRs and scheduled runs.

### Testing
- Compiled the updated validator with `python -m py_compile scripts/readme_migration/validate_template.py` and it succeeded. 
- Programmatically invoked `validate_readme()` against `projects/README.md`, `scripts/README.md`, and `tools/README.md` and confirmed there are zero `broken_local_link` errors for those files. 
- Ran the validator in `--mode changed --base-ref HEAD~1` to exercise PR-scoped detection which reported no matched files in the local test scope. 
- Ran the validator in `--mode full` to observe repository-wide results which surfaced existing non-compliant READMEs (expected for pre-existing issues) so the gate will surface those in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d262a4fd5c8327af38f99d9a58ff36)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected relative path references in Evidence Index links across multiple README files to ensure accurate navigation throughout the repository documentation structure.

* **Quality Assurance**
  * Implemented enhanced validation system with new checks to automatically detect and report broken local documentation links, improving overall documentation quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->